### PR TITLE
Unify typography under a single font

### DIFF
--- a/lib/core/theme/utils.dart
+++ b/lib/core/theme/utils.dart
@@ -8,19 +8,7 @@ class LoadingNotifier extends Notifier<bool> {
   void set(bool value) => state = value;
 }
 
-TextTheme createTextTheme(
-    BuildContext context, String bodyFontString, String displayFontString) {
+TextTheme createTextTheme(BuildContext context, String fontString) {
   TextTheme baseTextTheme = Theme.of(context).textTheme;
-  TextTheme bodyTextTheme = GoogleFonts.getTextTheme(bodyFontString, baseTextTheme);
-  TextTheme displayTextTheme =
-  GoogleFonts.getTextTheme(displayFontString, baseTextTheme);
-  TextTheme textTheme = displayTextTheme.copyWith(
-    bodyLarge: bodyTextTheme.bodyLarge,
-    bodyMedium: bodyTextTheme.bodyMedium,
-    bodySmall: bodyTextTheme.bodySmall,
-    labelLarge: bodyTextTheme.labelLarge,
-    labelMedium: bodyTextTheme.labelMedium,
-    labelSmall: bodyTextTheme.labelSmall,
-  );
-  return textTheme;
+  return GoogleFonts.getTextTheme(fontString, baseTextTheme);
 }

--- a/lib/core/widgets/buttons/button_base.dart
+++ b/lib/core/widgets/buttons/button_base.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 /// A base class for button styling and behavior
 /// that can be extended by specific button types
@@ -18,7 +17,7 @@ abstract class ButtonBase extends StatelessWidget {
   });
 
   // Default text style used by all buttons
-  TextStyle get textStyle => GoogleFonts.roboto(
+  TextStyle get textStyle => const TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     letterSpacing: 0.5,

--- a/lib/features/auth/widgets/auth_base_screen.dart
+++ b/lib/features/auth/widgets/auth_base_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 /// Base screen for all authentication-related screens (login, register, etc.)
 /// Handles common layout for both mobile and desktop views
@@ -60,8 +59,7 @@ class AuthBaseScreen extends ConsumerWidget {
                   // Logo/App name
                   Text(
                     'Turbo',
-                    style: GoogleFonts.libreBaskerville(
-                      fontSize: 36,
+                    style: textTheme.displaySmall?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: colorScheme.onPrimaryContainer,
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,8 +57,7 @@ class MyApp extends ConsumerWidget {
     if (kDebugMode) {
       print("Building MyApp. Auth Status: ${authState.status}, Initializing: ${authState.isInitializing}");
     }
-    TextTheme textTheme =
-    createTextTheme(context, "Roboto", "Libre Baskerville");
+    TextTheme textTheme = createTextTheme(context, "Roboto");
     MaterialTheme theme = MaterialTheme(textTheme);
 
     return MaterialApp(


### PR DESCRIPTION
Removes the dual body/display font setup (Roboto + Libre Baskerville)
so all headings and body text now share one font family. The auth
screen logo and ButtonBase no longer hardcode their own font and
instead inherit from the theme, keeping heading styles consistent
across the app.

https://claude.ai/code/session_01S74gxi4pkp9Zmj25twp6Y3