### PR TITLE
Remove drop shadow from search bar for a more cohesive look

### DIFF
--- a/lib/features/search/widgets/search_bar_desktop.dart
+++ b/lib/features/search/widgets/search_bar_desktop.dart
@@ -134,6 +134,13 @@ class _DesktopSearchBarState extends ConsumerState<DesktopSearchBar> {
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainer,
             borderRadius: BorderRadius.circular(28.0),
+            boxShadow: [
+              BoxShadow(
+                color: theme.shadowColor.withValues(alpha: 0.1),
+                blurRadius: 3,
+                offset: const Offset(0, 1),
+              ),
+            ],
           ),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -151,6 +158,11 @@ class _DesktopSearchBarState extends ConsumerState<DesktopSearchBar> {
                     hintText: l10n.searchHint,
                     isDense: true,
                     border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
+                    disabledBorder: InputBorder.none,
+                    errorBorder: InputBorder.none,
+                    focusedErrorBorder: InputBorder.none,
                     contentPadding: EdgeInsets.zero,
                   ),
                 ),

--- a/lib/features/search/widgets/search_bar_desktop.dart
+++ b/lib/features/search/widgets/search_bar_desktop.dart
@@ -134,13 +134,6 @@ class _DesktopSearchBarState extends ConsumerState<DesktopSearchBar> {
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainer,
             borderRadius: BorderRadius.circular(28.0),
-            boxShadow: [
-              BoxShadow(
-                color: theme.shadowColor.withValues(alpha: 0.1),
-                blurRadius: 3,
-                offset: const Offset(0, 1),
-              ),
-            ],
           ),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/features/search/widgets/search_bar_mobile.dart
+++ b/lib/features/search/widgets/search_bar_mobile.dart
@@ -140,13 +140,6 @@ class _MobileSearchBarState extends ConsumerState<MobileSearchBar> {
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainer,
           borderRadius: BorderRadius.circular(28.0),
-          boxShadow: [
-            BoxShadow(
-              color: theme.shadowColor.withValues(alpha: 0.1),
-              blurRadius: 3,
-              offset: const Offset(0, 1),
-            ),
-          ],
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/features/search/widgets/search_bar_mobile.dart
+++ b/lib/features/search/widgets/search_bar_mobile.dart
@@ -140,6 +140,13 @@ class _MobileSearchBarState extends ConsumerState<MobileSearchBar> {
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainer,
           borderRadius: BorderRadius.circular(28.0),
+          boxShadow: [
+            BoxShadow(
+              color: theme.shadowColor.withValues(alpha: 0.1),
+              blurRadius: 3,
+              offset: const Offset(0, 1),
+            ),
+          ],
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -165,6 +172,11 @@ class _MobileSearchBarState extends ConsumerState<MobileSearchBar> {
                 decoration: InputDecoration(
                   hintText: l10n.searchHintMobile,
                   border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  disabledBorder: InputBorder.none,
+                  errorBorder: InputBorder.none,
+                  focusedErrorBorder: InputBorder.none,
                   isDense: true, // Important for vertical alignment
                   contentPadding: EdgeInsets.zero, // Remove all internal padding
                 ),


### PR DESCRIPTION
The boxShadow on the search bar Container rendered as a subtle outline
halo against the dark map background, making the bar feel like a
detached floating element. Dropping the shadow lets the surface tint
alone distinguish the bar so the menu icon, text field, and clear
button read as one component.