### PR TITLE
* Version bump

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.20
+version: 1.0.21
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Bump version to 1.0.21 to trigger the release workflow (tags `v1.0.21` and builds APKs).

---
_Generated by [Claude Code](https://claude.ai/code/session_0122dMEC9EXAwhR4dTXueScJ)_