### PR TITLE
Add collections feature for grouping markers and paths

### DIFF
--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -266,6 +266,34 @@ abstract class AppLocalizations {
   String get markerUpdated;
   String errorExportingMarker(String error);
 
+  // Collections
+  String get collections;
+  String get collection;
+  String get newCollection;
+  String get editCollection;
+  String get deleteCollection;
+  String get collectionName;
+  String get noCollectionsYet;
+  String get noCollectionsHint;
+  String get allMarkers;
+  String get allPaths;
+  String get addToCollection;
+  String get markersSection;
+  String get pathsSection;
+  String memberCount(int count);
+  String get noMembersInCollection;
+  String get confirmDeleteCollectionTitle;
+  String get confirmDeleteCollectionMessage;
+  String get collectionCreated;
+  String get collectionUpdated;
+  String get collectionDeleted;
+  String errorSavingCollection(String error);
+  String errorDeletingCollection(String error);
+  String get visibleOnMap;
+  String get hiddenOnMap;
+  String get color;
+  String get removeColor;
+
   // Offline Maps
   String get offlineMaps;
   String get noOfflineMapsDownloaded;
@@ -521,6 +549,33 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get markerUpdated => 'Marker updated';
   @override String errorExportingMarker(String error) => 'Error exporting marker: $error';
 
+  @override String get collections => 'Collections';
+  @override String get collection => 'Collection';
+  @override String get newCollection => 'New Collection';
+  @override String get editCollection => 'Edit Collection';
+  @override String get deleteCollection => 'Delete Collection';
+  @override String get collectionName => 'Collection name';
+  @override String get noCollectionsYet => 'No collections yet';
+  @override String get noCollectionsHint => 'Group markers and paths together so you can toggle, browse, and export them as a unit.';
+  @override String get allMarkers => 'All markers';
+  @override String get allPaths => 'All paths';
+  @override String get addToCollection => 'Add to collection';
+  @override String get markersSection => 'Markers';
+  @override String get pathsSection => 'Paths';
+  @override String memberCount(int count) => count == 1 ? '1 item' : '$count items';
+  @override String get noMembersInCollection => 'No markers or paths in this collection yet.';
+  @override String get confirmDeleteCollectionTitle => 'Delete collection?';
+  @override String get confirmDeleteCollectionMessage => 'The markers and paths inside will remain — only the collection is removed.';
+  @override String get collectionCreated => 'Collection created';
+  @override String get collectionUpdated => 'Collection updated';
+  @override String get collectionDeleted => 'Collection deleted';
+  @override String errorSavingCollection(String error) => 'Error saving collection: $error';
+  @override String errorDeletingCollection(String error) => 'Error deleting collection: $error';
+  @override String get visibleOnMap => 'Visible on map';
+  @override String get hiddenOnMap => 'Hidden on map';
+  @override String get color => 'Color';
+  @override String get removeColor => 'Remove color';
+
   @override String get offlineMaps => 'Offline Maps';
   @override String get noOfflineMapsDownloaded => 'No maps downloaded yet.\nTap the button below to download an area.';
   @override String get addOfflineRegion => 'Add offline region';
@@ -771,6 +826,33 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get markerDeleted => 'Punkt slettet';
   @override String get markerUpdated => 'Punkt oppdatert';
   @override String errorExportingMarker(String error) => 'Feil ved eksportering av punkt: $error';
+
+  @override String get collections => 'Samlinger';
+  @override String get collection => 'Samling';
+  @override String get newCollection => 'Ny samling';
+  @override String get editCollection => 'Rediger samling';
+  @override String get deleteCollection => 'Slett samling';
+  @override String get collectionName => 'Samlingsnavn';
+  @override String get noCollectionsYet => 'Ingen samlinger ennå';
+  @override String get noCollectionsHint => 'Grupper punkter og ruter slik at du kan slå dem av/på, bla gjennom og eksportere dem sammen.';
+  @override String get allMarkers => 'Alle punkter';
+  @override String get allPaths => 'Alle ruter';
+  @override String get addToCollection => 'Legg til i samling';
+  @override String get markersSection => 'Punkter';
+  @override String get pathsSection => 'Ruter';
+  @override String memberCount(int count) => count == 1 ? '1 element' : '$count elementer';
+  @override String get noMembersInCollection => 'Ingen punkter eller ruter i denne samlingen ennå.';
+  @override String get confirmDeleteCollectionTitle => 'Slette samlingen?';
+  @override String get confirmDeleteCollectionMessage => 'Punktene og rutene blir værende — bare samlingen blir fjernet.';
+  @override String get collectionCreated => 'Samling opprettet';
+  @override String get collectionUpdated => 'Samling oppdatert';
+  @override String get collectionDeleted => 'Samling slettet';
+  @override String errorSavingCollection(String error) => 'Feil ved lagring av samling: $error';
+  @override String errorDeletingCollection(String error) => 'Feil ved sletting av samling: $error';
+  @override String get visibleOnMap => 'Synlig på kartet';
+  @override String get hiddenOnMap => 'Skjult på kartet';
+  @override String get color => 'Farge';
+  @override String get removeColor => 'Fjern farge';
 
   @override String get offlineMaps => 'Offline-kart';
   @override String get noOfflineMapsDownloaded => 'Ingen kart lastet ned ennå.\nTrykk på knappen under for å laste ned et område.';

--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -629,8 +629,8 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get collectionName => 'Collection name';
   @override String get noCollectionsYet => 'No collections yet';
   @override String get noCollectionsHint => 'Group markers and paths together so you can toggle, browse, and export them as a unit.';
-  @override String get allMarkers => 'All markers';
-  @override String get allPaths => 'All paths';
+  @override String get allMarkers => 'Markers';
+  @override String get allPaths => 'Paths';
   @override String get addToCollection => 'Add to collection';
   @override String get markersSection => 'Markers';
   @override String get pathsSection => 'Paths';
@@ -943,8 +943,8 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get collectionName => 'Samlingsnavn';
   @override String get noCollectionsYet => 'Ingen samlinger ennå';
   @override String get noCollectionsHint => 'Grupper punkter og ruter slik at du kan slå dem av/på, bla gjennom og eksportere dem sammen.';
-  @override String get allMarkers => 'Alle punkter';
-  @override String get allPaths => 'Alle ruter';
+  @override String get allMarkers => 'Punkter';
+  @override String get allPaths => 'Ruter';
   @override String get addToCollection => 'Legg til i samling';
   @override String get markersSection => 'Punkter';
   @override String get pathsSection => 'Ruter';

--- a/lib/core/data/database_provider.dart
+++ b/lib/core/data/database_provider.dart
@@ -6,7 +6,7 @@ import 'package:path/path.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 const String _dbName = 'turbo_app_v1.db';
-const int _dbVersion = 4;
+const int _dbVersion = 5;
 
 // Table Names
 const String regionsTable = 'offline_regions';
@@ -15,6 +15,8 @@ const String tileStoreTable = 'tile_store';
 const String markersTable = 'markers';
 const String pendingDeletesTable = 'pending_deletes';
 const String savedPathsTable = 'saved_paths';
+const String collectionsTable = 'collections';
+const String collectionItemsTable = 'collection_items';
 
 
 /// A provider that creates and holds the single instance of the app's database.
@@ -138,6 +140,31 @@ Future<void> _createDb(Database db, int version) async {
   ''');
   batch.execute('CREATE INDEX idx_saved_paths_bounds ON $savedPathsTable(min_lat, max_lat, min_lng, max_lng)');
 
+  // Collections + join table (v5). The join table is keyed by (type, uuid)
+  // so future item types do not require schema changes.
+  batch.execute('''
+    CREATE TABLE $collectionsTable(
+      uuid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      color_hex TEXT,
+      icon_key TEXT,
+      created_at TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    )
+  ''');
+  batch.execute('''
+    CREATE TABLE $collectionItemsTable(
+      collection_uuid TEXT NOT NULL,
+      item_type TEXT NOT NULL,
+      item_uuid TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      PRIMARY KEY (collection_uuid, item_type, item_uuid),
+      FOREIGN KEY (collection_uuid) REFERENCES $collectionsTable(uuid) ON DELETE CASCADE
+    )
+  ''');
+  batch.execute('CREATE INDEX idx_collection_items_item ON $collectionItemsTable(item_type, item_uuid)');
+
   await batch.commit(noResult: true);
 }
 
@@ -150,8 +177,35 @@ Future<void> _upgradeDb(Database db, int oldVersion, int newVersion) async {
         await _migrateV2ToV3(db);
       case 4:
         await _migrateV3ToV4(db);
+      case 5:
+        await _migrateV4ToV5(db);
     }
   }
+}
+
+Future<void> _migrateV4ToV5(Database db) async {
+  await db.execute('''
+    CREATE TABLE IF NOT EXISTS $collectionsTable(
+      uuid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      color_hex TEXT,
+      icon_key TEXT,
+      created_at TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    )
+  ''');
+  await db.execute('''
+    CREATE TABLE IF NOT EXISTS $collectionItemsTable(
+      collection_uuid TEXT NOT NULL,
+      item_type TEXT NOT NULL,
+      item_uuid TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      PRIMARY KEY (collection_uuid, item_type, item_uuid),
+      FOREIGN KEY (collection_uuid) REFERENCES $collectionsTable(uuid) ON DELETE CASCADE
+    )
+  ''');
+  await db.execute('CREATE INDEX IF NOT EXISTS idx_collection_items_item ON $collectionItemsTable(item_type, item_uuid)');
 }
 
 Future<void> _migrateV3ToV4(Database db) async {

--- a/lib/features/auth/widgets/drawer_widget.dart
+++ b/lib/features/auth/widgets/drawer_widget.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
+import 'package:turbo/features/collections/api.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart';
 import 'package:turbo/features/settings/api.dart';
 import 'package:turbo/features/tile_storage/offline_regions/api.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
@@ -22,6 +25,9 @@ class AppDrawer extends ConsumerWidget {
 
     final List<Map<String, dynamic>> destinations = [
       {'key': 'map', 'icon': Icons.map_outlined, 'selectedIcon': Icons.map, 'label': l10n.map},
+      {'key': 'collections', 'icon': Icons.folder_outlined, 'selectedIcon': Icons.folder, 'label': l10n.collections},
+      {'key': 'all_markers', 'icon': Icons.place_outlined, 'selectedIcon': Icons.place, 'label': l10n.allMarkers},
+      {'key': 'all_paths', 'icon': Icons.route_outlined, 'selectedIcon': Icons.route, 'label': l10n.allPaths},
       {'key': 'offline_maps', 'icon': Icons.download_for_offline_outlined, 'selectedIcon': Icons.download_for_offline, 'label': l10n.offlineMaps},
       {'key': 'settings', 'icon': Icons.settings_outlined, 'selectedIcon': Icons.settings, 'label': l10n.settings},
       if (isAuthenticated)
@@ -113,6 +119,24 @@ class AppDrawer extends ConsumerWidget {
                 switch (selectedKey) {
                   case 'map':
                   // Already on map, do nothing
+                    break;
+                  case 'collections':
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const CollectionsPage()),
+                    );
+                    break;
+                  case 'all_markers':
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const MarkersListPage()),
+                    );
+                    break;
+                  case 'all_paths':
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const PathsListPage()),
+                    );
                     break;
                   case 'offline_maps':
                     Navigator.push(

--- a/lib/features/collections/api.dart
+++ b/lib/features/collections/api.dart
@@ -17,5 +17,6 @@ export 'data/collection_filter.dart' show isItemVisibleForCollections;
 export 'widgets/collections_page.dart' show CollectionsPage;
 export 'widgets/collection_detail_page.dart' show CollectionDetailPage;
 export 'widgets/add_to_collection_sheet.dart' show AddToCollectionSheet;
+export 'widgets/collection_picker_row.dart' show CollectionPickerRow;
 export 'widgets/create_or_edit_collection_sheet.dart'
     show CreateOrEditCollectionSheet;

--- a/lib/features/collections/api.dart
+++ b/lib/features/collections/api.dart
@@ -1,0 +1,21 @@
+/// Public API for the Collections feature.
+library;
+
+export 'models/collection.dart' show Collection;
+export 'models/collection_item_ref.dart' show CollectionItemRef;
+export 'data/collection_data_store.dart' show CollectionDataStore;
+export 'data/collection_repository.dart'
+    show
+        collectionRepositoryProvider,
+        localCollectionDataStoreProvider,
+        CollectionRepository,
+        CollectionRepositoryState,
+        CollectionRepositoryStateX;
+export 'data/collection_visibility_provider.dart'
+    show collectionVisibilityProvider, CollectionVisibilityNotifier;
+export 'data/collection_filter.dart' show isItemVisibleForCollections;
+export 'widgets/collections_page.dart' show CollectionsPage;
+export 'widgets/collection_detail_page.dart' show CollectionDetailPage;
+export 'widgets/add_to_collection_sheet.dart' show AddToCollectionSheet;
+export 'widgets/create_or_edit_collection_sheet.dart'
+    show CreateOrEditCollectionSheet;

--- a/lib/features/collections/data/collection_data_store.dart
+++ b/lib/features/collections/data/collection_data_store.dart
@@ -1,0 +1,22 @@
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+
+abstract class CollectionDataStore {
+  Future<void> init();
+
+  // Collections
+  Future<List<Collection>> getAll();
+  Future<Collection?> getByUuid(String uuid);
+  Future<void> insert(Collection collection);
+  Future<void> update(Collection collection);
+  Future<void> delete(String uuid);
+
+  // Membership
+  Future<List<CollectionItemRef>> getItems(String collectionUuid);
+  Future<List<String>> getCollectionUuidsFor(CollectionItemRef ref);
+  Future<Map<CollectionItemRef, List<String>>> getMembershipIndex();
+  Future<void> addItem(String collectionUuid, CollectionItemRef ref);
+  Future<void> removeItem(String collectionUuid, CollectionItemRef ref);
+  Future<void> removeItemFromAll(CollectionItemRef ref);
+  Future<int> countItems(String collectionUuid);
+}

--- a/lib/features/collections/data/collection_filter.dart
+++ b/lib/features/collections/data/collection_filter.dart
@@ -1,0 +1,21 @@
+import '../models/collection_item_ref.dart';
+import 'collection_repository.dart';
+
+/// Returns true when an item should be visible on the map given the current
+/// collection memberships and visibility map.
+///
+/// Semantics: an item is hidden only when it belongs to one or more
+/// collections AND every one of those collections is toggled off. An item in
+/// zero collections is always visible (subject to the global type toggles).
+bool isItemVisibleForCollections({
+  required CollectionItemRef ref,
+  required CollectionRepositoryState collectionState,
+  required Map<String, bool> visibility,
+}) {
+  final memberships = collectionState.collectionsFor(ref);
+  if (memberships.isEmpty) return true;
+  for (final c in memberships) {
+    if (visibility[c] ?? true) return true;
+  }
+  return false;
+}

--- a/lib/features/collections/data/collection_repository.dart
+++ b/lib/features/collections/data/collection_repository.dart
@@ -69,11 +69,15 @@ class CollectionRepository
       ref.read(localCollectionDataStoreProvider.future);
 
   Future<void> _loadData() async {
+    if (!ref.mounted) return;
     state = const AsyncValue.loading();
     try {
       final store = await _store;
+      if (!ref.mounted) return;
       final collections = await store.getAll();
+      if (!ref.mounted) return;
       final membershipIndex = await store.getMembershipIndex();
+      if (!ref.mounted) return;
       final counts = <String, int>{};
       for (final entry in membershipIndex.entries) {
         for (final cUuid in entry.value) {
@@ -87,6 +91,7 @@ class CollectionRepository
       ));
     } catch (e, st) {
       _log.severe('Error loading collections', e, st);
+      if (!ref.mounted) return;
       state = AsyncValue.error(e, st);
     }
   }

--- a/lib/features/collections/data/collection_repository.dart
+++ b/lib/features/collections/data/collection_repository.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+import 'package:turbo/core/data/database_provider.dart';
+
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+import 'collection_data_store.dart';
+import 'indexdb_collection_data_store.dart';
+import 'sqlite_collection_data_store.dart';
+
+final localCollectionDataStoreProvider =
+    FutureProvider<CollectionDataStore>((ref) async {
+  if (kIsWeb) {
+    final store = ShimDBCollectionDataStore();
+    await store.init();
+    return store;
+  } else {
+    final db = await ref.watch(databaseProvider.future);
+    return SQLiteCollectionDataStore(db);
+  }
+});
+
+class CollectionRepositoryState {
+  final List<Collection> collections;
+  final Map<String, int> memberCounts;
+  final Map<CollectionItemRef, List<String>> membershipIndex;
+
+  const CollectionRepositoryState({
+    required this.collections,
+    required this.memberCounts,
+    required this.membershipIndex,
+  });
+
+  const CollectionRepositoryState.empty()
+      : collections = const [],
+        memberCounts = const {},
+        membershipIndex = const {};
+
+  CollectionRepositoryState copyWith({
+    List<Collection>? collections,
+    Map<String, int>? memberCounts,
+    Map<CollectionItemRef, List<String>>? membershipIndex,
+  }) {
+    return CollectionRepositoryState(
+      collections: collections ?? this.collections,
+      memberCounts: memberCounts ?? this.memberCounts,
+      membershipIndex: membershipIndex ?? this.membershipIndex,
+    );
+  }
+}
+
+final collectionRepositoryProvider = NotifierProvider<CollectionRepository,
+    AsyncValue<CollectionRepositoryState>>(() {
+  return CollectionRepository();
+});
+
+class CollectionRepository
+    extends Notifier<AsyncValue<CollectionRepositoryState>> {
+  final _log = Logger('CollectionRepository');
+
+  @override
+  AsyncValue<CollectionRepositoryState> build() {
+    _loadData();
+    return const AsyncValue.data(CollectionRepositoryState.empty());
+  }
+
+  Future<CollectionDataStore> get _store =>
+      ref.read(localCollectionDataStoreProvider.future);
+
+  Future<void> _loadData() async {
+    state = const AsyncValue.loading();
+    try {
+      final store = await _store;
+      final collections = await store.getAll();
+      final membershipIndex = await store.getMembershipIndex();
+      final counts = <String, int>{};
+      for (final entry in membershipIndex.entries) {
+        for (final cUuid in entry.value) {
+          counts[cUuid] = (counts[cUuid] ?? 0) + 1;
+        }
+      }
+      state = AsyncValue.data(CollectionRepositoryState(
+        collections: collections,
+        memberCounts: counts,
+        membershipIndex: membershipIndex,
+      ));
+    } catch (e, st) {
+      _log.severe('Error loading collections', e, st);
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> refresh() => _loadData();
+
+  Future<Collection> create(Collection collection) async {
+    final store = await _store;
+    await store.insert(collection);
+    await _loadData();
+    return collection;
+  }
+
+  Future<void> updateCollection(Collection collection) async {
+    final store = await _store;
+    await store.update(collection);
+    await _loadData();
+  }
+
+  Future<void> deleteCollection(String uuid) async {
+    final store = await _store;
+    await store.delete(uuid);
+    await _loadData();
+  }
+
+  Future<void> addItem(String collectionUuid, CollectionItemRef ref) async {
+    final store = await _store;
+    await store.addItem(collectionUuid, ref);
+    await _loadData();
+  }
+
+  Future<void> removeItem(String collectionUuid, CollectionItemRef ref) async {
+    final store = await _store;
+    await store.removeItem(collectionUuid, ref);
+    await _loadData();
+  }
+
+  /// Set the exact set of collections an item belongs to.
+  Future<void> setMembership(
+    CollectionItemRef ref,
+    Set<String> desiredCollectionUuids,
+  ) async {
+    final store = await _store;
+    final current = (await store.getCollectionUuidsFor(ref)).toSet();
+    final toAdd = desiredCollectionUuids.difference(current);
+    final toRemove = current.difference(desiredCollectionUuids);
+    for (final c in toAdd) {
+      await store.addItem(c, ref);
+    }
+    for (final c in toRemove) {
+      await store.removeItem(c, ref);
+    }
+    await _loadData();
+  }
+
+  /// Called by marker/path repositories when an underlying item is deleted,
+  /// so dangling join rows do not accumulate.
+  Future<void> handleItemDeleted(CollectionItemRef ref) async {
+    final store = await _store;
+    await store.removeItemFromAll(ref);
+    await _loadData();
+  }
+}
+
+extension CollectionRepositoryStateX on CollectionRepositoryState {
+  List<String> collectionsFor(CollectionItemRef ref) =>
+      membershipIndex[ref] ?? const [];
+
+  int memberCountFor(String collectionUuid) =>
+      memberCounts[collectionUuid] ?? 0;
+}

--- a/lib/features/collections/data/collection_visibility_provider.dart
+++ b/lib/features/collections/data/collection_visibility_provider.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final collectionVisibilityProvider =
+    NotifierProvider<CollectionVisibilityNotifier, Map<String, bool>>(
+  CollectionVisibilityNotifier.new,
+);
+
+class CollectionVisibilityNotifier extends Notifier<Map<String, bool>> {
+  static const _prefsKey = 'collectionVisibility';
+
+  @override
+  Map<String, bool> build() {
+    _loadFromPrefs();
+    return <String, bool>{};
+  }
+
+  Future<void> _loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return;
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      state = decoded.map((k, v) => MapEntry(k, v == true));
+    } catch (_) {
+      // Ignore malformed prefs; treat as empty.
+    }
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(state));
+  }
+
+  bool isVisible(String collectionUuid) {
+    return state[collectionUuid] ?? true;
+  }
+
+  void toggle(String collectionUuid) {
+    setVisible(collectionUuid, !isVisible(collectionUuid));
+  }
+
+  void setVisible(String collectionUuid, bool visible) {
+    final next = Map<String, bool>.from(state);
+    next[collectionUuid] = visible;
+    state = next;
+    _persist();
+  }
+
+  void clearFor(String collectionUuid) {
+    if (!state.containsKey(collectionUuid)) return;
+    final next = Map<String, bool>.from(state);
+    next.remove(collectionUuid);
+    state = next;
+    _persist();
+  }
+}

--- a/lib/features/collections/data/indexdb_collection_data_store.dart
+++ b/lib/features/collections/data/indexdb_collection_data_store.dart
@@ -1,0 +1,205 @@
+import 'package:idb_shim/idb_browser.dart';
+
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+import 'collection_data_store.dart';
+
+class ShimDBCollectionDataStore implements CollectionDataStore {
+  Database? _database;
+  final IdbFactory _idbFactory;
+  static const String dbName = 'CollectionsDatabaseV1';
+  static const String collectionsStore = 'collections';
+  static const String itemsStore = 'collection_items';
+  static const int _dbVersion = 1;
+
+  ShimDBCollectionDataStore({IdbFactory? idbFactory})
+      : _idbFactory = idbFactory ?? getIdbFactory()!;
+
+  Future<Database> get _db async {
+    if (_database != null) return _database!;
+    _database = await _idbFactory.open(
+      dbName,
+      version: _dbVersion,
+      onUpgradeNeeded: _onUpgradeNeeded,
+    );
+    return _database!;
+  }
+
+  @override
+  Future<void> init() async {
+    await _db;
+  }
+
+  void _onUpgradeNeeded(VersionChangeEvent event) {
+    final db = event.database;
+    if (!db.objectStoreNames.contains(collectionsStore)) {
+      db.createObjectStore(collectionsStore, keyPath: 'uuid');
+    }
+    if (!db.objectStoreNames.contains(itemsStore)) {
+      final store = db.createObjectStore(itemsStore, keyPath: 'id');
+      store.createIndex('by_collection', 'collection_uuid', unique: false);
+      store.createIndex(
+        'by_item',
+        ['item_type', 'item_uuid'],
+        unique: false,
+      );
+    }
+  }
+
+  String _itemKey(String collectionUuid, CollectionItemRef ref) =>
+      '$collectionUuid|${ref.type}|${ref.uuid}';
+
+  @override
+  Future<List<Collection>> getAll() async {
+    final db = await _db;
+    final txn = db.transaction(collectionsStore, 'readonly');
+    final store = txn.objectStore(collectionsStore);
+    final records = await store.getAll();
+    await txn.completed;
+    final list = records
+        .map((r) => Collection.fromLocalMap(r as Map<String, dynamic>))
+        .toList();
+    list.sort((a, b) {
+      final cmp = a.sortOrder.compareTo(b.sortOrder);
+      if (cmp != 0) return cmp;
+      return a.createdAt.compareTo(b.createdAt);
+    });
+    return list;
+  }
+
+  @override
+  Future<Collection?> getByUuid(String uuid) async {
+    final db = await _db;
+    final txn = db.transaction(collectionsStore, 'readonly');
+    final store = txn.objectStore(collectionsStore);
+    final data = await store.getObject(uuid) as Map<String, dynamic>?;
+    await txn.completed;
+    return data != null ? Collection.fromLocalMap(data) : null;
+  }
+
+  @override
+  Future<void> insert(Collection collection) async {
+    final db = await _db;
+    final txn = db.transaction(collectionsStore, 'readwrite');
+    final store = txn.objectStore(collectionsStore);
+    await store.put(collection.toLocalMap());
+    await txn.completed;
+  }
+
+  @override
+  Future<void> update(Collection collection) async {
+    await insert(collection);
+  }
+
+  @override
+  Future<void> delete(String uuid) async {
+    final db = await _db;
+    final txn = db.transaction(
+      [collectionsStore, itemsStore],
+      'readwrite',
+    );
+    final colStore = txn.objectStore(collectionsStore);
+    final itemStore = txn.objectStore(itemsStore);
+    await colStore.delete(uuid);
+    final index = itemStore.index('by_collection');
+    final keys = await index.getAllKeys(uuid);
+    for (final k in keys) {
+      await itemStore.delete(k);
+    }
+    await txn.completed;
+  }
+
+  @override
+  Future<List<CollectionItemRef>> getItems(String collectionUuid) async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readonly');
+    final store = txn.objectStore(itemsStore);
+    final index = store.index('by_collection');
+    final records = await index.getAll(collectionUuid);
+    await txn.completed;
+    final maps = records.cast<Map<String, dynamic>>().toList();
+    maps.sort((a, b) => (a['added_at'] as String).compareTo(b['added_at'] as String));
+    return maps
+        .map((m) => CollectionItemRef(
+              type: m['item_type'] as String,
+              uuid: m['item_uuid'] as String,
+            ))
+        .toList();
+  }
+
+  @override
+  Future<List<String>> getCollectionUuidsFor(CollectionItemRef ref) async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readonly');
+    final store = txn.objectStore(itemsStore);
+    final index = store.index('by_item');
+    final records = await index.getAll([ref.type, ref.uuid]);
+    await txn.completed;
+    return records
+        .cast<Map<String, dynamic>>()
+        .map((m) => m['collection_uuid'] as String)
+        .toList();
+  }
+
+  @override
+  Future<Map<CollectionItemRef, List<String>>> getMembershipIndex() async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readonly');
+    final store = txn.objectStore(itemsStore);
+    final records = await store.getAll();
+    await txn.completed;
+    final out = <CollectionItemRef, List<String>>{};
+    for (final r in records) {
+      final m = r as Map<String, dynamic>;
+      final ref = CollectionItemRef(
+        type: m['item_type'] as String,
+        uuid: m['item_uuid'] as String,
+      );
+      (out[ref] ??= <String>[]).add(m['collection_uuid'] as String);
+    }
+    return out;
+  }
+
+  @override
+  Future<void> addItem(String collectionUuid, CollectionItemRef ref) async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readwrite');
+    final store = txn.objectStore(itemsStore);
+    await store.put({
+      'id': _itemKey(collectionUuid, ref),
+      'collection_uuid': collectionUuid,
+      'item_type': ref.type,
+      'item_uuid': ref.uuid,
+      'added_at': DateTime.now().toIso8601String(),
+    });
+    await txn.completed;
+  }
+
+  @override
+  Future<void> removeItem(String collectionUuid, CollectionItemRef ref) async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readwrite');
+    final store = txn.objectStore(itemsStore);
+    await store.delete(_itemKey(collectionUuid, ref));
+    await txn.completed;
+  }
+
+  @override
+  Future<void> removeItemFromAll(CollectionItemRef ref) async {
+    final db = await _db;
+    final txn = db.transaction(itemsStore, 'readwrite');
+    final store = txn.objectStore(itemsStore);
+    final index = store.index('by_item');
+    final keys = await index.getAllKeys([ref.type, ref.uuid]);
+    for (final k in keys) {
+      await store.delete(k);
+    }
+    await txn.completed;
+  }
+
+  @override
+  Future<int> countItems(String collectionUuid) async {
+    final items = await getItems(collectionUuid);
+    return items.length;
+  }
+}

--- a/lib/features/collections/data/sqlite_collection_data_store.dart
+++ b/lib/features/collections/data/sqlite_collection_data_store.dart
@@ -1,0 +1,153 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:turbo/core/data/database_provider.dart';
+
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+import 'collection_data_store.dart';
+
+class SQLiteCollectionDataStore implements CollectionDataStore {
+  final Database db;
+
+  SQLiteCollectionDataStore(this.db);
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<List<Collection>> getAll() async {
+    final maps = await db.query(
+      collectionsTable,
+      orderBy: 'sort_order ASC, created_at ASC',
+    );
+    return maps.map(Collection.fromLocalMap).toList();
+  }
+
+  @override
+  Future<Collection?> getByUuid(String uuid) async {
+    final maps = await db.query(
+      collectionsTable,
+      where: 'uuid = ?',
+      whereArgs: [uuid],
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return Collection.fromLocalMap(maps.first);
+  }
+
+  @override
+  Future<void> insert(Collection collection) async {
+    await db.insert(
+      collectionsTable,
+      collection.toLocalMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  @override
+  Future<void> update(Collection collection) async {
+    await db.update(
+      collectionsTable,
+      collection.toLocalMap(),
+      where: 'uuid = ?',
+      whereArgs: [collection.uuid],
+    );
+  }
+
+  @override
+  Future<void> delete(String uuid) async {
+    await db.transaction((txn) async {
+      await txn.delete(
+        collectionItemsTable,
+        where: 'collection_uuid = ?',
+        whereArgs: [uuid],
+      );
+      await txn.delete(
+        collectionsTable,
+        where: 'uuid = ?',
+        whereArgs: [uuid],
+      );
+    });
+  }
+
+  @override
+  Future<List<CollectionItemRef>> getItems(String collectionUuid) async {
+    final maps = await db.query(
+      collectionItemsTable,
+      where: 'collection_uuid = ?',
+      whereArgs: [collectionUuid],
+      orderBy: 'added_at ASC',
+    );
+    return maps
+        .map((m) => CollectionItemRef(
+              type: m['item_type'] as String,
+              uuid: m['item_uuid'] as String,
+            ))
+        .toList();
+  }
+
+  @override
+  Future<List<String>> getCollectionUuidsFor(CollectionItemRef ref) async {
+    final maps = await db.query(
+      collectionItemsTable,
+      columns: ['collection_uuid'],
+      where: 'item_type = ? AND item_uuid = ?',
+      whereArgs: [ref.type, ref.uuid],
+    );
+    return maps.map((m) => m['collection_uuid'] as String).toList();
+  }
+
+  @override
+  Future<Map<CollectionItemRef, List<String>>> getMembershipIndex() async {
+    final maps = await db.query(collectionItemsTable);
+    final index = <CollectionItemRef, List<String>>{};
+    for (final m in maps) {
+      final ref = CollectionItemRef(
+        type: m['item_type'] as String,
+        uuid: m['item_uuid'] as String,
+      );
+      (index[ref] ??= <String>[]).add(m['collection_uuid'] as String);
+    }
+    return index;
+  }
+
+  @override
+  Future<void> addItem(String collectionUuid, CollectionItemRef ref) async {
+    await db.insert(
+      collectionItemsTable,
+      {
+        'collection_uuid': collectionUuid,
+        'item_type': ref.type,
+        'item_uuid': ref.uuid,
+        'added_at': DateTime.now().toIso8601String(),
+      },
+      conflictAlgorithm: ConflictAlgorithm.ignore,
+    );
+  }
+
+  @override
+  Future<void> removeItem(String collectionUuid, CollectionItemRef ref) async {
+    await db.delete(
+      collectionItemsTable,
+      where: 'collection_uuid = ? AND item_type = ? AND item_uuid = ?',
+      whereArgs: [collectionUuid, ref.type, ref.uuid],
+    );
+  }
+
+  @override
+  Future<void> removeItemFromAll(CollectionItemRef ref) async {
+    await db.delete(
+      collectionItemsTable,
+      where: 'item_type = ? AND item_uuid = ?',
+      whereArgs: [ref.type, ref.uuid],
+    );
+  }
+
+  @override
+  Future<int> countItems(String collectionUuid) async {
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM $collectionItemsTable WHERE collection_uuid = ?',
+      [collectionUuid],
+    );
+    return (result.first['c'] as num).toInt();
+  }
+}

--- a/lib/features/collections/models/collection.dart
+++ b/lib/features/collections/models/collection.dart
@@ -1,0 +1,94 @@
+import 'package:uuid/uuid.dart';
+
+class Collection {
+  final String uuid;
+  final String name;
+  final String? description;
+  final String? colorHex;
+  final String? iconKey;
+  final DateTime createdAt;
+  final int sortOrder;
+
+  Collection({
+    String? uuid,
+    required this.name,
+    this.description,
+    this.colorHex,
+    this.iconKey,
+    DateTime? createdAt,
+    this.sortOrder = 0,
+  })  : uuid = uuid ?? const Uuid().v4(),
+        createdAt = createdAt ?? DateTime.now();
+
+  Collection copyWith({
+    String? uuid,
+    String? name,
+    String? description,
+    bool clearDescription = false,
+    String? colorHex,
+    bool clearColorHex = false,
+    String? iconKey,
+    bool clearIconKey = false,
+    DateTime? createdAt,
+    int? sortOrder,
+  }) {
+    return Collection(
+      uuid: uuid ?? this.uuid,
+      name: name ?? this.name,
+      description:
+          clearDescription ? null : (description ?? this.description),
+      colorHex: clearColorHex ? null : (colorHex ?? this.colorHex),
+      iconKey: clearIconKey ? null : (iconKey ?? this.iconKey),
+      createdAt: createdAt ?? this.createdAt,
+      sortOrder: sortOrder ?? this.sortOrder,
+    );
+  }
+
+  factory Collection.fromLocalMap(Map<String, dynamic> map) {
+    return Collection(
+      uuid: map['uuid'] as String,
+      name: map['name'] as String,
+      description: map['description'] as String?,
+      colorHex: map['color_hex'] as String?,
+      iconKey: map['icon_key'] as String?,
+      createdAt: DateTime.parse(map['created_at'] as String),
+      sortOrder: (map['sort_order'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toLocalMap() {
+    return {
+      'uuid': uuid,
+      'name': name,
+      'description': description,
+      'color_hex': colorHex,
+      'icon_key': iconKey,
+      'created_at': createdAt.toIso8601String(),
+      'sort_order': sortOrder,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Collection &&
+          runtimeType == other.runtimeType &&
+          uuid == other.uuid &&
+          name == other.name &&
+          description == other.description &&
+          colorHex == other.colorHex &&
+          iconKey == other.iconKey &&
+          createdAt == other.createdAt &&
+          sortOrder == other.sortOrder;
+
+  @override
+  int get hashCode => Object.hash(
+        uuid,
+        name,
+        description,
+        colorHex,
+        iconKey,
+        createdAt,
+        sortOrder,
+      );
+}

--- a/lib/features/collections/models/collection_item_ref.dart
+++ b/lib/features/collections/models/collection_item_ref.dart
@@ -1,0 +1,28 @@
+/// A typed reference to an item that can live in a [Collection].
+///
+/// Keeping the item type a free-form string keeps the join table generic:
+/// adding a new item type (e.g. regions, photos) does not require a schema
+/// change.
+class CollectionItemRef {
+  final String type;
+  final String uuid;
+
+  const CollectionItemRef({required this.type, required this.uuid});
+
+  static const String typeMarker = 'marker';
+  static const String typePath = 'path';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CollectionItemRef &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          uuid == other.uuid;
+
+  @override
+  int get hashCode => Object.hash(type, uuid);
+
+  @override
+  String toString() => 'CollectionItemRef($type, $uuid)';
+}

--- a/lib/features/collections/widgets/add_to_collection_sheet.dart
+++ b/lib/features/collections/widgets/add_to_collection_sheet.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart' show hexToColor;
+
+import '../data/collection_repository.dart';
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+import 'create_or_edit_collection_sheet.dart';
+
+class AddToCollectionSheet extends ConsumerStatefulWidget {
+  final CollectionItemRef itemRef;
+
+  const AddToCollectionSheet({super.key, required this.itemRef});
+
+  static Future<void> show(BuildContext context, CollectionItemRef ref) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => AddToCollectionSheet(itemRef: ref),
+    );
+  }
+
+  @override
+  ConsumerState<AddToCollectionSheet> createState() =>
+      _AddToCollectionSheetState();
+}
+
+class _AddToCollectionSheetState extends ConsumerState<AddToCollectionSheet> {
+  late Set<String> _selected;
+  bool _initialized = false;
+  bool _saving = false;
+
+  void _initSelection(CollectionRepositoryState state) {
+    if (_initialized) return;
+    _selected = state.collectionsFor(widget.itemRef).toSet();
+    _initialized = true;
+  }
+
+  Future<void> _createNew() async {
+    final created = await CreateOrEditCollectionSheet.show(context);
+    if (created != null && mounted) {
+      setState(() => _selected.add(created.uuid));
+    }
+  }
+
+  Future<void> _save() async {
+    final l10n = context.l10n;
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(collectionRepositoryProvider.notifier)
+          .setMembership(widget.itemRef, _selected);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        AppSnackbars.error(context, l10n.errorSavingCollection(e.toString()));
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    final mediaQuery = MediaQuery.of(context);
+    final bottomPadding = mediaQuery.viewInsets.bottom > 0
+        ? mediaQuery.viewInsets.bottom
+        : mediaQuery.padding.bottom;
+    final asyncState = ref.watch(collectionRepositoryProvider);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+      child: asyncState.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.all(24),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        error: (e, _) => Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text('$e'),
+        ),
+        data: (state) {
+          _initSelection(state);
+          final collections = state.collections;
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      l10n.addToCollection,
+                      style: textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  backgroundColor: colorScheme.primaryContainer,
+                  child: Icon(Icons.add, color: colorScheme.onPrimaryContainer),
+                ),
+                title: Text(l10n.newCollection),
+                onTap: _saving ? null : _createNew,
+              ),
+              if (collections.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Text(
+                    l10n.noCollectionsYet,
+                    textAlign: TextAlign.center,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                Flexible(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: collections.length,
+                    itemBuilder: (context, i) {
+                      final c = collections[i];
+                      return _CollectionCheckRow(
+                        collection: c,
+                        selected: _selected.contains(c.uuid),
+                        onChanged: (v) {
+                          setState(() {
+                            if (v == true) {
+                              _selected.add(c.uuid);
+                            } else {
+                              _selected.remove(c.uuid);
+                            }
+                          });
+                        },
+                      );
+                    },
+                  ),
+                ),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _saving ? null : _save,
+                child: Text(l10n.save),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CollectionCheckRow extends StatelessWidget {
+  final Collection collection;
+  final bool selected;
+  final ValueChanged<bool?> onChanged;
+
+  const _CollectionCheckRow({
+    required this.collection,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = hexToColor(collection.colorHex) ?? colorScheme.primary;
+    final iconService = IconService();
+    final namedIcon = collection.iconKey != null
+        ? iconService.getIcon(context, collection.iconKey)
+        : null;
+
+    return CheckboxListTile(
+      contentPadding: EdgeInsets.zero,
+      value: selected,
+      onChanged: onChanged,
+      title: Text(collection.name),
+      subtitle: collection.description != null && collection.description!.isNotEmpty
+          ? Text(collection.description!)
+          : null,
+      secondary: CircleAvatar(
+        backgroundColor: color.withAlpha(40),
+        child: Icon(
+          namedIcon?.icon ?? Icons.folder_outlined,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/add_to_collection_sheet.dart
+++ b/lib/features/collections/widgets/add_to_collection_sheet.dart
@@ -10,11 +10,25 @@ import '../models/collection.dart';
 import '../models/collection_item_ref.dart';
 import 'create_or_edit_collection_sheet.dart';
 
+/// Sheet for picking collections.
+///
+/// Two modes:
+/// - Binding mode (`itemRef != null`): writes membership directly to the
+///   repository on save and pops with no result.
+/// - Picker mode (`itemRef == null`): seeds the checkboxes from
+///   [initialSelected] and pops with the chosen `Set<String>`. Used by the
+///   create sheets where the item does not yet have a UUID.
 class AddToCollectionSheet extends ConsumerStatefulWidget {
-  final CollectionItemRef itemRef;
+  final CollectionItemRef? itemRef;
+  final Set<String> initialSelected;
 
-  const AddToCollectionSheet({super.key, required this.itemRef});
+  const AddToCollectionSheet({
+    super.key,
+    this.itemRef,
+    this.initialSelected = const {},
+  });
 
+  /// Binding mode — writes membership for [ref] when the user saves.
   static Future<void> show(BuildContext context, CollectionItemRef ref) {
     return showModalBottomSheet<void>(
       context: context,
@@ -24,6 +38,23 @@ class AddToCollectionSheet extends ConsumerStatefulWidget {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (_) => AddToCollectionSheet(itemRef: ref),
+    );
+  }
+
+  /// Picker mode — returns the selected collection UUIDs, or null if the
+  /// user dismissed the sheet without saving.
+  static Future<Set<String>?> pick(
+    BuildContext context, {
+    Set<String> initialSelected = const {},
+  }) {
+    return showModalBottomSheet<Set<String>>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => AddToCollectionSheet(initialSelected: initialSelected),
     );
   }
 
@@ -39,7 +70,10 @@ class _AddToCollectionSheetState extends ConsumerState<AddToCollectionSheet> {
 
   void _initSelection(CollectionRepositoryState state) {
     if (_initialized) return;
-    _selected = state.collectionsFor(widget.itemRef).toSet();
+    final itemRef = widget.itemRef;
+    _selected = itemRef != null
+        ? state.collectionsFor(itemRef).toSet()
+        : widget.initialSelected.toSet();
     _initialized = true;
   }
 
@@ -52,11 +86,16 @@ class _AddToCollectionSheetState extends ConsumerState<AddToCollectionSheet> {
 
   Future<void> _save() async {
     final l10n = context.l10n;
+    final itemRef = widget.itemRef;
+    if (itemRef == null) {
+      Navigator.of(context).pop(_selected);
+      return;
+    }
     setState(() => _saving = true);
     try {
       await ref
           .read(collectionRepositoryProvider.notifier)
-          .setMembership(widget.itemRef, _selected);
+          .setMembership(itemRef, _selected);
       if (!mounted) return;
       Navigator.of(context).pop();
     } catch (e) {
@@ -139,12 +178,12 @@ class _AddToCollectionSheetState extends ConsumerState<AddToCollectionSheet> {
                     itemCount: collections.length,
                     itemBuilder: (context, i) {
                       final c = collections[i];
-                      return _CollectionCheckRow(
+                      return _CollectionSwitchRow(
                         collection: c,
                         selected: _selected.contains(c.uuid),
                         onChanged: (v) {
                           setState(() {
-                            if (v == true) {
+                            if (v) {
                               _selected.add(c.uuid);
                             } else {
                               _selected.remove(c.uuid);
@@ -168,12 +207,12 @@ class _AddToCollectionSheetState extends ConsumerState<AddToCollectionSheet> {
   }
 }
 
-class _CollectionCheckRow extends StatelessWidget {
+class _CollectionSwitchRow extends StatelessWidget {
   final Collection collection;
   final bool selected;
-  final ValueChanged<bool?> onChanged;
+  final ValueChanged<bool> onChanged;
 
-  const _CollectionCheckRow({
+  const _CollectionSwitchRow({
     required this.collection,
     required this.selected,
     required this.onChanged,
@@ -188,7 +227,7 @@ class _CollectionCheckRow extends StatelessWidget {
         ? iconService.getIcon(context, collection.iconKey)
         : null;
 
-    return CheckboxListTile(
+    return SwitchListTile(
       contentPadding: EdgeInsets.zero,
       value: selected,
       onChanged: onChanged,

--- a/lib/features/collections/widgets/collection_detail_page.dart
+++ b/lib/features/collections/widgets/collection_detail_page.dart
@@ -1,0 +1,371 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+
+import '../data/collection_repository.dart';
+import '../data/collection_visibility_provider.dart';
+import '../models/collection.dart';
+import '../models/collection_item_ref.dart';
+import 'collections_page.dart' show confirmDeleteCollection;
+import 'create_or_edit_collection_sheet.dart';
+
+class CollectionDetailPage extends ConsumerWidget {
+  final String collectionUuid;
+
+  const CollectionDetailPage({super.key, required this.collectionUuid});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final asyncState = ref.watch(collectionRepositoryProvider);
+
+    return asyncState.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => Scaffold(
+        appBar: AppBar(),
+        body: Center(child: Text('$e')),
+      ),
+      data: (state) {
+        Collection? collection;
+        for (final c in state.collections) {
+          if (c.uuid == collectionUuid) {
+            collection = c;
+            break;
+          }
+        }
+        if (collection == null) {
+          // Collection was deleted while we were viewing it.
+          return Scaffold(
+            appBar: AppBar(title: Text(l10n.collection)),
+            body: Center(child: Text(l10n.collectionDeleted)),
+          );
+        }
+        return _Loaded(collection: collection, repoState: state);
+      },
+    );
+  }
+}
+
+class _Loaded extends ConsumerStatefulWidget {
+  final Collection collection;
+  final CollectionRepositoryState repoState;
+
+  const _Loaded({required this.collection, required this.repoState});
+
+  @override
+  ConsumerState<_Loaded> createState() => _LoadedState();
+}
+
+class _LoadedState extends ConsumerState<_Loaded> {
+  List<CollectionItemRef> _refs = const [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadItems();
+  }
+
+  @override
+  void didUpdateWidget(covariant _Loaded oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.collection.uuid != widget.collection.uuid ||
+        oldWidget.repoState != widget.repoState) {
+      _loadItems();
+    }
+  }
+
+  Future<void> _loadItems() async {
+    setState(() => _loading = true);
+    final store = await ref.read(localCollectionDataStoreProvider.future);
+    final items = await store.getItems(widget.collection.uuid);
+    if (!mounted) return;
+    setState(() {
+      _refs = items;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = hexToColor(widget.collection.colorHex) ?? colorScheme.primary;
+    final iconService = IconService();
+    final namedIcon = widget.collection.iconKey != null
+        ? iconService.getIcon(context, widget.collection.iconKey)
+        : null;
+    final visibility = ref.watch(collectionVisibilityProvider);
+    final isVisible = visibility[widget.collection.uuid] ?? true;
+
+    final markerRefs =
+        _refs.where((r) => r.type == CollectionItemRef.typeMarker).toList();
+    final pathRefs =
+        _refs.where((r) => r.type == CollectionItemRef.typePath).toList();
+
+    final markers = ref.watch(locationRepositoryProvider).asData?.value ?? const [];
+    final paths = ref.watch(savedPathRepositoryProvider).asData?.value ?? const [];
+    final markerByUuid = {for (final m in markers) m.uuid: m};
+    final pathByUuid = {for (final p in paths) p.uuid: p};
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.collection.name),
+        actions: [
+          IconButton(
+            tooltip: isVisible ? l10n.visibleOnMap : l10n.hiddenOnMap,
+            icon: Icon(isVisible
+                ? Icons.visibility_outlined
+                : Icons.visibility_off_outlined),
+            onPressed: () => ref
+                .read(collectionVisibilityProvider.notifier)
+                .toggle(widget.collection.uuid),
+          ),
+          IconButton(
+            tooltip: l10n.edit,
+            icon: const Icon(Icons.edit_outlined),
+            onPressed: () => CreateOrEditCollectionSheet.show(
+              context,
+              existing: widget.collection,
+            ),
+          ),
+          IconButton(
+            tooltip: l10n.delete,
+            icon: const Icon(Icons.delete_outline),
+            onPressed: () async {
+              await confirmDeleteCollection(context, ref, widget.collection);
+              if (!context.mounted) return;
+              if (ref.read(collectionRepositoryProvider).asData?.value
+                      .collections
+                      .any((c) => c.uuid == widget.collection.uuid) ==
+                  false) {
+                Navigator.of(context).pop();
+              }
+            },
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadItems,
+              child: CustomScrollView(
+                slivers: [
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    sliver: SliverToBoxAdapter(
+                      child: Row(
+                        children: [
+                          CircleAvatar(
+                            backgroundColor: color.withAlpha(40),
+                            radius: 28,
+                            child: Icon(
+                              namedIcon?.icon ?? Icons.folder_outlined,
+                              color: color,
+                              size: 28,
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                if (widget.collection.description != null &&
+                                    widget.collection.description!.isNotEmpty)
+                                  Text(
+                                    widget.collection.description!,
+                                    style: Theme.of(context).textTheme.bodyMedium,
+                                  ),
+                                Text(
+                                  l10n.memberCount(_refs.length),
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodySmall
+                                      ?.copyWith(
+                                        color: colorScheme.onSurfaceVariant,
+                                      ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  if (_refs.isEmpty)
+                    SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(32),
+                          child: Text(
+                            l10n.noMembersInCollection,
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                          ),
+                        ),
+                      ),
+                    )
+                  else ...[
+                    if (markerRefs.isNotEmpty) ...[
+                      SliverPadding(
+                        padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+                        sliver: SliverToBoxAdapter(
+                          child: Text(
+                            l10n.markersSection,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ),
+                      ),
+                      SliverList.builder(
+                        itemCount: markerRefs.length,
+                        itemBuilder: (context, i) {
+                          final ref = markerRefs[i];
+                          final marker = markerByUuid[ref.uuid];
+                          if (marker == null) {
+                            return ListTile(
+                              leading: const Icon(Icons.help_outline),
+                              title: Text(ref.uuid),
+                            );
+                          }
+                          return _MarkerRow(
+                            marker: marker,
+                            onChanged: _loadItems,
+                          );
+                        },
+                      ),
+                    ],
+                    if (pathRefs.isNotEmpty) ...[
+                      SliverPadding(
+                        padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+                        sliver: SliverToBoxAdapter(
+                          child: Text(
+                            l10n.pathsSection,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ),
+                      ),
+                      SliverList.builder(
+                        itemCount: pathRefs.length,
+                        itemBuilder: (context, i) {
+                          final ref = pathRefs[i];
+                          final path = pathByUuid[ref.uuid];
+                          if (path == null) {
+                            return ListTile(
+                              leading: const Icon(Icons.help_outline),
+                              title: Text(ref.uuid),
+                            );
+                          }
+                          return _PathRow(path: path, onChanged: _loadItems);
+                        },
+                      ),
+                    ],
+                    const SliverPadding(
+                      padding: EdgeInsets.only(bottom: 32),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+    );
+  }
+}
+
+class _MarkerRow extends ConsumerWidget {
+  final Marker marker;
+  final VoidCallback onChanged;
+
+  const _MarkerRow({required this.marker, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final iconService = IconService();
+    final namedIcon = iconService.getIcon(context, marker.icon);
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: colorScheme.primaryContainer,
+        child: Icon(namedIcon.icon, color: colorScheme.onPrimaryContainer),
+      ),
+      title: Text(marker.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: marker.description != null && marker.description!.isNotEmpty
+          ? Text(marker.description!, maxLines: 1, overflow: TextOverflow.ellipsis)
+          : null,
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () async {
+        final result = await showModalBottomSheet<MarkerInfoResult>(
+          context: context,
+          isScrollControlled: true,
+          useSafeArea: true,
+          builder: (_) => MarkerInfoSheet(marker: marker),
+        );
+        if (!context.mounted) return;
+        if (result == MarkerInfoResult.deleted) {
+          AppSnackbars.success(context, l10n.markerDeleted);
+          onChanged();
+        } else if (result == MarkerInfoResult.updated) {
+          AppSnackbars.success(context, l10n.markerUpdated);
+          onChanged();
+        }
+      },
+    );
+  }
+}
+
+class _PathRow extends ConsumerWidget {
+  final SavedPath path;
+  final VoidCallback onChanged;
+
+  const _PathRow({required this.path, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final pathColor = hexToColor(path.colorHex) ?? colorScheme.onSurfaceVariant;
+    final iconService = IconService();
+    final namedIcon = path.iconKey != null
+        ? iconService.getIcon(context, path.iconKey)
+        : null;
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: pathColor.withAlpha(40),
+        child: Icon(namedIcon?.icon ?? Icons.route, color: pathColor),
+      ),
+      title: Text(path.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        '${(path.distance / 1000).toStringAsFixed(2)} km',
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () async {
+        final result = await showModalBottomSheet<PathDetailResult>(
+          context: context,
+          isScrollControlled: true,
+          useSafeArea: true,
+          builder: (_) => PathInfoSheet(path: path),
+        );
+        if (!context.mounted) return;
+        if (result == PathDetailResult.deleted) {
+          AppSnackbars.success(context, l10n.pathDeleted);
+          onChanged();
+        } else if (result == PathDetailResult.updated) {
+          AppSnackbars.success(context, l10n.pathUpdated);
+          onChanged();
+        }
+      },
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_picker_row.dart
+++ b/lib/features/collections/widgets/collection_picker_row.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/saved_paths/api.dart' show hexToColor;
+
+import '../data/collection_repository.dart';
+import 'add_to_collection_sheet.dart';
+
+/// Tappable row showing the collections an as-yet-uncreated item will be
+/// added to. Shows a single "+ Add to collection" chip when empty, otherwise
+/// the selected collections as chips followed by an inline `+` button.
+///
+/// Used by `CreateLocationSheet` and `SavePathSheet` to attach the new
+/// marker / path to one or more collections at the moment it is saved.
+class CollectionPickerRow extends ConsumerWidget {
+  final Set<String> selectedUuids;
+  final ValueChanged<Set<String>> onChanged;
+
+  const CollectionPickerRow({
+    super.key,
+    required this.selectedUuids,
+    required this.onChanged,
+  });
+
+  Future<void> _open(BuildContext context) async {
+    final picked = await AddToCollectionSheet.pick(
+      context,
+      initialSelected: selectedUuids,
+    );
+    if (picked != null) onChanged(picked);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final asyncState = ref.watch(collectionRepositoryProvider);
+
+    return asyncState.maybeWhen(
+      data: (state) {
+        final byUuid = {for (final c in state.collections) c.uuid: c};
+        final present = selectedUuids.where(byUuid.containsKey).toList();
+
+        return SizedBox(
+          height: 36,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                if (present.isEmpty)
+                  ActionChip(
+                    avatar: Icon(
+                      Icons.folder_outlined,
+                      size: 16,
+                      color: colorScheme.primary,
+                    ),
+                    label: Text(l10n.addToCollection),
+                    onPressed: () => _open(context),
+                    visualDensity: VisualDensity.compact,
+                  )
+                else ...[
+                  for (final id in present)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 6),
+                      child: ActionChip(
+                        avatar: Icon(
+                          Icons.folder_outlined,
+                          size: 16,
+                          color: hexToColor(byUuid[id]!.colorHex) ??
+                              colorScheme.primary,
+                        ),
+                        label: Text(byUuid[id]!.name),
+                        onPressed: () => _open(context),
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ),
+                  IconButton(
+                    tooltip: l10n.addToCollection,
+                    iconSize: 20,
+                    visualDensity: VisualDensity.compact,
+                    icon: const Icon(Icons.add_circle_outline),
+                    onPressed: () => _open(context),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_picker_row.dart
+++ b/lib/features/collections/widgets/collection_picker_row.dart
@@ -6,12 +6,13 @@ import 'package:turbo/features/saved_paths/api.dart' show hexToColor;
 import '../data/collection_repository.dart';
 import 'add_to_collection_sheet.dart';
 
-/// Tappable row showing the collections an as-yet-uncreated item will be
-/// added to. Shows a single "+ Add to collection" chip when empty, otherwise
-/// the selected collections as chips followed by an inline `+` button.
+/// Tappable surface row letting the user attach the marker / path being
+/// created to one or more collections. Matches the surface-card pattern used
+/// by `PathCustomizationControls` so it sits naturally next to the Icon row.
 ///
-/// Used by `CreateLocationSheet` and `SavePathSheet` to attach the new
-/// marker / path to one or more collections at the moment it is saved.
+/// Empty state shows the leading folder avatar with an "Add to collection"
+/// label and a chevron. With selections it shows the picked collections as
+/// chips inside the same surface, still tap-to-edit.
 class CollectionPickerRow extends ConsumerWidget {
   final Set<String> selectedUuids;
   final ValueChanged<Set<String>> onChanged;
@@ -34,55 +35,77 @@ class CollectionPickerRow extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final asyncState = ref.watch(collectionRepositoryProvider);
 
     return asyncState.maybeWhen(
       data: (state) {
         final byUuid = {for (final c in state.collections) c.uuid: c};
         final present = selectedUuids.where(byUuid.containsKey).toList();
+        final hasSelection = present.isNotEmpty;
 
-        return SizedBox(
-          height: 36,
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                if (present.isEmpty)
-                  ActionChip(
-                    avatar: Icon(
+        return Material(
+          color: colorScheme.surfaceContainer,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => _open(context),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: hasSelection
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
                       Icons.folder_outlined,
-                      size: 16,
-                      color: colorScheme.primary,
+                      color: hasSelection
+                          ? colorScheme.onPrimaryContainer
+                          : colorScheme.onSurfaceVariant,
+                      size: 24,
                     ),
-                    label: Text(l10n.addToCollection),
-                    onPressed: () => _open(context),
-                    visualDensity: VisualDensity.compact,
-                  )
-                else ...[
-                  for (final id in present)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 6),
-                      child: ActionChip(
-                        avatar: Icon(
-                          Icons.folder_outlined,
-                          size: 16,
-                          color: hexToColor(byUuid[id]!.colorHex) ??
-                              colorScheme.primary,
-                        ),
-                        label: Text(byUuid[id]!.name),
-                        onPressed: () => _open(context),
-                        visualDensity: VisualDensity.compact,
-                      ),
-                    ),
-                  IconButton(
-                    tooltip: l10n.addToCollection,
-                    iconSize: 20,
-                    visualDensity: VisualDensity.compact,
-                    icon: const Icon(Icons.add_circle_outline),
-                    onPressed: () => _open(context),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: hasSelection
+                        ? Wrap(
+                            spacing: 6,
+                            runSpacing: 4,
+                            children: [
+                              for (final id in present)
+                                Chip(
+                                  avatar: Icon(
+                                    Icons.folder_outlined,
+                                    size: 14,
+                                    color: hexToColor(byUuid[id]!.colorHex) ??
+                                        colorScheme.primary,
+                                  ),
+                                  label: Text(byUuid[id]!.name),
+                                  visualDensity: VisualDensity.compact,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                            ],
+                          )
+                        : Text(
+                            l10n.addToCollection,
+                            style: textTheme.bodyLarge?.copyWith(
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                  ),
+                  Icon(
+                    Icons.chevron_right,
+                    color: colorScheme.onSurfaceVariant,
                   ),
                 ],
-              ],
+              ),
             ),
           ),
         );

--- a/lib/features/collections/widgets/collection_picker_row.dart
+++ b/lib/features/collections/widgets/collection_picker_row.dart
@@ -87,6 +87,12 @@ class CollectionPickerRow extends ConsumerWidget {
                                         colorScheme.primary,
                                   ),
                                   label: Text(byUuid[id]!.name),
+                                  shape: const StadiumBorder(),
+                                  side: BorderSide(color: colorScheme.outlineVariant),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
                                   visualDensity: VisualDensity.compact,
                                   materialTapTargetSize:
                                       MaterialTapTargetSize.shrinkWrap,

--- a/lib/features/collections/widgets/collections_page.dart
+++ b/lib/features/collections/widgets/collections_page.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart' show hexToColor;
+
+import '../data/collection_repository.dart';
+import '../data/collection_visibility_provider.dart';
+import '../models/collection.dart';
+import 'collection_detail_page.dart';
+import 'create_or_edit_collection_sheet.dart';
+
+class CollectionsPage extends ConsumerWidget {
+  const CollectionsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final asyncState = ref.watch(collectionRepositoryProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.collections)),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => CreateOrEditCollectionSheet.show(context),
+        icon: const Icon(Icons.add),
+        label: Text(l10n.newCollection),
+      ),
+      body: asyncState.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (state) {
+          if (state.collections.isEmpty) {
+            return _EmptyState();
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(8, 8, 8, 96),
+            itemCount: state.collections.length,
+            separatorBuilder: (_, _) => const SizedBox(height: 4),
+            itemBuilder: (context, i) {
+              final c = state.collections[i];
+              return _CollectionRow(
+                collection: c,
+                memberCount: state.memberCountFor(c.uuid),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.folder_open_outlined,
+            size: 64,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            l10n.noCollectionsYet,
+            style: textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.noCollectionsHint,
+            style: textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CollectionRow extends ConsumerWidget {
+  final Collection collection;
+  final int memberCount;
+
+  const _CollectionRow({required this.collection, required this.memberCount});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = hexToColor(collection.colorHex) ?? colorScheme.primary;
+    final iconService = IconService();
+    final namedIcon = collection.iconKey != null
+        ? iconService.getIcon(context, collection.iconKey)
+        : null;
+    final visibility = ref.watch(collectionVisibilityProvider);
+    final isVisible = visibility[collection.uuid] ?? true;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: color.withAlpha(40),
+          child: Icon(
+            namedIcon?.icon ?? Icons.folder_outlined,
+            color: color,
+          ),
+        ),
+        title: Text(collection.name),
+        subtitle: Text(l10n.memberCount(memberCount)),
+        trailing: IconButton(
+          tooltip: isVisible ? l10n.visibleOnMap : l10n.hiddenOnMap,
+          icon: Icon(
+            isVisible ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+            color: isVisible
+                ? colorScheme.onSurface
+                : colorScheme.onSurfaceVariant,
+          ),
+          onPressed: () => ref
+              .read(collectionVisibilityProvider.notifier)
+              .toggle(collection.uuid),
+        ),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => CollectionDetailPage(collectionUuid: collection.uuid),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Helper for showing a delete confirmation from any consumer.
+Future<void> confirmDeleteCollection(
+  BuildContext context,
+  WidgetRef ref,
+  Collection collection,
+) async {
+  final l10n = context.l10n;
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog.adaptive(
+      title: Text(l10n.confirmDeleteCollectionTitle),
+      content: Text(l10n.confirmDeleteCollectionMessage),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: Text(l10n.cancel),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+          ),
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: Text(l10n.delete),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+  try {
+    await ref
+        .read(collectionRepositoryProvider.notifier)
+        .deleteCollection(collection.uuid);
+    if (context.mounted) {
+      AppSnackbars.success(context, l10n.collectionDeleted);
+    }
+  } catch (e) {
+    if (context.mounted) {
+      AppSnackbars.error(
+        context,
+        l10n.errorDeletingCollection(e.toString()),
+      );
+    }
+  }
+}

--- a/lib/features/collections/widgets/create_or_edit_collection_sheet.dart
+++ b/lib/features/collections/widgets/create_or_edit_collection_sheet.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/core/widgets/color_circle.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart' show colorToHex, hexToColor, pathColorPalette;
+
+import '../data/collection_repository.dart';
+import '../models/collection.dart';
+
+class CreateOrEditCollectionSheet extends ConsumerStatefulWidget {
+  final Collection? existing;
+
+  const CreateOrEditCollectionSheet({super.key, this.existing});
+
+  static Future<Collection?> show(
+    BuildContext context, {
+    Collection? existing,
+  }) {
+    return showModalBottomSheet<Collection>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => CreateOrEditCollectionSheet(existing: existing),
+    );
+  }
+
+  @override
+  ConsumerState<CreateOrEditCollectionSheet> createState() =>
+      _CreateOrEditCollectionSheetState();
+}
+
+class _CreateOrEditCollectionSheetState
+    extends ConsumerState<CreateOrEditCollectionSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _descController;
+  String? _colorHex;
+  String? _iconKey;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final existing = widget.existing;
+    _nameController = TextEditingController(text: existing?.name ?? '');
+    _descController = TextEditingController(text: existing?.description ?? '');
+    _colorHex = existing?.colorHex;
+    _iconKey = existing?.iconKey;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    final l10n = context.l10n;
+    setState(() => _saving = true);
+    try {
+      final repo = ref.read(collectionRepositoryProvider.notifier);
+      final existing = widget.existing;
+      Collection saved;
+      if (existing == null) {
+        saved = Collection(
+          name: _nameController.text.trim(),
+          description: _descController.text.trim().isEmpty
+              ? null
+              : _descController.text.trim(),
+          colorHex: _colorHex,
+          iconKey: _iconKey,
+        );
+        await repo.create(saved);
+      } else {
+        saved = existing.copyWith(
+          name: _nameController.text.trim(),
+          description: _descController.text.trim().isEmpty
+              ? null
+              : _descController.text.trim(),
+          clearDescription: _descController.text.trim().isEmpty,
+          colorHex: _colorHex,
+          clearColorHex: _colorHex == null,
+          iconKey: _iconKey,
+          clearIconKey: _iconKey == null,
+        );
+        await repo.updateCollection(saved);
+      }
+      if (!mounted) return;
+      Navigator.of(context).pop(saved);
+    } catch (error) {
+      if (!mounted) return;
+      AppSnackbars.error(
+        context,
+        l10n.errorSavingCollection(error.toString()),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    final mediaQuery = MediaQuery.of(context);
+    final bottomPadding = mediaQuery.viewInsets.bottom > 0
+        ? mediaQuery.viewInsets.bottom
+        : mediaQuery.padding.bottom;
+    final isEdit = widget.existing != null;
+    final selectedColor = hexToColor(_colorHex);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+      child: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      isEdit ? l10n.editCollection : l10n.newCollection,
+                      style: textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  labelText: l10n.collectionName,
+                  border: const OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return l10n.pleaseEnterName;
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _descController,
+                decoration: InputDecoration(
+                  labelText: l10n.descriptionOptional,
+                  border: const OutlineInputBorder(),
+                ),
+                maxLines: 2,
+              ),
+              const SizedBox(height: 16),
+              Text(l10n.color, style: textTheme.titleSmall),
+              const SizedBox(height: 8),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    ColorCircle(
+                      color: null,
+                      isSelected: selectedColor == null,
+                      onTap: () => setState(() => _colorHex = null),
+                      label: l10n.defaultColor,
+                      colorScheme: colorScheme,
+                    ),
+                    ...pathColorPalette.map((c) => ColorCircle(
+                          color: c,
+                          isSelected: selectedColor != null &&
+                              colorToHex(selectedColor) == colorToHex(c),
+                          onTap: () =>
+                              setState(() => _colorHex = colorToHex(c)),
+                          colorScheme: colorScheme,
+                        )),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _IconPickerRow(
+                iconKey: _iconKey,
+                onChanged: (key) => setState(() => _iconKey = key),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _saving ? null : _save,
+                child: Text(isEdit ? l10n.saveChanges : l10n.save),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IconPickerRow extends StatelessWidget {
+  final String? iconKey;
+  final ValueChanged<String?> onChanged;
+
+  const _IconPickerRow({required this.iconKey, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final iconService = IconService();
+    final hasIcon = iconKey != null;
+    final namedIcon = hasIcon ? iconService.getIcon(context, iconKey) : null;
+
+    return Material(
+      color: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () async {
+          final result = await IconSelectionPage.show(context);
+          FocusManager.instance.primaryFocus?.unfocus();
+          if (result != null) {
+            onChanged(result.title);
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: hasIcon
+                      ? colorScheme.primaryContainer
+                      : colorScheme.surfaceContainerHighest,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  hasIcon ? namedIcon!.icon : Icons.add,
+                  color: hasIcon
+                      ? colorScheme.onPrimaryContainer
+                      : colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(
+                  hasIcon
+                      ? (namedIcon!.localizedTitle ?? namedIcon.title)
+                      : l10n.icon,
+                  style: textTheme.bodyLarge,
+                ),
+              ),
+              if (hasIcon)
+                IconButton(
+                  icon: const Icon(Icons.clear),
+                  tooltip: l10n.removeIcon,
+                  onPressed: () => onChanged(null),
+                )
+              else
+                Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/map_view/widgets/layers/viewport_marker_layer.dart
+++ b/lib/features/map_view/widgets/layers/viewport_marker_layer.dart
@@ -5,6 +5,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:turbo/app/shadows.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/markers/api.dart' as marker_model;
 import 'package:turbo/features/markers/api.dart' hide Marker;
 import 'package:turbo/features/saved_paths/api.dart';
@@ -79,9 +80,28 @@ class _ViewportMarkersState extends ConsumerState<ViewportMarkers> {
 
     final viewportMarkersAsync = ref.watch(viewportMarkerNotifierProvider);
     final iconService = IconService();
+    final collectionState =
+        ref.watch(collectionRepositoryProvider).asData?.value ??
+            const CollectionRepositoryState.empty();
+    final visibility = ref.watch(collectionVisibilityProvider);
+
+    List<marker_model.Marker> applyFilter(List<marker_model.Marker> input) {
+      if (collectionState.membershipIndex.isEmpty) return input;
+      return input
+          .where((m) => isItemVisibleForCollections(
+                ref: CollectionItemRef(
+                  type: CollectionItemRef.typeMarker,
+                  uuid: m.uuid,
+                ),
+                collectionState: collectionState,
+                visibility: visibility,
+              ))
+          .toList();
+    }
 
     return viewportMarkersAsync.when(
-      data: (locations) {
+      data: (raw) {
+        final locations = applyFilter(raw);
         return MarkerLayer(
           markers: locations.map((location) {
             final namedIcon = iconService.getIcon(context ,location.icon);
@@ -110,8 +130,9 @@ class _ViewportMarkersState extends ConsumerState<ViewportMarkers> {
         final previousData =
             ref.read(viewportMarkerNotifierProvider).asData?.value;
         if (previousData != null && previousData.isNotEmpty) {
+          final filteredPrev = applyFilter(previousData);
           return MarkerLayer(
-            markers: previousData.map((location) {
+            markers: filteredPrev.map((location) {
               final namedIcon = iconService.getIcon(context, location.icon);
               const double markerScale = 1.0;
               const double markerHeight = MapMarkerWidget.baseHeight * markerScale;

--- a/lib/features/markers/api.dart
+++ b/lib/features/markers/api.dart
@@ -9,6 +9,7 @@ export 'widgets/create_location_sheet.dart' show CreateLocationSheet;
 export 'widgets/edit_location_sheet.dart' show EditLocationSheet;
 export 'widgets/icon_selection_page.dart' show IconSelectionPage;
 export 'widgets/marker_info_sheet.dart' show MarkerInfoSheet, MarkerInfoResult;
+export 'widgets/markers_list_page.dart' show MarkersListPage;
 export 'widgets/marker_export_options_sheet.dart' show MarkerExportOptionsSheet;
 export 'data/marker_export_service.dart' show MarkerExportService;
 export 'data/marker_geojson_serializer.dart' show markerToGeoJson;

--- a/lib/features/markers/widgets/create_location_sheet.dart
+++ b/lib/features/markers/widgets/create_location_sheet.dart
@@ -4,6 +4,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:turbo/core/widgets/app_button.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/collections/api.dart';
 import '../models/named_icon.dart';
 import '../models/marker.dart';
 import '../data/location_repository.dart';
@@ -24,6 +25,7 @@ class CreateLocationSheetState extends ConsumerState<CreateLocationSheet> {
   NamedIcon? _selectedIcon;
   late TextEditingController _nameController;
   late TextEditingController _descriptionController;
+  Set<String> _selectedCollectionUuids = {};
   bool _isLoading = false;
 
   @override
@@ -72,11 +74,23 @@ class CreateLocationSheetState extends ConsumerState<CreateLocationSheet> {
               child: SingleChildScrollView(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 24),
-                  child: LocationFormFields(
-                    nameController: _nameController,
-                    descriptionController: _descriptionController,
-                    selectedIcon: _selectedIcon,
-                    onIconSelected: (icon) => setState(() => _selectedIcon = icon),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      LocationFormFields(
+                        nameController: _nameController,
+                        descriptionController: _descriptionController,
+                        selectedIcon: _selectedIcon,
+                        onIconSelected: (icon) =>
+                            setState(() => _selectedIcon = icon),
+                      ),
+                      const SizedBox(height: 16),
+                      CollectionPickerRow(
+                        selectedUuids: _selectedCollectionUuids,
+                        onChanged: (next) =>
+                            setState(() => _selectedCollectionUuids = next),
+                      ),
+                    ],
                   ),
                 ),
               ),
@@ -111,6 +125,18 @@ class CreateLocationSheetState extends ConsumerState<CreateLocationSheet> {
         );
 
         await locationNotifier.addMarker(newMarker);
+
+        if (_selectedCollectionUuids.isNotEmpty) {
+          await ref
+              .read(collectionRepositoryProvider.notifier)
+              .setMembership(
+                CollectionItemRef(
+                  type: CollectionItemRef.typeMarker,
+                  uuid: newMarker.uuid,
+                ),
+                _selectedCollectionUuids,
+              );
+        }
 
         if (!mounted) return;
         Navigator.of(context).pop(newMarker);

--- a/lib/features/markers/widgets/marker_info_sheet.dart
+++ b/lib/features/markers/widgets/marker_info_sheet.dart
@@ -284,6 +284,8 @@ class _CollectionChipStrip extends ConsumerWidget {
                     ),
                     label: Text(l10n.addToCollection),
                     onPressed: onTap,
+                    shape: const StadiumBorder(),
+                    side: BorderSide(color: colorScheme.outlineVariant),
                     visualDensity: VisualDensity.compact,
                   )
                 else ...[
@@ -300,6 +302,8 @@ class _CollectionChipStrip extends ConsumerWidget {
                           ),
                           label: Text(byUuid[id]!.name),
                           onPressed: onTap,
+                          shape: const StadiumBorder(),
+                          side: BorderSide(color: colorScheme.outlineVariant),
                           visualDensity: VisualDensity.compact,
                         ),
                       ),

--- a/lib/features/markers/widgets/marker_info_sheet.dart
+++ b/lib/features/markers/widgets/marker_info_sheet.dart
@@ -4,6 +4,8 @@ import 'package:turbo/core/widgets/action_button.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/collections/api.dart';
+import 'package:turbo/features/saved_paths/api.dart' show hexToColor;
 import '../data/icon_service.dart';
 import '../data/location_repository.dart';
 import '../models/marker.dart';
@@ -106,7 +108,14 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
             ),
           ],
 
-          const SizedBox(height: 24),
+          const SizedBox(height: 12),
+          _CollectionChipStrip(
+            itemRef: CollectionItemRef(
+              type: CollectionItemRef.typeMarker,
+              uuid: _marker.uuid,
+            ),
+          ),
+          const SizedBox(height: 16),
 
           // Actions row
           Row(
@@ -116,6 +125,11 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
                 icon: Icons.edit_outlined,
                 label: l10n.edit,
                 onTap: _openEdit,
+              ),
+              ActionButton(
+                icon: Icons.folder_outlined,
+                label: l10n.addToCollection,
+                onTap: _openAddToCollection,
               ),
               ActionButton(
                 icon: Icons.ios_share_outlined,
@@ -130,6 +144,16 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _openAddToCollection() async {
+    await AddToCollectionSheet.show(
+      context,
+      CollectionItemRef(
+        type: CollectionItemRef.typeMarker,
+        uuid: _marker.uuid,
       ),
     );
   }
@@ -178,6 +202,12 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
       await ref
           .read(locationRepositoryProvider.notifier)
           .deleteMarker(_marker.uuid);
+      await ref
+          .read(collectionRepositoryProvider.notifier)
+          .handleItemDeleted(CollectionItemRef(
+            type: CollectionItemRef.typeMarker,
+            uuid: _marker.uuid,
+          ));
       if (mounted) {
         Navigator.of(context).pop(MarkerInfoResult.deleted);
       }
@@ -190,6 +220,48 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
         setState(() => _isDeleting = false);
       }
     }
+  }
+}
+
+class _CollectionChipStrip extends ConsumerWidget {
+  final CollectionItemRef itemRef;
+
+  const _CollectionChipStrip({required this.itemRef});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncState = ref.watch(collectionRepositoryProvider);
+    return asyncState.maybeWhen(
+      data: (state) {
+        final uuids = state.collectionsFor(itemRef);
+        if (uuids.isEmpty) return const SizedBox.shrink();
+        final byUuid = {for (final c in state.collections) c.uuid: c};
+        final colorScheme = Theme.of(context).colorScheme;
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final id in uuids)
+                if (byUuid[id] != null)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: Chip(
+                      avatar: Icon(
+                        Icons.folder_outlined,
+                        size: 16,
+                        color: hexToColor(byUuid[id]!.colorHex) ??
+                            colorScheme.primary,
+                      ),
+                      label: Text(byUuid[id]!.name),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+            ],
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
+    );
   }
 }
 

--- a/lib/features/markers/widgets/markers_list_page.dart
+++ b/lib/features/markers/widgets/markers_list_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+
+import '../data/icon_service.dart';
+import '../data/location_repository.dart';
+import '../models/marker.dart';
+import 'marker_info_sheet.dart';
+
+class MarkersListPage extends ConsumerWidget {
+  const MarkersListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final asyncMarkers = ref.watch(locationRepositoryProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+    final iconService = IconService();
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.allMarkers)),
+      body: asyncMarkers.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (markers) {
+          if (markers.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  l10n.noResultsFound,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ),
+            );
+          }
+          final sorted = [...markers]
+            ..sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+          return ListView.separated(
+            itemCount: sorted.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final m = sorted[i];
+              final namedIcon = iconService.getIcon(context, m.icon);
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: colorScheme.primaryContainer,
+                  child: Icon(
+                    namedIcon.icon,
+                    color: colorScheme.onPrimaryContainer,
+                  ),
+                ),
+                title: Text(m.title),
+                subtitle: Text(
+                  '${m.position.latitude.toStringAsFixed(4)}, '
+                  '${m.position.longitude.toStringAsFixed(4)}',
+                ),
+                onTap: () => _openInfo(context, m),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openInfo(BuildContext context, Marker marker) async {
+    final l10n = context.l10n;
+    final result = await showModalBottomSheet<MarkerInfoResult>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => MarkerInfoSheet(marker: marker),
+    );
+    if (!context.mounted) return;
+    if (result == MarkerInfoResult.deleted) {
+      AppSnackbars.success(context, l10n.markerDeleted);
+    } else if (result == MarkerInfoResult.updated) {
+      AppSnackbars.success(context, l10n.markerUpdated);
+    }
+  }
+}

--- a/lib/features/saved_paths/api.dart
+++ b/lib/features/saved_paths/api.dart
@@ -15,3 +15,4 @@ export 'data/geojson_serializer.dart' show savedPathToGeoJson;
 export 'data/path_export_service.dart' show PathExportService, ExportFormat;
 export 'widgets/export_options_sheet.dart' show ExportOptionsSheet;
 export 'widgets/path_info_sheet.dart' show PathInfoSheet;
+export 'widgets/paths_list_page.dart' show PathsListPage;

--- a/lib/features/saved_paths/widgets/path_info_sheet.dart
+++ b/lib/features/saved_paths/widgets/path_info_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:turbo/core/widgets/action_button.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/markers/api.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 import '../data/saved_path_repository.dart';
@@ -125,7 +126,14 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
             ),
           ],
 
-          const SizedBox(height: 24),
+          const SizedBox(height: 12),
+          _PathCollectionChipStrip(
+            itemRef: CollectionItemRef(
+              type: CollectionItemRef.typePath,
+              uuid: _path.uuid,
+            ),
+          ),
+          const SizedBox(height: 16),
 
           // Actions row
           Row(
@@ -135,6 +143,11 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
                 icon: Icons.edit_outlined,
                 label: l10n.edit,
                 onTap: _openEdit,
+              ),
+              ActionButton(
+                icon: Icons.folder_outlined,
+                label: l10n.addToCollection,
+                onTap: _openAddToCollection,
               ),
               ActionButton(
                 icon: Icons.ios_share_outlined,
@@ -149,6 +162,16 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _openAddToCollection() async {
+    await AddToCollectionSheet.show(
+      context,
+      CollectionItemRef(
+        type: CollectionItemRef.typePath,
+        uuid: _path.uuid,
       ),
     );
   }
@@ -197,6 +220,12 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
       await ref
           .read(savedPathRepositoryProvider.notifier)
           .deletePath(_path.uuid);
+      await ref
+          .read(collectionRepositoryProvider.notifier)
+          .handleItemDeleted(CollectionItemRef(
+            type: CollectionItemRef.typePath,
+            uuid: _path.uuid,
+          ));
       if (mounted) {
         Navigator.of(context).pop(PathDetailResult.deleted);
       }
@@ -209,5 +238,47 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
         setState(() => _isDeleting = false);
       }
     }
+  }
+}
+
+class _PathCollectionChipStrip extends ConsumerWidget {
+  final CollectionItemRef itemRef;
+
+  const _PathCollectionChipStrip({required this.itemRef});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncState = ref.watch(collectionRepositoryProvider);
+    return asyncState.maybeWhen(
+      data: (state) {
+        final uuids = state.collectionsFor(itemRef);
+        if (uuids.isEmpty) return const SizedBox.shrink();
+        final byUuid = {for (final c in state.collections) c.uuid: c};
+        final colorScheme = Theme.of(context).colorScheme;
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final id in uuids)
+                if (byUuid[id] != null)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: Chip(
+                      avatar: Icon(
+                        Icons.folder_outlined,
+                        size: 16,
+                        color: hexToColor(byUuid[id]!.colorHex) ??
+                            colorScheme.primary,
+                      ),
+                      label: Text(byUuid[id]!.name),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+            ],
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
+    );
   }
 }

--- a/lib/features/saved_paths/widgets/path_info_sheet.dart
+++ b/lib/features/saved_paths/widgets/path_info_sheet.dart
@@ -267,6 +267,8 @@ class _PathCollectionChipStrip extends ConsumerWidget {
                     ),
                     label: Text(l10n.addToCollection),
                     onPressed: onTap,
+                    shape: const StadiumBorder(),
+                    side: BorderSide(color: colorScheme.outlineVariant),
                     visualDensity: VisualDensity.compact,
                   )
                 else ...[
@@ -283,6 +285,8 @@ class _PathCollectionChipStrip extends ConsumerWidget {
                           ),
                           label: Text(byUuid[id]!.name),
                           onPressed: onTap,
+                          shape: const StadiumBorder(),
+                          side: BorderSide(color: colorScheme.outlineVariant),
                           visualDensity: VisualDensity.compact,
                         ),
                       ),

--- a/lib/features/saved_paths/widgets/paths_list_page.dart
+++ b/lib/features/saved_paths/widgets/paths_list_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/markers/api.dart' show IconService;
+
+import '../data/saved_path_repository.dart';
+import '../models/path_style.dart';
+import '../models/saved_path.dart';
+import 'path_detail_sheet.dart';
+import 'path_info_sheet.dart';
+
+class PathsListPage extends ConsumerWidget {
+  const PathsListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final asyncPaths = ref.watch(savedPathRepositoryProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+    final iconService = IconService();
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.allPaths)),
+      body: asyncPaths.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (paths) {
+          if (paths.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  l10n.noResultsFound,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ),
+            );
+          }
+          final sorted = [...paths]
+            ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+          return ListView.separated(
+            itemCount: sorted.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final p = sorted[i];
+              final color = hexToColor(p.colorHex) ?? colorScheme.onSurfaceVariant;
+              final namedIcon = p.iconKey != null
+                  ? iconService.getIcon(context, p.iconKey)
+                  : null;
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: color.withAlpha(40),
+                  child: Icon(namedIcon?.icon ?? Icons.route, color: color),
+                ),
+                title: Text(p.title),
+                subtitle: Text('${(p.distance / 1000).toStringAsFixed(2)} km'),
+                onTap: () => _openInfo(context, p),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openInfo(BuildContext context, SavedPath path) async {
+    final l10n = context.l10n;
+    final result = await showModalBottomSheet<PathDetailResult>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => PathInfoSheet(path: path),
+    );
+    if (!context.mounted) return;
+    if (result == PathDetailResult.deleted) {
+      AppSnackbars.success(context, l10n.pathDeleted);
+    } else if (result == PathDetailResult.updated) {
+      AppSnackbars.success(context, l10n.pathUpdated);
+    }
+  }
+}

--- a/lib/features/saved_paths/widgets/save_path_sheet.dart
+++ b/lib/features/saved_paths/widgets/save_path_sheet.dart
@@ -5,6 +5,7 @@ import 'package:turbo/core/widgets/app_button.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/core/widgets/app_text_field.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/settings/api.dart';
 import '../models/saved_path.dart';
 import '../models/path_style.dart';
@@ -37,6 +38,7 @@ class _SavePathSheetState extends ConsumerState<SavePathSheet> {
   String? _selectedIconKey;
   late bool _isSmoothing;
   PathLineStyle _lineStyle = PathLineStyle.solid;
+  Set<String> _selectedCollectionUuids = {};
 
   @override
   void initState() {
@@ -134,6 +136,12 @@ class _SavePathSheetState extends ConsumerState<SavePathSheet> {
               initiallyExpanded: false,
             ),
             const SizedBox(height: 16),
+            CollectionPickerRow(
+              selectedUuids: _selectedCollectionUuids,
+              onChanged: (next) =>
+                  setState(() => _selectedCollectionUuids = next),
+            ),
+            const SizedBox(height: 16),
             Text(
               '${l10n.totalDistance}: ${(widget.distance / 1000).toStringAsFixed(2)} km',
               style: textTheme.bodyMedium?.copyWith(
@@ -180,6 +188,16 @@ class _SavePathSheetState extends ConsumerState<SavePathSheet> {
       );
 
       await ref.read(savedPathRepositoryProvider.notifier).addPath(path);
+
+      if (_selectedCollectionUuids.isNotEmpty) {
+        await ref.read(collectionRepositoryProvider.notifier).setMembership(
+              CollectionItemRef(
+                type: CollectionItemRef.typePath,
+                uuid: path.uuid,
+              ),
+              _selectedCollectionUuids,
+            );
+      }
 
       // Remember the style for the next save sheet.
       await ref.read(settingsProvider.notifier).setLastPathStyle(

--- a/lib/features/saved_paths/widgets/saved_paths_layer.dart
+++ b/lib/features/saved_paths/widgets/saved_paths_layer.dart
@@ -4,6 +4,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:turbo/core/util/catmull_rom_spline.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/markers/api.dart' hide Marker;
 import 'package:turbo/app/l10n/app_localizations.dart';
 import '../data/data_visibility_provider.dart';
@@ -91,17 +92,38 @@ class _SavedPathsLayerState extends ConsumerState<SavedPathsLayer> {
 
     final pathsAsync = ref.watch(viewportSavedPathNotifierProvider);
     final colorScheme = Theme.of(context).colorScheme;
+    final collectionState =
+        ref.watch(collectionRepositoryProvider).asData?.value ??
+            const CollectionRepositoryState.empty();
+    final visibility = ref.watch(collectionVisibilityProvider);
+
+    List<SavedPath> applyFilter(List<SavedPath> input) {
+      if (collectionState.membershipIndex.isEmpty) return input;
+      return input
+          .where((p) => isItemVisibleForCollections(
+                ref: CollectionItemRef(
+                  type: CollectionItemRef.typePath,
+                  uuid: p.uuid,
+                ),
+                collectionState: collectionState,
+                visibility: visibility,
+              ))
+          .toList();
+    }
 
     return pathsAsync.when(
       data: (paths) {
-        if (paths.isEmpty) return const SizedBox.shrink();
-        return _buildLayer(paths, colorScheme);
+        final filtered = applyFilter(paths);
+        if (filtered.isEmpty) return const SizedBox.shrink();
+        return _buildLayer(filtered, colorScheme);
       },
       loading: () {
         final previousData =
             ref.read(viewportSavedPathNotifierProvider).asData?.value;
         if (previousData != null && previousData.isNotEmpty) {
-          return _buildLayer(previousData, colorScheme);
+          final filteredPrev = applyFilter(previousData);
+          if (filteredPrev.isEmpty) return const SizedBox.shrink();
+          return _buildLayer(filteredPrev, colorScheme);
         }
         return const SizedBox.shrink();
       },

--- a/test/features/collections/collection_data_store_test.dart
+++ b/test/features/collections/collection_data_store_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:turbo/features/collections/data/sqlite_collection_data_store.dart';
+import 'package:turbo/features/collections/models/collection.dart';
+import 'package:turbo/features/collections/models/collection_item_ref.dart';
+
+import '../../helpers/in_memory_db.dart';
+
+void main() {
+  late Database db;
+  late SQLiteCollectionDataStore store;
+
+  setUp(() async {
+    db = await createCollectionsDb();
+    store = SQLiteCollectionDataStore(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('insert / getAll / getByUuid', () async {
+    final c = Collection(name: 'Trip A', description: 'd', colorHex: 'FF0000');
+    await store.insert(c);
+    final all = await store.getAll();
+    expect(all, hasLength(1));
+    expect(all.first.uuid, c.uuid);
+
+    final found = await store.getByUuid(c.uuid);
+    expect(found?.name, 'Trip A');
+    expect(found?.colorHex, 'FF0000');
+  });
+
+  test('update changes existing collection', () async {
+    final c = Collection(name: 'A');
+    await store.insert(c);
+    await store.update(c.copyWith(name: 'B'));
+    final found = await store.getByUuid(c.uuid);
+    expect(found?.name, 'B');
+  });
+
+  test('delete removes collection and its join rows', () async {
+    final c = Collection(name: 'A');
+    await store.insert(c);
+    final m = CollectionItemRef(type: 'marker', uuid: 'm1');
+    await store.addItem(c.uuid, m);
+    await store.delete(c.uuid);
+    expect(await store.getByUuid(c.uuid), isNull);
+    expect(await store.getCollectionUuidsFor(m), isEmpty);
+  });
+
+  test('addItem is idempotent (PK conflict ignored)', () async {
+    final c = Collection(name: 'A');
+    await store.insert(c);
+    final m = CollectionItemRef(type: 'marker', uuid: 'm1');
+    await store.addItem(c.uuid, m);
+    await store.addItem(c.uuid, m);
+    expect(await store.countItems(c.uuid), 1);
+  });
+
+  test('many-to-many membership for the same item', () async {
+    final a = Collection(name: 'A');
+    final b = Collection(name: 'B');
+    await store.insert(a);
+    await store.insert(b);
+    final m = CollectionItemRef(type: 'marker', uuid: 'm1');
+    await store.addItem(a.uuid, m);
+    await store.addItem(b.uuid, m);
+    final cs = await store.getCollectionUuidsFor(m);
+    expect(cs.toSet(), {a.uuid, b.uuid});
+  });
+
+  test('removeItem only removes from the target collection', () async {
+    final a = Collection(name: 'A');
+    final b = Collection(name: 'B');
+    await store.insert(a);
+    await store.insert(b);
+    final m = CollectionItemRef(type: 'marker', uuid: 'm1');
+    await store.addItem(a.uuid, m);
+    await store.addItem(b.uuid, m);
+    await store.removeItem(a.uuid, m);
+    expect((await store.getCollectionUuidsFor(m)).toSet(), {b.uuid});
+  });
+
+  test('removeItemFromAll clears every join row for an item', () async {
+    final a = Collection(name: 'A');
+    final b = Collection(name: 'B');
+    await store.insert(a);
+    await store.insert(b);
+    final m = CollectionItemRef(type: 'marker', uuid: 'm1');
+    await store.addItem(a.uuid, m);
+    await store.addItem(b.uuid, m);
+    await store.removeItemFromAll(m);
+    expect(await store.getCollectionUuidsFor(m), isEmpty);
+  });
+
+  test('getItems returns markers and paths mixed', () async {
+    final c = Collection(name: 'Mixed');
+    await store.insert(c);
+    await store.addItem(c.uuid,
+        CollectionItemRef(type: CollectionItemRef.typeMarker, uuid: 'm1'));
+    await store.addItem(c.uuid,
+        CollectionItemRef(type: CollectionItemRef.typePath, uuid: 'p1'));
+    final items = await store.getItems(c.uuid);
+    expect(items, hasLength(2));
+    expect(items.map((r) => r.type).toSet(),
+        {CollectionItemRef.typeMarker, CollectionItemRef.typePath});
+  });
+
+  test('getMembershipIndex builds reverse lookup', () async {
+    final a = Collection(name: 'A');
+    final b = Collection(name: 'B');
+    await store.insert(a);
+    await store.insert(b);
+    final m1 = CollectionItemRef(type: 'marker', uuid: 'm1');
+    final m2 = CollectionItemRef(type: 'marker', uuid: 'm2');
+    await store.addItem(a.uuid, m1);
+    await store.addItem(b.uuid, m1);
+    await store.addItem(a.uuid, m2);
+    final idx = await store.getMembershipIndex();
+    expect(idx[m1]!.toSet(), {a.uuid, b.uuid});
+    expect(idx[m2]!.toSet(), {a.uuid});
+  });
+}

--- a/test/features/collections/collection_filter_test.dart
+++ b/test/features/collections/collection_filter_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:turbo/features/collections/data/collection_filter.dart';
+import 'package:turbo/features/collections/data/collection_repository.dart';
+import 'package:turbo/features/collections/models/collection_item_ref.dart';
+
+CollectionRepositoryState _stateWith(Map<CollectionItemRef, List<String>> idx) {
+  return CollectionRepositoryState(
+    collections: const [],
+    memberCounts: const {},
+    membershipIndex: idx,
+  );
+}
+
+void main() {
+  const item = CollectionItemRef(type: 'marker', uuid: 'm1');
+
+  test('item with no memberships is always visible', () {
+    final visible = isItemVisibleForCollections(
+      ref: item,
+      collectionState: _stateWith({}),
+      visibility: const {'A': false, 'B': false},
+    );
+    expect(visible, isTrue);
+  });
+
+  test('item is visible when at least one of its collections is visible', () {
+    final state = _stateWith({
+      item: ['A', 'B'],
+    });
+    expect(
+      isItemVisibleForCollections(
+        ref: item,
+        collectionState: state,
+        visibility: const {'A': false, 'B': true},
+      ),
+      isTrue,
+    );
+  });
+
+  test('item is hidden when all of its collections are toggled off', () {
+    final state = _stateWith({
+      item: ['A', 'B'],
+    });
+    expect(
+      isItemVisibleForCollections(
+        ref: item,
+        collectionState: state,
+        visibility: const {'A': false, 'B': false},
+      ),
+      isFalse,
+    );
+  });
+
+  test('missing visibility entry defaults to visible', () {
+    final state = _stateWith({
+      item: ['A'],
+    });
+    expect(
+      isItemVisibleForCollections(
+        ref: item,
+        collectionState: state,
+        visibility: const {},
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/features/markers/marker_info_sheet_test.dart
+++ b/test/features/markers/marker_info_sheet_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/markers/api.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 
@@ -24,6 +25,15 @@ class _FakeRepo extends LocationRepository {
   }
 }
 
+class _FakeCollectionRepo extends CollectionRepository {
+  @override
+  AsyncValue<CollectionRepositoryState> build() =>
+      const AsyncData(CollectionRepositoryState.empty());
+
+  @override
+  Future<void> handleItemDeleted(CollectionItemRef ref) async {}
+}
+
 Marker _marker() => Marker(
       uuid: 'm1',
       title: 'My Pin',
@@ -36,7 +46,10 @@ Future<_FakeRepo> _openSheet(WidgetTester tester, {Marker? marker}) async {
   final m = marker ?? _marker();
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [locationRepositoryProvider.overrideWith(() => repo)],
+      overrides: [
+        locationRepositoryProvider.overrideWith(() => repo),
+        collectionRepositoryProvider.overrideWith(() => _FakeCollectionRepo()),
+      ],
       child: MaterialApp(
         localizationsDelegates: const [
           AppLocalizations.delegate,

--- a/test/features/saved_paths/path_info_sheet_test.dart
+++ b/test/features/saved_paths/path_info_sheet_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/saved_paths/api.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 
@@ -20,6 +21,15 @@ class _FakeRepo extends SavedPathRepository {
   }
 }
 
+class _FakeCollectionRepo extends CollectionRepository {
+  @override
+  AsyncValue<CollectionRepositoryState> build() =>
+      const AsyncData(CollectionRepositoryState.empty());
+
+  @override
+  Future<void> handleItemDeleted(CollectionItemRef ref) async {}
+}
+
 SavedPath _path() => SavedPath(
       uuid: 'p1',
       title: 'Morning Run',
@@ -34,7 +44,10 @@ Future<_FakeRepo> _openSheet(WidgetTester tester) async {
   final p = _path();
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [savedPathRepositoryProvider.overrideWith(() => repo)],
+      overrides: [
+        savedPathRepositoryProvider.overrideWith(() => repo),
+        collectionRepositoryProvider.overrideWith(() => _FakeCollectionRepo()),
+      ],
       child: MaterialApp(
         localizationsDelegates: const [
           AppLocalizations.delegate,

--- a/test/helpers/in_memory_db.dart
+++ b/test/helpers/in_memory_db.dart
@@ -109,6 +109,59 @@ Future<Database> createFullSchemaDb() async {
   ''');
   batch.execute(
       'CREATE INDEX idx_saved_paths_bounds ON $savedPathsTable(min_lat, max_lat, min_lng, max_lng)');
+  batch.execute('''
+    CREATE TABLE $collectionsTable(
+      uuid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      color_hex TEXT,
+      icon_key TEXT,
+      created_at TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    )
+  ''');
+  batch.execute('''
+    CREATE TABLE $collectionItemsTable(
+      collection_uuid TEXT NOT NULL,
+      item_type TEXT NOT NULL,
+      item_uuid TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      PRIMARY KEY (collection_uuid, item_type, item_uuid)
+    )
+  ''');
+  batch.execute(
+      'CREATE INDEX idx_collection_items_item ON $collectionItemsTable(item_type, item_uuid)');
+  await batch.commit(noResult: true);
+  return db;
+}
+
+/// Opens a fresh in-memory SQLite database with only the collections schema.
+Future<Database> createCollectionsDb() async {
+  initSqfliteFfi();
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  final batch = db.batch();
+  batch.execute('''
+    CREATE TABLE $collectionsTable(
+      uuid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      color_hex TEXT,
+      icon_key TEXT,
+      created_at TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    )
+  ''');
+  batch.execute('''
+    CREATE TABLE $collectionItemsTable(
+      collection_uuid TEXT NOT NULL,
+      item_type TEXT NOT NULL,
+      item_uuid TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      PRIMARY KEY (collection_uuid, item_type, item_uuid)
+    )
+  ''');
+  batch.execute(
+      'CREATE INDEX idx_collection_items_item ON $collectionItemsTable(item_type, item_uuid)');
   await batch.commit(noResult: true);
   return db;
 }


### PR DESCRIPTION
Introduces a generalized Collection model with a many-to-many join table
keyed by (item_type, item_uuid) so the same mechanism handles markers
and paths today and accepts future item types without schema changes.
Each collection has its own map visibility toggle; an item is hidden
only when every collection it belongs to is toggled off. Adds drawer
entries for Collections, All markers, and All paths.

https://claude.ai/code/session_01WH1sJ3d4YwRAMATFtbazFD