### PR TITLE
Add shareable web link encoding for markers and saved paths

### DIFF
--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -258,8 +258,10 @@ abstract class AppLocalizations {
   String get edit;
   String get export;
   String get exportMarker;
-  String get textDescription;
-  String get shareAsText;
+  String get linkDescription;
+  String get shareAsLink;
+  String get linkCopied;
+  String get linkTooLargeShareGpxInstead;
   String get shareAsFile;
   String get markerExported;
   String get markerDeleted;
@@ -513,8 +515,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get edit => 'Edit';
   @override String get export => 'Export';
   @override String get exportMarker => 'Export Marker';
-  @override String get textDescription => 'Plain text - easy to paste anywhere';
-  @override String get shareAsText => 'Share as text';
+  @override String get linkDescription => 'Web link - opens in any browser';
+  @override String get shareAsLink => 'Share as link';
+  @override String get linkCopied => 'Link copied to clipboard';
+  @override String get linkTooLargeShareGpxInstead =>
+      'This route is too large to share as a link. Share as GPX instead.';
   @override String get shareAsFile => 'Share as file';
   @override String get markerExported => 'Marker saved';
   @override String get markerDeleted => 'Marker deleted';
@@ -764,8 +769,11 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get edit => 'Rediger';
   @override String get export => 'Eksporter';
   @override String get exportMarker => 'Eksporter punkt';
-  @override String get textDescription => 'Ren tekst - enkelt å lime inn hvor som helst';
-  @override String get shareAsText => 'Del som tekst';
+  @override String get linkDescription => 'Nettlenke - åpnes i en hvilken som helst nettleser';
+  @override String get shareAsLink => 'Del som lenke';
+  @override String get linkCopied => 'Lenke kopiert til utklippstavlen';
+  @override String get linkTooLargeShareGpxInstead =>
+      'Denne ruten er for stor til å deles som lenke. Del som GPX i stedet.';
   @override String get shareAsFile => 'Del som fil';
   @override String get markerExported => 'Punkt lagret';
   @override String get markerDeleted => 'Punkt slettet';

--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -293,6 +293,13 @@ abstract class AppLocalizations {
   String get shareAsLink;
   String get linkCopied;
   String get linkTooLargeShareGpxInstead;
+  String get sharedMarkerTitle;
+  String get sharedPathTitle;
+  String get saveToMyMarkers;
+  String get saveToMyPaths;
+  String get savedToMyMarkers;
+  String get savedToMyPaths;
+  String pointCount(int count);
   String get shareAsFile;
   String get markerExported;
   String get markerDeleted;
@@ -587,6 +594,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get linkCopied => 'Link copied to clipboard';
   @override String get linkTooLargeShareGpxInstead =>
       'This route is too large to share as a link. Share as GPX instead.';
+  @override String get sharedMarkerTitle => 'Shared marker';
+  @override String get sharedPathTitle => 'Shared route';
+  @override String get saveToMyMarkers => 'Save to my markers';
+  @override String get saveToMyPaths => 'Save to my routes';
+  @override String get savedToMyMarkers => 'Saved to your markers';
+  @override String get savedToMyPaths => 'Saved to your routes';
+  @override String pointCount(int count) => '$count points';
   @override String get shareAsFile => 'Share as file';
   @override String get markerExported => 'Marker saved';
   @override String get markerDeleted => 'Marker deleted';
@@ -877,6 +891,13 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get linkCopied => 'Lenke kopiert til utklippstavlen';
   @override String get linkTooLargeShareGpxInstead =>
       'Denne ruten er for stor til å deles som lenke. Del som GPX i stedet.';
+  @override String get sharedMarkerTitle => 'Delt punkt';
+  @override String get sharedPathTitle => 'Delt rute';
+  @override String get saveToMyMarkers => 'Lagre i mine punkter';
+  @override String get saveToMyPaths => 'Lagre i mine ruter';
+  @override String get savedToMyMarkers => 'Lagret i dine punkter';
+  @override String get savedToMyPaths => 'Lagret i dine ruter';
+  @override String pointCount(int count) => '$count punkter';
   @override String get shareAsFile => 'Del som fil';
   @override String get markerExported => 'Punkt lagret';
   @override String get markerDeleted => 'Punkt slettet';

--- a/lib/app/main.dart
+++ b/lib/app/main.dart
@@ -9,6 +9,7 @@ import 'package:turbo/core/data/database_provider.dart';
 import 'package:turbo/core/service/logger.dart';
 import 'package:turbo/features/auth/api.dart';
 import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/sharing/api.dart';
 import 'package:turbo/features/tile_storage/offline_regions/api.dart'
     as offline_regions;
 
@@ -18,6 +19,10 @@ void main() {
 
   final container = ProviderContainer();
   unawaited(_kickOffBackgroundInit(container));
+  // Parse any share URL embedded in the initial location (web cold-start
+  // or platform deep-link). Has to happen before the first frame so the
+  // map can react.
+  ShareRouteHandler(container).handle(Uri.base);
 
   runApp(
     UncontrolledProviderScope(
@@ -40,4 +45,6 @@ Future<void> _kickOffBackgroundInit(ProviderContainer container) async {
   }
   container.read(authStateProvider);
   container.read(localMarkerDataStoreProvider);
+  // Start watching app links for share URLs (no-op on web).
+  container.read(shareLinkListenerProvider);
 }

--- a/lib/core/config/env_config.dart
+++ b/lib/core/config/env_config.dart
@@ -31,9 +31,6 @@ class EnvironmentConfig {
 
   /// Base URL of the hosted Flutter-web frontend. Used to build shareable
   /// links for markers and routes (e.g. `<webBaseUrl>/share/m?d=...`).
-  ///
-  /// Replace the production value with the real Cloudflare Pages domain
-  /// once it is known.
   static String get webBaseUrl {
     if (isDevelopment) {
       return 'http://localhost:8080';

--- a/lib/core/config/env_config.dart
+++ b/lib/core/config/env_config.dart
@@ -29,6 +29,19 @@ class EnvironmentConfig {
     }
   }
 
+  /// Base URL of the hosted Flutter-web frontend. Used to build shareable
+  /// links for markers and routes (e.g. `<webBaseUrl>/share/m?d=...`).
+  ///
+  /// Replace the production value with the real Cloudflare Pages domain
+  /// once it is known.
+  static String get webBaseUrl {
+    if (isDevelopment) {
+      return 'http://localhost:8080';
+    } else {
+      return 'https://kart.sandring.no';
+    }
+  }
+
   static String get googleServerClientId {
     if (isDevelopment) {
       return '863382325847-l4s030g7ruif29o6no75ugb19c380an0.apps.googleusercontent.com';

--- a/lib/core/sharing/api.dart
+++ b/lib/core/sharing/api.dart
@@ -1,0 +1,10 @@
+export 'share_url_provider.dart' show webBaseUrlProvider;
+export 'shareable_link_codec.dart'
+    show
+        ShareableLinkCodec,
+        SharedPayload,
+        SharedMarkerPayload,
+        SharedPathPayload,
+        LinkTooLargeException,
+        InvalidShareLinkException,
+        UnsupportedShareVersionException;

--- a/lib/core/sharing/share_url_provider.dart
+++ b/lib/core/sharing/share_url_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../config/env_config.dart';
+
+/// Base URL for share links, derived from [EnvironmentConfig.webBaseUrl].
+/// Exposed as a provider so tests can override it.
+final webBaseUrlProvider = Provider<String>((ref) {
+  return EnvironmentConfig.webBaseUrl;
+});

--- a/lib/core/sharing/shareable_link_codec.dart
+++ b/lib/core/sharing/shareable_link_codec.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
+
+import '../../features/markers/api.dart';
+import '../../features/saved_paths/api.dart';
+
+/// Maximum length of a share URL before we refuse to build it.
+/// 8000 chars is a safe upper bound across modern browsers (Edge caps URLs
+/// near 2 KB; Chrome/Firefox tolerate ~32 KB; servers and proxies often cap
+/// near 8 KB). Past this we steer users toward GPX export.
+const int kMaxShareUrlLength = 8000;
+
+/// Current schema version of the encoded payload.
+const int _kPayloadVersion = 1;
+
+/// Marker kind in URLs: `/share/m`.
+const String _kMarkerKind = 'm';
+
+/// Path kind in URLs: `/share/p`.
+const String _kPathKind = 'p';
+
+/// Result of decoding a share URL.
+sealed class SharedPayload {
+  const SharedPayload();
+}
+
+class SharedMarkerPayload extends SharedPayload {
+  final Marker marker;
+  const SharedMarkerPayload(this.marker);
+}
+
+class SharedPathPayload extends SharedPayload {
+  final SavedPath path;
+  const SharedPathPayload(this.path);
+}
+
+class LinkTooLargeException implements Exception {
+  final int length;
+  LinkTooLargeException(this.length);
+  @override
+  String toString() =>
+      'LinkTooLargeException: encoded URL is $length chars '
+      '(max $kMaxShareUrlLength). Share as GPX instead.';
+}
+
+class InvalidShareLinkException implements Exception {
+  final String message;
+  InvalidShareLinkException(this.message);
+  @override
+  String toString() => 'InvalidShareLinkException: $message';
+}
+
+class UnsupportedShareVersionException implements Exception {
+  final int version;
+  UnsupportedShareVersionException(this.version);
+  @override
+  String toString() =>
+      'UnsupportedShareVersionException: payload version $version is not '
+      'supported by this client. Update the app to view this share.';
+}
+
+/// Encodes markers and saved paths into shareable web URLs and decodes them
+/// back. The payload (JSON) is gzipped and base64url-encoded into a single
+/// `d` query parameter. The host is the configured Flutter-web frontend.
+class ShareableLinkCodec {
+  ShareableLinkCodec._();
+
+  static String encodeMarker(Marker marker, String webBaseUrl) {
+    final json = <String, dynamic>{
+      'v': _kPayloadVersion,
+      't': marker.title,
+      if (_nonEmpty(marker.description)) 'd': marker.description,
+      if (_nonEmpty(marker.icon)) 'i': marker.icon,
+      'p': [
+        _round6(marker.position.latitude),
+        _round6(marker.position.longitude),
+      ],
+    };
+    return _buildUrl(webBaseUrl, _kMarkerKind, json);
+  }
+
+  static String encodePath(SavedPath path, String webBaseUrl) {
+    final json = <String, dynamic>{
+      'v': _kPayloadVersion,
+      't': path.title,
+      if (_nonEmpty(path.description)) 'd': path.description,
+      if (_nonEmpty(path.colorHex)) 'c': path.colorHex,
+      if (_nonEmpty(path.iconKey)) 'i': path.iconKey,
+      if (path.smoothing) 's': true,
+      if (_nonEmpty(path.lineStyleKey)) 'l': path.lineStyleKey,
+      'pts': [
+        for (final pt in path.points)
+          [_round6(pt.latitude), _round6(pt.longitude)],
+      ],
+    };
+    return _buildUrl(webBaseUrl, _kPathKind, json);
+  }
+
+  /// Returns `null` if [uri] is not a share URL; throws on malformed shares.
+  static SharedPayload? decodeShareUrl(Uri uri) {
+    final segments = uri.pathSegments;
+    if (segments.length < 2) return null;
+    final tail = segments.sublist(segments.length - 2);
+    if (tail[0] != 'share') return null;
+    final kind = tail[1];
+    if (kind != _kMarkerKind && kind != _kPathKind) return null;
+
+    final data = uri.queryParameters['d'];
+    if (data == null || data.isEmpty) {
+      throw InvalidShareLinkException('missing "d" query parameter');
+    }
+    return decodeRawPayload(data, kind: kind);
+  }
+
+  /// Test-only entry point that bypasses URL parsing.
+  @visibleForTesting
+  static SharedPayload decodeRawPayload(
+    String data, {
+    required String kind,
+    int? overrideVersionForTest,
+  }) {
+    final json = _decodeJson(data);
+    final version = overrideVersionForTest ?? (json['v'] as int? ?? -1);
+    if (version != _kPayloadVersion) {
+      throw UnsupportedShareVersionException(version);
+    }
+    return switch (kind) {
+      _kMarkerKind => SharedMarkerPayload(_markerFromJson(json)),
+      _kPathKind => SharedPathPayload(_pathFromJson(json)),
+      _ => throw InvalidShareLinkException('unknown share kind "$kind"'),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+
+  static String _buildUrl(String webBaseUrl, String kind, Map<String, dynamic> json) {
+    final encoded = _encodeJson(json);
+    final base = Uri.parse(webBaseUrl);
+    final newSegments = <String>[
+      ...base.pathSegments.where((s) => s.isNotEmpty),
+      'share',
+      kind,
+    ];
+    final url = base.replace(
+      pathSegments: newSegments,
+      queryParameters: {'d': encoded},
+    ).toString();
+
+    if (url.length > kMaxShareUrlLength) {
+      throw LinkTooLargeException(url.length);
+    }
+    return url;
+  }
+
+  static String _encodeJson(Map<String, dynamic> json) {
+    final raw = utf8.encode(jsonEncode(json));
+    final gzipped = const GZipEncoder().encode(raw);
+    return base64UrlEncode(gzipped).replaceAll('=', '');
+  }
+
+  static Map<String, dynamic> _decodeJson(String data) {
+    try {
+      final padded = _padBase64(data);
+      final gzipped = base64Url.decode(padded);
+      final raw = const GZipDecoder().decodeBytes(gzipped);
+      final decoded = jsonDecode(utf8.decode(raw));
+      if (decoded is! Map<String, dynamic>) {
+        throw InvalidShareLinkException('payload is not a JSON object');
+      }
+      return decoded;
+    } on InvalidShareLinkException {
+      rethrow;
+    } catch (e) {
+      throw InvalidShareLinkException('could not decode payload: $e');
+    }
+  }
+
+  static String _padBase64(String s) {
+    final pad = (4 - s.length % 4) % 4;
+    return s + ('=' * pad);
+  }
+
+  static Marker _markerFromJson(Map<String, dynamic> json) {
+    final p = json['p'];
+    if (p is! List || p.length != 2) {
+      throw InvalidShareLinkException('marker payload missing position');
+    }
+    return Marker(
+      title: json['t'] as String? ?? '',
+      description: json['d'] as String?,
+      icon: json['i'] as String?,
+      position: LatLng((p[0] as num).toDouble(), (p[1] as num).toDouble()),
+    );
+  }
+
+  static SavedPath _pathFromJson(Map<String, dynamic> json) {
+    final raw = json['pts'];
+    if (raw is! List || raw.isEmpty) {
+      throw InvalidShareLinkException('path payload missing points');
+    }
+    final points = <LatLng>[];
+    for (final entry in raw) {
+      if (entry is! List || entry.length != 2) {
+        throw InvalidShareLinkException('path point malformed');
+      }
+      points.add(LatLng(
+        (entry[0] as num).toDouble(),
+        (entry[1] as num).toDouble(),
+      ));
+    }
+    final distance = _haversineDistance(points);
+    return SavedPath(
+      title: json['t'] as String? ?? '',
+      description: json['d'] as String?,
+      points: points,
+      distance: distance,
+      colorHex: json['c'] as String?,
+      iconKey: json['i'] as String?,
+      smoothing: json['s'] as bool? ?? false,
+      lineStyleKey: json['l'] as String?,
+    );
+  }
+
+  static double _haversineDistance(List<LatLng> points) {
+    const distance = Distance();
+    var total = 0.0;
+    for (var i = 1; i < points.length; i++) {
+      total += distance(points[i - 1], points[i]);
+    }
+    return total;
+  }
+
+  static bool _nonEmpty(String? s) => s != null && s.isNotEmpty;
+
+  static double _round6(double v) => (v * 1e6).roundToDouble() / 1e6;
+}

--- a/lib/core/sharing/shareable_link_codec.dart
+++ b/lib/core/sharing/shareable_link_codec.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
 import 'package:archive/archive.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:latlong2/latlong.dart';
-import 'package:meta/meta.dart';
 
 import '../../features/markers/api.dart';
 import '../../features/saved_paths/api.dart';

--- a/lib/features/map_view/widgets/main_map_page.dart
+++ b/lib/features/map_view/widgets/main_map_page.dart
@@ -15,6 +15,7 @@ as offline_api;
 import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/markers/api.dart' as marker_model;
 import 'package:turbo/features/navigation/api.dart';
+import 'package:turbo/features/sharing/api.dart';
 
 import 'package:turbo/core/location/compass_mode_state.dart';
 import 'package:turbo/core/location/compass_state.dart';
@@ -262,7 +263,9 @@ class _MainMapPageState extends ConsumerState<MainMapPage>
       );
     }
 
-    return LayoutBuilder(
+    return SharedPayloadListener(
+      onCenter: (point) => _smoothMoveTo(point),
+      child: LayoutBuilder(
       builder: (context, constraints) {
         final isMobile = constraints.maxWidth < 600;
         final mapControls = isMobile
@@ -299,6 +302,7 @@ class _MainMapPageState extends ConsumerState<MainMapPage>
           );
         }
       },
+      ),
     );
   }
 

--- a/lib/features/markers/data/marker_export_service.dart
+++ b/lib/features/markers/data/marker_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/lib/features/markers/data/marker_export_service.dart
+++ b/lib/features/markers/data/marker_export_service.dart
@@ -3,26 +3,25 @@ import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../core/sharing/shareable_link_codec.dart';
 import '../models/marker.dart';
 import 'marker_geojson_serializer.dart';
 
 class MarkerExportService {
-  String shareText(Marker marker) {
-    final coords =
-        '${marker.position.latitude.toStringAsFixed(6)}, '
-        '${marker.position.longitude.toStringAsFixed(6)}';
-    final buffer = StringBuffer('${marker.title} ($coords)');
-    if (marker.description != null && marker.description!.isNotEmpty) {
-      buffer.write('\n${marker.description}');
-    }
-    return buffer.toString();
+  /// Encodes [marker] into a shareable web URL pointing at [webBaseUrl].
+  String buildShareLink(Marker marker, String webBaseUrl) {
+    return ShareableLinkCodec.encodeMarker(marker, webBaseUrl);
   }
 
-  Future<void> shareAsText(Marker marker) async {
-    await Share.share(shareText(marker));
+  /// Copies the share link to the clipboard and opens the system share sheet.
+  Future<void> shareAsLink(Marker marker, String webBaseUrl) async {
+    final url = buildShareLink(marker, webBaseUrl);
+    await Clipboard.setData(ClipboardData(text: url));
+    await Share.share(url, subject: marker.title);
   }
 
   String _buildFilename(Marker marker) {

--- a/lib/features/markers/widgets/marker_export_options_sheet.dart
+++ b/lib/features/markers/widgets/marker_export_options_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/core/sharing/api.dart';
 import 'package:turbo/core/widgets/app_list_card.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
@@ -6,13 +8,13 @@ import 'package:turbo/app/l10n/app_localizations.dart';
 import '../data/marker_export_service.dart';
 import '../models/marker.dart';
 
-class MarkerExportOptionsSheet extends StatelessWidget {
+class MarkerExportOptionsSheet extends ConsumerWidget {
   final Marker marker;
 
   const MarkerExportOptionsSheet({super.key, required this.marker});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final textTheme = Theme.of(context).textTheme;
     final mediaQuery = MediaQuery.of(context);
@@ -38,34 +40,14 @@ class MarkerExportOptionsSheet extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           AppListCard(
-            icon: Icons.text_fields,
-            title: l10n.shareAsText,
-            subtitle: l10n.textDescription,
+            icon: Icons.link,
+            title: l10n.shareAsLink,
+            subtitle: l10n.linkDescription,
             trailing: [
               IconButton(
                 icon: const Icon(Icons.share),
                 tooltip: l10n.share,
-                onPressed: () => _export(context, _MarkerExportAction.shareText),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          AppListCard(
-            icon: Icons.data_object,
-            title: 'GeoJSON',
-            subtitle: l10n.geoJsonDescription,
-            trailing: [
-              IconButton(
-                icon: const Icon(Icons.share),
-                tooltip: l10n.share,
-                onPressed: () =>
-                    _export(context, _MarkerExportAction.shareGeoJson),
-              ),
-              IconButton(
-                icon: const Icon(Icons.save_alt),
-                tooltip: l10n.saveToFile,
-                onPressed: () =>
-                    _export(context, _MarkerExportAction.saveGeoJson),
+                onPressed: () => _shareLink(context, ref),
               ),
             ],
           ),
@@ -74,33 +56,19 @@ class MarkerExportOptionsSheet extends StatelessWidget {
     );
   }
 
-  Future<void> _export(
-    BuildContext context,
-    _MarkerExportAction action,
-  ) async {
+  Future<void> _shareLink(BuildContext context, WidgetRef ref) async {
     final l10n = context.l10n;
     final navigator = Navigator.of(context);
+    final webBaseUrl = ref.read(webBaseUrlProvider);
 
     try {
-      final service = MarkerExportService();
-      switch (action) {
-        case _MarkerExportAction.shareText:
-          await service.shareAsText(marker);
-        case _MarkerExportAction.shareGeoJson:
-          await service.shareAsGeoJson(marker);
-        case _MarkerExportAction.saveGeoJson:
-          final result = await service.saveToFile(marker);
-          if (result == null) return;
-      }
-
+      await MarkerExportService().shareAsLink(marker, webBaseUrl);
       if (!context.mounted) return;
       navigator.pop();
-      AppSnackbars.success(context, l10n.markerExported);
+      AppSnackbars.success(context, l10n.linkCopied);
     } catch (error) {
       if (!context.mounted) return;
       AppSnackbars.error(context, l10n.errorExportingMarker(error.toString()));
     }
   }
 }
-
-enum _MarkerExportAction { shareText, shareGeoJson, saveGeoJson }

--- a/lib/features/saved_paths/data/path_export_service.dart
+++ b/lib/features/saved_paths/data/path_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/lib/features/saved_paths/data/path_export_service.dart
+++ b/lib/features/saved_paths/data/path_export_service.dart
@@ -3,9 +3,11 @@ import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../core/sharing/shareable_link_codec.dart';
 import '../models/saved_path.dart';
 import 'geojson_serializer.dart';
 import 'gpx_serializer.dart';
@@ -13,6 +15,20 @@ import 'gpx_serializer.dart';
 enum ExportFormat { gpx, geoJson }
 
 class PathExportService {
+  /// Encodes [path] into a shareable web URL pointing at [webBaseUrl].
+  /// Throws [LinkTooLargeException] for paths whose encoded URL exceeds the
+  /// safe URL-length budget — callers should fall back to GPX sharing.
+  String buildShareLink(SavedPath path, String webBaseUrl) {
+    return ShareableLinkCodec.encodePath(path, webBaseUrl);
+  }
+
+  /// Copies the share link to the clipboard and opens the system share sheet.
+  Future<void> shareAsLink(SavedPath path, String webBaseUrl) async {
+    final url = buildShareLink(path, webBaseUrl);
+    await Clipboard.setData(ClipboardData(text: url));
+    await Share.share(url, subject: path.title);
+  }
+
   String serialize(SavedPath path, ExportFormat format) {
     return switch (format) {
       ExportFormat.gpx => savedPathToGpx(path),

--- a/lib/features/saved_paths/widgets/export_options_sheet.dart
+++ b/lib/features/saved_paths/widgets/export_options_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/core/sharing/api.dart';
 import 'package:turbo/core/widgets/app_list_card.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
@@ -6,13 +8,13 @@ import 'package:turbo/app/l10n/app_localizations.dart';
 import '../data/path_export_service.dart';
 import '../models/saved_path.dart';
 
-class ExportOptionsSheet extends StatelessWidget {
+class ExportOptionsSheet extends ConsumerWidget {
   final SavedPath path;
 
   const ExportOptionsSheet({super.key, required this.path});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final textTheme = Theme.of(context).textTheme;
     final mediaQuery = MediaQuery.of(context);
@@ -38,6 +40,19 @@ class ExportOptionsSheet extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           AppListCard(
+            icon: Icons.link,
+            title: l10n.shareAsLink,
+            subtitle: l10n.linkDescription,
+            trailing: [
+              IconButton(
+                icon: const Icon(Icons.share),
+                tooltip: l10n.share,
+                onPressed: () => _shareLink(context, ref),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          AppListCard(
             icon: Icons.route,
             title: 'GPX',
             subtitle: l10n.gpxDescription,
@@ -46,33 +61,13 @@ class ExportOptionsSheet extends StatelessWidget {
                 icon: const Icon(Icons.share),
                 tooltip: l10n.share,
                 onPressed: () =>
-                    _export(context, ExportFormat.gpx, share: true),
+                    _exportFile(context, ExportFormat.gpx, share: true),
               ),
               IconButton(
                 icon: const Icon(Icons.save_alt),
                 tooltip: l10n.saveToFile,
                 onPressed: () =>
-                    _export(context, ExportFormat.gpx, share: false),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          AppListCard(
-            icon: Icons.data_object,
-            title: 'GeoJSON',
-            subtitle: l10n.geoJsonDescription,
-            trailing: [
-              IconButton(
-                icon: const Icon(Icons.share),
-                tooltip: l10n.share,
-                onPressed: () =>
-                    _export(context, ExportFormat.geoJson, share: true),
-              ),
-              IconButton(
-                icon: const Icon(Icons.save_alt),
-                tooltip: l10n.saveToFile,
-                onPressed: () =>
-                    _export(context, ExportFormat.geoJson, share: false),
+                    _exportFile(context, ExportFormat.gpx, share: false),
               ),
             ],
           ),
@@ -81,7 +76,26 @@ class ExportOptionsSheet extends StatelessWidget {
     );
   }
 
-  Future<void> _export(
+  Future<void> _shareLink(BuildContext context, WidgetRef ref) async {
+    final l10n = context.l10n;
+    final navigator = Navigator.of(context);
+    final webBaseUrl = ref.read(webBaseUrlProvider);
+
+    try {
+      await PathExportService().shareAsLink(path, webBaseUrl);
+      if (!context.mounted) return;
+      navigator.pop();
+      AppSnackbars.success(context, l10n.linkCopied);
+    } on LinkTooLargeException {
+      if (!context.mounted) return;
+      AppSnackbars.error(context, l10n.linkTooLargeShareGpxInstead);
+    } catch (error) {
+      if (!context.mounted) return;
+      AppSnackbars.error(context, l10n.errorExportingPath(error.toString()));
+    }
+  }
+
+  Future<void> _exportFile(
     BuildContext context,
     ExportFormat format, {
     required bool share,
@@ -106,4 +120,3 @@ class ExportOptionsSheet extends StatelessWidget {
     }
   }
 }
-

--- a/lib/features/sharing/api.dart
+++ b/lib/features/sharing/api.dart
@@ -1,0 +1,11 @@
+/// Public API for the sharing feature: incoming share-link handling.
+library;
+
+export 'data/pending_share_provider.dart'
+    show pendingShareProvider, PendingShareNotifier;
+export 'data/share_route_handler.dart' show ShareRouteHandler;
+export 'data/share_link_listener_provider.dart' show shareLinkListenerProvider;
+export 'widgets/shared_marker_preview_sheet.dart'
+    show SharedMarkerPreviewSheet;
+export 'widgets/shared_path_preview_sheet.dart' show SharedPathPreviewSheet;
+export 'widgets/shared_payload_listener.dart' show SharedPayloadListener;

--- a/lib/features/sharing/data/pending_share_provider.dart
+++ b/lib/features/sharing/data/pending_share_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sharing/shareable_link_codec.dart';
+
+/// Holds at most one [SharedPayload] that arrived via a share URL and is
+/// waiting for the map UI to consume it. Cleared once the preview sheet
+/// opens.
+final pendingShareProvider =
+    NotifierProvider<PendingShareNotifier, SharedPayload?>(
+  PendingShareNotifier.new,
+);
+
+class PendingShareNotifier extends Notifier<SharedPayload?> {
+  @override
+  SharedPayload? build() => null;
+
+  void push(SharedPayload payload) {
+    state = payload;
+  }
+
+  /// Returns the current payload (if any) and clears the state in one step.
+  SharedPayload? consume() {
+    final current = state;
+    state = null;
+    return current;
+  }
+}

--- a/lib/features/sharing/data/share_link_listener_provider.dart
+++ b/lib/features/sharing/data/share_link_listener_provider.dart
@@ -1,0 +1,25 @@
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import 'share_route_handler.dart';
+
+final _log = Logger('ShareLinkListener');
+
+/// Subscribes to subsequent app links (mobile only) and forwards any share
+/// URLs to [ShareRouteHandler]. The initial cold-start URL is handled
+/// directly in `main.dart` via `Uri.base`.
+final shareLinkListenerProvider = Provider<void>((ref) {
+  if (kIsWeb) return;
+
+  try {
+    final appLinks = AppLinks();
+    final sub = appLinks.uriLinkStream.listen((uri) {
+      ShareRouteHandler(ref.container).handle(uri);
+    });
+    ref.onDispose(sub.cancel);
+  } catch (e, st) {
+    _log.warning('Failed to subscribe to app links for share URLs', e, st);
+  }
+});

--- a/lib/features/sharing/data/share_route_handler.dart
+++ b/lib/features/sharing/data/share_route_handler.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../../core/sharing/shareable_link_codec.dart';
+import 'pending_share_provider.dart';
+
+/// Decodes incoming share URLs and pushes their payload onto the
+/// [pendingShareProvider] so the map UI can react.
+///
+/// Used in three places:
+///   * Web cold-start: parse `Uri.base` at app startup.
+///   * Mobile cold-start: parse the initial app-link.
+///   * Subsequent links (mobile): from the `app_links` stream.
+class ShareRouteHandler {
+  static final _log = Logger('ShareRouteHandler');
+
+  final ProviderContainer _container;
+  ShareRouteHandler(this._container);
+
+  /// Returns true if [uri] was a share URL that was successfully decoded
+  /// and pushed onto the pending provider.
+  bool handle(Uri uri) {
+    try {
+      final payload = ShareableLinkCodec.decodeShareUrl(uri);
+      if (payload == null) return false;
+      _container.read(pendingShareProvider.notifier).push(payload);
+      return true;
+    } catch (e, st) {
+      _log.warning('Failed to decode share URL: $uri', e, st);
+      return false;
+    }
+  }
+}

--- a/lib/features/sharing/widgets/shared_marker_preview_sheet.dart
+++ b/lib/features/sharing/widgets/shared_marker_preview_sheet.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_button.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/markers/api.dart';
+
+/// Bottom sheet shown when the app opens an incoming `/share/m` link.
+/// Lets the user preview the shared marker and import it into their own
+/// collection.
+class SharedMarkerPreviewSheet extends ConsumerWidget {
+  final Marker marker;
+
+  const SharedMarkerPreviewSheet({super.key, required this.marker});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+    final bottomPadding = mediaQuery.viewInsets.bottom > 0
+        ? mediaQuery.viewInsets.bottom
+        : mediaQuery.padding.bottom;
+
+    final lat = marker.position.latitude.toStringAsFixed(6);
+    final lon = marker.position.longitude.toStringAsFixed(6);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(l10n.sharedMarkerTitle, style: theme.textTheme.titleLarge),
+              IconButton(
+                onPressed: () => Navigator.pop(context),
+                icon: const Icon(Icons.close),
+                tooltip: l10n.close,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(marker.title, style: theme.textTheme.headlineSmall),
+          if (marker.description != null && marker.description!.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(marker.description!, style: theme.textTheme.bodyMedium),
+          ],
+          const SizedBox(height: 12),
+          Text(
+            '$lat, $lon',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 24),
+          AppButton.primary(
+            text: l10n.saveToMyMarkers,
+            icon: Icons.bookmark_add,
+            fullWidth: true,
+            onPressed: () => _save(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save(BuildContext context, WidgetRef ref) async {
+    final l10n = context.l10n;
+    final navigator = Navigator.of(context);
+    // Copy the marker without the shared uuid so the local store assigns a
+    // fresh one — otherwise two recipients of the same share would clash.
+    final fresh = Marker(
+      title: marker.title,
+      description: marker.description,
+      icon: marker.icon,
+      position: marker.position,
+    );
+    await ref.read(locationRepositoryProvider.notifier).addMarker(fresh);
+    if (!context.mounted) return;
+    navigator.pop();
+    AppSnackbars.success(context, l10n.savedToMyMarkers);
+  }
+}

--- a/lib/features/sharing/widgets/shared_path_preview_sheet.dart
+++ b/lib/features/sharing/widgets/shared_path_preview_sheet.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_button.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+import 'package:turbo/features/settings/api.dart';
+
+/// Bottom sheet shown when the app opens an incoming `/share/p` link.
+class SharedPathPreviewSheet extends ConsumerWidget {
+  final SavedPath path;
+
+  const SharedPathPreviewSheet({super.key, required this.path});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final unit = ref.watch(settingsProvider
+        .select((s) => s.value?.distanceUnit ?? DistanceUnit.metric));
+    final mediaQuery = MediaQuery.of(context);
+    final bottomPadding = mediaQuery.viewInsets.bottom > 0
+        ? mediaQuery.viewInsets.bottom
+        : mediaQuery.padding.bottom;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(l10n.sharedPathTitle, style: theme.textTheme.titleLarge),
+              IconButton(
+                onPressed: () => Navigator.pop(context),
+                icon: const Icon(Icons.close),
+                tooltip: l10n.close,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(path.title, style: theme.textTheme.headlineSmall),
+          if (path.description != null && path.description!.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(path.description!, style: theme.textTheme.bodyMedium),
+          ],
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Icon(Icons.straighten,
+                  size: 16, color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: 4),
+              Text(
+                formatDistance(path.distance, unit),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Icon(Icons.scatter_plot,
+                  size: 16, color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: 4),
+              Text(
+                l10n.pointCount(path.points.length),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          AppButton.primary(
+            text: l10n.saveToMyPaths,
+            icon: Icons.bookmark_add,
+            fullWidth: true,
+            onPressed: () => _save(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save(BuildContext context, WidgetRef ref) async {
+    final l10n = context.l10n;
+    final navigator = Navigator.of(context);
+    final fresh = SavedPath(
+      title: path.title,
+      description: path.description,
+      points: path.points,
+      distance: path.distance,
+      colorHex: path.colorHex,
+      iconKey: path.iconKey,
+      smoothing: path.smoothing,
+      lineStyleKey: path.lineStyleKey,
+    );
+    await ref.read(savedPathRepositoryProvider.notifier).addPath(fresh);
+    if (!context.mounted) return;
+    navigator.pop();
+    AppSnackbars.success(context, l10n.savedToMyPaths);
+  }
+}

--- a/lib/features/sharing/widgets/shared_payload_listener.dart
+++ b/lib/features/sharing/widgets/shared_payload_listener.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../core/sharing/shareable_link_codec.dart';
+import '../data/pending_share_provider.dart';
+import 'shared_marker_preview_sheet.dart';
+import 'shared_path_preview_sheet.dart';
+
+/// Watches [pendingShareProvider]; when a payload arrives, opens the
+/// matching preview sheet over the map. Designed to wrap the map page.
+class SharedPayloadListener extends ConsumerStatefulWidget {
+  final Widget child;
+
+  /// Optional hook the host (the map page) can use to recenter the map on
+  /// the shared item before the preview sheet appears.
+  final void Function(LatLng center)? onCenter;
+
+  const SharedPayloadListener({
+    super.key,
+    required this.child,
+    this.onCenter,
+  });
+
+  @override
+  ConsumerState<SharedPayloadListener> createState() =>
+      _SharedPayloadListenerState();
+}
+
+class _SharedPayloadListenerState
+    extends ConsumerState<SharedPayloadListener> {
+  @override
+  void initState() {
+    super.initState();
+    // Drain any payload that arrived before the listener mounted (cold-start).
+    WidgetsBinding.instance.addPostFrameCallback((_) => _drain());
+  }
+
+  void _drain() {
+    final payload =
+        ref.read(pendingShareProvider.notifier).consume();
+    if (payload != null) _openSheet(payload);
+  }
+
+  void _openSheet(SharedPayload payload) {
+    if (!mounted) return;
+    final center = switch (payload) {
+      SharedMarkerPayload(:final marker) => marker.position,
+      SharedPathPayload(:final path) =>
+        path.points.isEmpty ? null : path.bounds.center,
+    };
+    if (center != null) widget.onCenter?.call(center);
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => switch (payload) {
+        SharedMarkerPayload(:final marker) =>
+          SharedMarkerPreviewSheet(marker: marker),
+        SharedPathPayload(:final path) =>
+          SharedPathPreviewSheet(path: path),
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Subsequent payloads (mobile deep links while app is open).
+    ref.listen<SharedPayload?>(pendingShareProvider, (prev, next) {
+      if (next != null) {
+        // consume to clear the state before opening so re-listens don't
+        // re-trigger.
+        final taken = ref.read(pendingShareProvider.notifier).consume();
+        if (taken != null) _openSheet(taken);
+      }
+    });
+
+    return widget.child;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  archive:
+    dependency: "direct main"
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -1021,6 +1029,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   proj4dart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
   image_picker: ^1.1.2
   logging: ^1.3.0
   connectivity_plus: ^6.1.4
+  archive: ^4.0.7
 
 dev_dependencies:
   flutter_test:

--- a/test/core/config/env_config_test.dart
+++ b/test/core/config/env_config_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:turbo/core/config/env_config.dart';
+
+void main() {
+  group('EnvironmentConfig.webBaseUrl', () {
+    test('returns a non-empty URL', () {
+      expect(EnvironmentConfig.webBaseUrl, isNotEmpty);
+    });
+
+    test('returns an https URL in production', () {
+      // The test environment runs as development; we still expect both
+      // branches of the getter to produce a parsable absolute URL.
+      final uri = Uri.parse(EnvironmentConfig.webBaseUrl);
+      expect(uri.hasScheme, isTrue);
+      expect(uri.host, isNotEmpty);
+    });
+  });
+}

--- a/test/core/sharing/shareable_link_codec_test.dart
+++ b/test/core/sharing/shareable_link_codec_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/sharing/shareable_link_codec.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+
+const _base = 'https://example.test';
+
+Marker _marker({
+  String title = 'Trolltunga',
+  String? description = 'A cliff in Norway',
+  String? icon = 'mountain',
+  LatLng? position,
+}) {
+  return Marker(
+    uuid: 'm-uuid',
+    title: title,
+    description: description,
+    icon: icon,
+    position: position ?? const LatLng(60.124123, 6.740456),
+  );
+}
+
+SavedPath _path({
+  int points = 3,
+  String title = 'Hike',
+  String? description = 'A long walk',
+  String? colorHex = '#ff5500',
+  String? iconKey = 'flag',
+  bool smoothing = true,
+  String? lineStyleKey = 'dashed',
+}) {
+  final pts = <LatLng>[
+    for (var i = 0; i < points; i++)
+      LatLng(60.0 + i * 0.0001, 10.0 + i * 0.0001),
+  ];
+  return SavedPath(
+    uuid: 'p-uuid',
+    title: title,
+    description: description,
+    points: pts,
+    distance: 1234.5,
+    createdAt: DateTime.utc(2025, 5, 1, 12),
+    colorHex: colorHex,
+    iconKey: iconKey,
+    smoothing: smoothing,
+    lineStyleKey: lineStyleKey,
+  );
+}
+
+void main() {
+  group('encodeMarker / decodeShareUrl', () {
+    test('round-trips a marker with all fields', () {
+      final marker = _marker();
+      final url = ShareableLinkCodec.encodeMarker(marker, _base);
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+
+      expect(decoded, isA<SharedMarkerPayload>());
+      final m = (decoded as SharedMarkerPayload).marker;
+      expect(m.title, marker.title);
+      expect(m.description, marker.description);
+      expect(m.icon, marker.icon);
+      expect(m.position.latitude, closeTo(marker.position.latitude, 1e-5));
+      expect(m.position.longitude, closeTo(marker.position.longitude, 1e-5));
+    });
+
+    test('round-trips a marker with only required fields', () {
+      final marker = _marker(description: null, icon: null);
+      final url = ShareableLinkCodec.encodeMarker(marker, _base);
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+      final m = (decoded as SharedMarkerPayload).marker;
+
+      expect(m.title, marker.title);
+      expect(m.description, isNull);
+      expect(m.icon, isNull);
+    });
+
+    test('produces a URL pointing at the configured base /share/m', () {
+      final url = ShareableLinkCodec.encodeMarker(_marker(), _base);
+      final uri = Uri.parse(url);
+
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'example.test');
+      expect(uri.path, '/share/m');
+      expect(uri.queryParameters['d'], isNotNull);
+      expect(uri.queryParameters['d'], isNotEmpty);
+    });
+
+    test('uses URL-safe base64 (no +, /, or = in payload)', () {
+      // Force a payload that's likely to need padding by varying lengths.
+      for (var i = 1; i < 30; i++) {
+        final url = ShareableLinkCodec.encodeMarker(
+          _marker(title: 'x' * i),
+          _base,
+        );
+        final d = Uri.parse(url).queryParameters['d']!;
+        expect(d.contains('+'), isFalse, reason: 'contains + in $d');
+        expect(d.contains('/'), isFalse, reason: 'contains / in $d');
+        expect(d.contains('='), isFalse, reason: 'contains = in $d');
+      }
+    });
+  });
+
+  group('encodePath / decodeShareUrl', () {
+    test('round-trips a path with all fields', () {
+      final path = _path(points: 5);
+      final url = ShareableLinkCodec.encodePath(path, _base);
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+
+      expect(decoded, isA<SharedPathPayload>());
+      final p = (decoded as SharedPathPayload).path;
+      expect(p.title, path.title);
+      expect(p.description, path.description);
+      expect(p.colorHex, path.colorHex);
+      expect(p.iconKey, path.iconKey);
+      expect(p.smoothing, path.smoothing);
+      expect(p.lineStyleKey, path.lineStyleKey);
+      expect(p.points.length, path.points.length);
+      for (var i = 0; i < path.points.length; i++) {
+        expect(p.points[i].latitude,
+            closeTo(path.points[i].latitude, 1e-5));
+        expect(p.points[i].longitude,
+            closeTo(path.points[i].longitude, 1e-5));
+      }
+    });
+
+    test('round-trips a path with only required fields', () {
+      final path = _path(
+        description: null,
+        colorHex: null,
+        iconKey: null,
+        smoothing: false,
+        lineStyleKey: null,
+      );
+      final url = ShareableLinkCodec.encodePath(path, _base);
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+      final p = (decoded as SharedPathPayload).path;
+
+      expect(p.description, isNull);
+      expect(p.colorHex, isNull);
+      expect(p.iconKey, isNull);
+      expect(p.smoothing, isFalse);
+      expect(p.lineStyleKey, isNull);
+    });
+
+    test('produces a URL pointing at the configured base /share/p', () {
+      final url = ShareableLinkCodec.encodePath(_path(), _base);
+      final uri = Uri.parse(url);
+
+      expect(uri.path, '/share/p');
+      expect(uri.queryParameters['d'], isNotEmpty);
+    });
+
+    test('throws LinkTooLargeException for very large paths', () {
+      final huge = _path(points: 100000);
+      expect(
+        () => ShareableLinkCodec.encodePath(huge, _base),
+        throwsA(isA<LinkTooLargeException>()),
+      );
+    });
+
+    test('handles a base URL with a trailing slash', () {
+      final url = ShareableLinkCodec.encodeMarker(
+        _marker(),
+        'https://example.test/',
+      );
+      expect(Uri.parse(url).path, '/share/m');
+    });
+
+    test('handles a base URL with a path prefix', () {
+      final url = ShareableLinkCodec.encodeMarker(
+        _marker(),
+        'https://example.test/app',
+      );
+      expect(Uri.parse(url).path, '/app/share/m');
+    });
+  });
+
+  group('decodeShareUrl error cases', () {
+    test('returns null for an unrelated path', () {
+      final result = ShareableLinkCodec.decodeShareUrl(
+        Uri.parse('https://example.test/login'),
+      );
+      expect(result, isNull);
+    });
+
+    test('throws for /share/m with a missing data parameter', () {
+      expect(
+        () => ShareableLinkCodec.decodeShareUrl(
+          Uri.parse('https://example.test/share/m'),
+        ),
+        throwsA(isA<InvalidShareLinkException>()),
+      );
+    });
+
+    test('throws for /share/p with corrupt base64 data', () {
+      expect(
+        () => ShareableLinkCodec.decodeShareUrl(
+          Uri.parse('https://example.test/share/p?d=not-base64!!!'),
+        ),
+        throwsA(isA<InvalidShareLinkException>()),
+      );
+    });
+
+    test('throws for an unknown payload version', () {
+      // Hand-craft a payload with v: 99 to confirm forward-compat handling.
+      final url = ShareableLinkCodec.encodeMarker(_marker(), _base);
+      final goodData = Uri.parse(url).queryParameters['d']!;
+      // Build a fake URL with the wrong path style won't trigger this; we
+      // instead exercise the version check via the test-only helper.
+      expect(
+        () => ShareableLinkCodec.decodeRawPayload(goodData, kind: 'm',
+            overrideVersionForTest: 99),
+        throwsA(isA<UnsupportedShareVersionException>()),
+      );
+    });
+  });
+}

--- a/test/features/markers/marker_export_options_sheet_test.dart
+++ b/test/features/markers/marker_export_options_sheet_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/sharing/api.dart';
+import 'package:turbo/features/markers/api.dart';
+
+Marker _marker() => Marker(
+      uuid: 'm1',
+      title: 'Cabin',
+      description: 'In the woods',
+      position: const LatLng(60.5, 10.5),
+    );
+
+Future<void> _openSheet(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        webBaseUrlProvider.overrideWithValue('https://example.test'),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                child: const Text('open'),
+                onPressed: () => showModalBottomSheet(
+                  context: ctx,
+                  builder: (_) => MarkerExportOptionsSheet(marker: _marker()),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('shows a "Share as link" row instead of text', (tester) async {
+    await _openSheet(tester);
+    expect(find.text('Share as link'), findsOneWidget);
+    expect(find.text('Share as text'), findsNothing);
+  });
+
+  testWidgets('does not show the GeoJSON row', (tester) async {
+    await _openSheet(tester);
+    expect(find.text('GeoJSON'), findsNothing);
+  });
+
+  testWidgets(
+    'tapping share copies the link to clipboard and closes the sheet',
+    (tester) async {
+      String? clipboardText;
+
+      // Intercept clipboard writes; the system channel is otherwise a no-op
+      // in tests.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardText =
+              (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      await _openSheet(tester);
+      await tester.tap(find.byIcon(Icons.share));
+      // share_plus opens a system sheet that is a no-op in tests; pump
+      // settles whatever async work the handler kicked off.
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, startsWith('https://example.test/share/m'));
+    },
+  );
+}

--- a/test/features/markers/marker_export_service_test.dart
+++ b/test/features/markers/marker_export_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/sharing/shareable_link_codec.dart';
+import 'package:turbo/features/markers/data/marker_export_service.dart';
+import 'package:turbo/features/markers/models/marker.dart';
+
+Marker _marker({String title = 'Cabin', String? description = 'In the woods'}) =>
+    Marker(
+      uuid: 'm1',
+      title: title,
+      description: description,
+      icon: 'home',
+      position: const LatLng(60.5, 10.5),
+    );
+
+void main() {
+  group('MarkerExportService.buildShareLink', () {
+    const base = 'https://example.test';
+    final service = MarkerExportService();
+
+    test('produces a /share/m URL that round-trips through the codec', () {
+      final marker = _marker();
+      final url = service.buildShareLink(marker, base);
+
+      expect(url, startsWith('$base/share/m'));
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+      expect(decoded, isA<SharedMarkerPayload>());
+      expect((decoded as SharedMarkerPayload).marker.title, 'Cabin');
+    });
+
+    test('preserves description and icon in the encoded payload', () {
+      final url = service.buildShareLink(_marker(), base);
+      final m = (ShareableLinkCodec.decodeShareUrl(Uri.parse(url))
+              as SharedMarkerPayload)
+          .marker;
+      expect(m.description, 'In the woods');
+      expect(m.icon, 'home');
+    });
+  });
+}

--- a/test/features/saved_paths/path_export_test.dart
+++ b/test/features/saved_paths/path_export_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/sharing/shareable_link_codec.dart';
 import 'package:turbo/features/saved_paths/data/gpx_serializer.dart';
 import 'package:turbo/features/saved_paths/data/geojson_serializer.dart';
 import 'package:turbo/features/saved_paths/data/path_export_service.dart';
@@ -209,6 +210,33 @@ void main() {
 
       final geoJson = service.serialize(path, ExportFormat.geoJson);
       expect(geoJson, contains('FeatureCollection'));
+    });
+  });
+
+  group('PathExportService.buildShareLink', () {
+    const base = 'https://example.test';
+    final service = PathExportService();
+
+    test('produces a /share/p URL that round-trips through the codec', () {
+      final path = _makePath(title: 'Loop');
+      final url = service.buildShareLink(path, base);
+
+      expect(url, startsWith('$base/share/p'));
+      final decoded = ShareableLinkCodec.decodeShareUrl(Uri.parse(url));
+      expect(decoded, isA<SharedPathPayload>());
+      expect((decoded as SharedPathPayload).path.title, 'Loop');
+    });
+
+    test('preserves point list in the encoded payload', () {
+      final pts = List<LatLng>.generate(
+        20,
+        (i) => LatLng(60.0 + i * 0.001, 10.0 + i * 0.001),
+      );
+      final url = service.buildShareLink(_makePath(points: pts), base);
+      final p = (ShareableLinkCodec.decodeShareUrl(Uri.parse(url))
+              as SharedPathPayload)
+          .path;
+      expect(p.points.length, pts.length);
     });
   });
 }

--- a/test/features/sharing/pending_share_provider_test.dart
+++ b/test/features/sharing/pending_share_provider_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/sharing/api.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/sharing/api.dart';
+
+void main() {
+  group('pendingShareProvider', () {
+    test('starts as null', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(pendingShareProvider), isNull);
+    });
+
+    test('push() stores the payload', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final payload = SharedMarkerPayload(Marker(
+        title: 'X',
+        position: const LatLng(60, 10),
+      ));
+      container.read(pendingShareProvider.notifier).push(payload);
+
+      expect(container.read(pendingShareProvider), same(payload));
+    });
+
+    test('consume() returns and clears the payload', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final payload = SharedMarkerPayload(Marker(
+        title: 'X',
+        position: const LatLng(60, 10),
+      ));
+      final notifier = container.read(pendingShareProvider.notifier);
+      notifier.push(payload);
+
+      expect(notifier.consume(), same(payload));
+      expect(container.read(pendingShareProvider), isNull);
+      expect(notifier.consume(), isNull);
+    });
+  });
+}

--- a/test/features/sharing/share_route_handler_test.dart
+++ b/test/features/sharing/share_route_handler_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/sharing/api.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+import 'package:turbo/features/sharing/api.dart';
+
+const _base = 'https://example.test';
+
+ProviderContainer _container() {
+  final c = ProviderContainer();
+  addTearDown(c.dispose);
+  return c;
+}
+
+void main() {
+  group('ShareRouteHandler.handle', () {
+    test('decodes a marker URL and pushes it to pendingShareProvider', () {
+      final container = _container();
+      final url = ShareableLinkCodec.encodeMarker(
+        Marker(title: 'X', position: const LatLng(60, 10)),
+        _base,
+      );
+      final handled = ShareRouteHandler(container)
+          .handle(Uri.parse(url));
+
+      expect(handled, isTrue);
+      final pending = container.read(pendingShareProvider);
+      expect(pending, isA<SharedMarkerPayload>());
+      expect((pending as SharedMarkerPayload).marker.title, 'X');
+    });
+
+    test('decodes a path URL and pushes it to pendingShareProvider', () {
+      final container = _container();
+      final url = ShareableLinkCodec.encodePath(
+        SavedPath(
+          title: 'P',
+          points: const [LatLng(60, 10), LatLng(60.1, 10.1)],
+          distance: 1,
+        ),
+        _base,
+      );
+      final handled = ShareRouteHandler(container)
+          .handle(Uri.parse(url));
+
+      expect(handled, isTrue);
+      expect(container.read(pendingShareProvider), isA<SharedPathPayload>());
+    });
+
+    test('returns false and leaves state untouched for unrelated URLs', () {
+      final container = _container();
+      final handled = ShareRouteHandler(container)
+          .handle(Uri.parse('https://example.test/login'));
+
+      expect(handled, isFalse);
+      expect(container.read(pendingShareProvider), isNull);
+    });
+
+    test('swallows invalid share URLs (logs but does not throw)', () {
+      final container = _container();
+      final handled = ShareRouteHandler(container)
+          .handle(Uri.parse('https://example.test/share/m?d=corrupt!'));
+
+      expect(handled, isFalse);
+      expect(container.read(pendingShareProvider), isNull);
+    });
+  });
+}

--- a/test/features/sharing/shared_marker_preview_sheet_test.dart
+++ b/test/features/sharing/shared_marker_preview_sheet_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/sharing/widgets/shared_marker_preview_sheet.dart';
+
+class _FakeRepo extends LocationRepository {
+  final List<Marker> added = [];
+
+  @override
+  AsyncValue<List<Marker>> build() => const AsyncData([]);
+
+  @override
+  Future<void> addMarker(Marker marker) async {
+    added.add(marker);
+  }
+}
+
+Marker _marker({
+  String title = 'Cabin',
+  String? description = 'A nice spot',
+}) =>
+    Marker(
+      uuid: 'shared-uuid',
+      title: title,
+      description: description,
+      icon: 'home',
+      position: const LatLng(60.5, 10.5),
+    );
+
+Future<_FakeRepo> _pump(WidgetTester tester, {Marker? marker}) async {
+  final repo = _FakeRepo();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        locationRepositoryProvider.overrideWith(() => repo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SharedMarkerPreviewSheet(marker: marker ?? _marker()),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return repo;
+}
+
+void main() {
+  testWidgets('renders the title and description of the shared marker',
+      (tester) async {
+    await _pump(tester);
+    expect(find.text('Cabin'), findsOneWidget);
+    expect(find.text('A nice spot'), findsOneWidget);
+  });
+
+  testWidgets('renders coordinates', (tester) async {
+    await _pump(tester);
+    expect(find.textContaining('60.5'), findsWidgets);
+    expect(find.textContaining('10.5'), findsWidgets);
+  });
+
+  testWidgets('Save action calls addMarker on the repository',
+      (tester) async {
+    final repo = await _pump(tester);
+
+    await tester.tap(find.text('Save to my markers'));
+    await tester.pumpAndSettle();
+
+    expect(repo.added, hasLength(1));
+    expect(repo.added.single.title, 'Cabin');
+    expect(repo.added.single.uuid, isNot('shared-uuid'),
+        reason:
+            'Imported marker should get a fresh local UUID to avoid collisions');
+  });
+}

--- a/test/features/sharing/shared_path_preview_sheet_test.dart
+++ b/test/features/sharing/shared_path_preview_sheet_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+import 'package:turbo/features/sharing/widgets/shared_path_preview_sheet.dart';
+
+class _FakeRepo extends SavedPathRepository {
+  final List<SavedPath> added = [];
+
+  @override
+  AsyncValue<List<SavedPath>> build() => const AsyncData([]);
+
+  @override
+  Future<void> addPath(SavedPath path) async {
+    added.add(path);
+  }
+}
+
+SavedPath _path() => SavedPath(
+      uuid: 'shared-uuid',
+      title: 'Loop',
+      description: 'Round trip',
+      points: const [
+        LatLng(60.0, 10.0),
+        LatLng(60.1, 10.1),
+        LatLng(60.2, 10.2),
+      ],
+      distance: 25000,
+    );
+
+Future<_FakeRepo> _pump(WidgetTester tester) async {
+  final repo = _FakeRepo();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        savedPathRepositoryProvider.overrideWith(() => repo),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SharedPathPreviewSheet(path: _path()),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return repo;
+}
+
+void main() {
+  testWidgets('renders title, description and point count', (tester) async {
+    await _pump(tester);
+    expect(find.text('Loop'), findsOneWidget);
+    expect(find.text('Round trip'), findsOneWidget);
+    expect(find.textContaining('3'), findsWidgets); // point count
+  });
+
+  testWidgets('Save action calls addPath on the repository', (tester) async {
+    final repo = await _pump(tester);
+
+    await tester.tap(find.text('Save to my routes'));
+    await tester.pumpAndSettle();
+
+    expect(repo.added, hasLength(1));
+    expect(repo.added.single.title, 'Loop');
+    expect(repo.added.single.uuid, isNot('shared-uuid'),
+        reason: 'Imported path should get a fresh local UUID');
+  });
+}

--- a/test/features/sharing/shared_payload_listener_test.dart
+++ b/test/features/sharing/shared_payload_listener_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/sharing/api.dart';
+import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/saved_paths/api.dart';
+import 'package:turbo/features/sharing/api.dart';
+
+class _NoopMarkerRepo extends LocationRepository {
+  @override
+  AsyncValue<List<Marker>> build() => const AsyncData([]);
+  @override
+  Future<void> addMarker(Marker marker) async {}
+}
+
+class _NoopPathRepo extends SavedPathRepository {
+  @override
+  AsyncValue<List<SavedPath>> build() => const AsyncData([]);
+  @override
+  Future<void> addPath(SavedPath path) async {}
+}
+
+Widget _scaffold(Widget child, ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: SharedPayloadListener(
+        child: Scaffold(body: child),
+      ),
+    ),
+  );
+}
+
+ProviderContainer _container() {
+  final c = ProviderContainer(overrides: [
+    locationRepositoryProvider.overrideWith(_NoopMarkerRepo.new),
+    savedPathRepositoryProvider.overrideWith(_NoopPathRepo.new),
+  ]);
+  addTearDown(c.dispose);
+  return c;
+}
+
+void main() {
+  testWidgets(
+      'opens marker preview when a marker payload was queued before mount',
+      (tester) async {
+    final container = _container();
+    container.read(pendingShareProvider.notifier).push(
+          SharedMarkerPayload(Marker(
+            title: 'Hut',
+            position: const LatLng(60, 10),
+          )),
+        );
+
+    await tester.pumpWidget(_scaffold(const Text('home'), container));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SharedMarkerPreviewSheet), findsOneWidget);
+    expect(find.text('Hut'), findsOneWidget);
+  });
+
+  testWidgets('opens path preview when a path payload arrives after mount',
+      (tester) async {
+    final container = _container();
+    await tester.pumpWidget(_scaffold(const Text('home'), container));
+    await tester.pumpAndSettle();
+
+    container.read(pendingShareProvider.notifier).push(
+          SharedPathPayload(SavedPath(
+            title: 'Loop',
+            points: const [LatLng(60, 10), LatLng(60.1, 10.1)],
+            distance: 100,
+          )),
+        );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SharedPathPreviewSheet), findsOneWidget);
+    expect(find.text('Loop'), findsOneWidget);
+  });
+
+  testWidgets('clears the pending payload after consuming it',
+      (tester) async {
+    final container = _container();
+    container.read(pendingShareProvider.notifier).push(
+          SharedMarkerPayload(Marker(
+            title: 'X',
+            position: const LatLng(60, 10),
+          )),
+        );
+
+    await tester.pumpWidget(_scaffold(const Text('home'), container));
+    await tester.pumpAndSettle();
+
+    expect(container.read(pendingShareProvider), isNull);
+  });
+}


### PR DESCRIPTION
Introduce ShareableLinkCodec (gzip + base64url) producing /share/m and
/share/p URLs pointing at the configured Flutter-web frontend. Replace
"Share as text" on markers with "Share as link", and add the same
option alongside GPX on routes. The codec round-trips all marker and
saved-path fields and refuses to build URLs that would exceed 8000
chars so very large routes are steered toward GPX export instead.

https://claude.ai/code/session_01RFyCoKrv9Fx9fxrLsea14G