### PR TITLE
test: e2e user flow for the offline-map download Start button

### DIFF
--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -342,6 +342,7 @@ abstract class AppLocalizations {
   // Offline Maps
   String get offlineMaps;
   String get noOfflineMapsDownloaded;
+  String get offlineMapsNotAvailableOnWebTitle;
   String get offlineMapsNotAvailableOnWeb;
   String get addOfflineRegion;
   String get errorLoadingOfflineRegions;
@@ -686,7 +687,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override String get offlineMaps => 'Offline Maps';
   @override String get noOfflineMapsDownloaded => 'No maps downloaded yet.\nTap the button below to download an area.';
-  @override String get offlineMapsNotAvailableOnWeb => 'Offline maps are not available on web yet. Use the desktop or mobile app to download tiles.';
+  @override String get offlineMapsNotAvailableOnWebTitle => 'Not available in the browser';
+  @override String get offlineMapsNotAvailableOnWeb => 'Downloading map tiles for offline use needs the desktop or mobile app. The browser version can\'t persist tiles locally.';
   @override String get addOfflineRegion => 'Add offline region';
   @override String get errorLoadingOfflineRegions => 'Could not load offline regions. Pull to refresh, or try again later.';
   @override String get manage => 'Manage';
@@ -1027,7 +1029,8 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override String get offlineMaps => 'Offline-kart';
   @override String get noOfflineMapsDownloaded => 'Ingen kart lastet ned ennå.\nTrykk på knappen under for å laste ned et område.';
-  @override String get offlineMapsNotAvailableOnWeb => 'Offline-kart er ikke tilgjengelig på web ennå. Bruk desktop- eller mobilappen for å laste ned ruter.';
+  @override String get offlineMapsNotAvailableOnWebTitle => 'Ikke tilgjengelig i nettleseren';
+  @override String get offlineMapsNotAvailableOnWeb => 'Nedlasting av kart for offline bruk krever desktop- eller mobilappen. Nettleserversjonen kan ikke lagre kartdata lokalt.';
   @override String get addOfflineRegion => 'Legg til offline-område';
   @override String get errorLoadingOfflineRegions => 'Kunne ikke laste offline-områder. Dra ned for å oppdatere, eller prøv igjen senere.';
   @override String get manage => 'Administrer';

--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -342,6 +342,7 @@ abstract class AppLocalizations {
   // Offline Maps
   String get offlineMaps;
   String get noOfflineMapsDownloaded;
+  String get offlineMapsNotAvailableOnWeb;
   String get addOfflineRegion;
   String get errorLoadingOfflineRegions;
   String get manage;
@@ -685,6 +686,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override String get offlineMaps => 'Offline Maps';
   @override String get noOfflineMapsDownloaded => 'No maps downloaded yet.\nTap the button below to download an area.';
+  @override String get offlineMapsNotAvailableOnWeb => 'Offline maps are not available on web yet. Use the desktop or mobile app to download tiles.';
   @override String get addOfflineRegion => 'Add offline region';
   @override String get errorLoadingOfflineRegions => 'Could not load offline regions. Pull to refresh, or try again later.';
   @override String get manage => 'Manage';
@@ -1025,6 +1027,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override String get offlineMaps => 'Offline-kart';
   @override String get noOfflineMapsDownloaded => 'Ingen kart lastet ned ennå.\nTrykk på knappen under for å laste ned et område.';
+  @override String get offlineMapsNotAvailableOnWeb => 'Offline-kart er ikke tilgjengelig på web ennå. Bruk desktop- eller mobilappen for å laste ned ruter.';
   @override String get addOfflineRegion => 'Legg til offline-område';
   @override String get errorLoadingOfflineRegions => 'Kunne ikke laste offline-områder. Dra ned for å oppdatere, eller prøv igjen senere.';
   @override String get manage => 'Administrer';

--- a/lib/features/tile_storage/offline_regions/data/offline_regions_notifier.dart
+++ b/lib/features/tile_storage/offline_regions/data/offline_regions_notifier.dart
@@ -31,7 +31,15 @@ class OfflineRegionsNotifier extends AsyncNotifier<List<OfflineRegion>> {
     return repo.getAllRegions();
   }
 
-  Future<void> createRegion({
+  /// Persists a new offline region and enqueues its tile jobs.
+  ///
+  /// Returns `true` when the region was scheduled, `false` when the platform
+  /// cannot run the offline download pipeline (currently web, which has no
+  /// sqflite database or filesystem to back the tile store / job queue).
+  /// Returns `false` for a degenerate bounds × zoom range that yields zero
+  /// tiles. Callers can use the result to surface user-facing feedback
+  /// instead of silently popping back to the root.
+  Future<bool> createRegion({
     required String name,
     required LatLngBounds bounds,
     required int minZoom,
@@ -40,10 +48,10 @@ class OfflineRegionsNotifier extends AsyncNotifier<List<OfflineRegion>> {
     required String tileProviderId,
     required String tileProviderName,
   }) async {
-    if (kIsWeb) return;
+    if (kIsWeb) return false;
 
     final coords = _calculateCoordsForRegion(bounds, minZoom, maxZoom);
-    if (coords.isEmpty) return;
+    if (coords.isEmpty) return false;
 
     final repo = await ref.read(regionRepositoryProvider.future);
     final jobQueue = await ref.read(tileJobQueueProvider.future);
@@ -79,6 +87,7 @@ class OfflineRegionsNotifier extends AsyncNotifier<List<OfflineRegion>> {
       );
     }).toList();
     await jobQueue.enqueueJobs(jobs);
+    return true;
   }
 
   Future<void> deleteRegion(String regionId) async {

--- a/lib/features/tile_storage/offline_regions/widgets/download_details_sheet.dart
+++ b/lib/features/tile_storage/offline_regions/widgets/download_details_sheet.dart
@@ -115,18 +115,26 @@ class _DownloadDetailsSheetState extends ConsumerState<DownloadDetailsSheet> {
     ref.read(tileRegistryProvider).availableProviders[_selectedProviderId!];
     if (provider == null) return;
 
-    // No need to await, the process runs in the background.
-    ref.read(offline_api.offlineRegionsProvider.notifier).createRegion(
-      name: _nameController.text.trim(),
-      bounds: widget.bounds,
-      minZoom: _zoomRange.start.round(),
-      maxZoom: _zoomRange.end.round(),
-      urlTemplate: provider.urlTemplate,
-      tileProviderId: provider.id,
-      tileProviderName: provider.name(context),
-    );
+    final scheduled =
+        await ref.read(offline_api.offlineRegionsProvider.notifier).createRegion(
+              name: _nameController.text.trim(),
+              bounds: widget.bounds,
+              minZoom: _zoomRange.start.round(),
+              maxZoom: _zoomRange.end.round(),
+              urlTemplate: provider.urlTemplate,
+              tileProviderId: provider.id,
+              tileProviderName: provider.name(context),
+            );
 
     if (!mounted) return;
+    if (!scheduled) {
+      // The platform refused the download (web has no local tile store) —
+      // tell the user instead of silently popping back to the root.
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.offlineMapsNotAvailableOnWeb)),
+      );
+      return;
+    }
     Navigator.of(context).popUntil((route) => route.isFirst);
   }
 

--- a/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
+++ b/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
@@ -18,18 +18,40 @@ class OfflineRegionsPage extends ConsumerWidget {
     final offlineRegionsAsync = ref.watch(offlineRegionsProvider);
 
     if (kIsWeb) {
+      final colorScheme = Theme.of(context).colorScheme;
+      final textTheme = Theme.of(context).textTheme;
       return Scaffold(
         appBar: AppBar(title: Text(l10n.offlineMaps)),
         body: Center(
           child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.l),
-            child: Text(
-              l10n.offlineMapsNotAvailableOnWeb,
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    height: 1.5,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              key: const Key('offline_regions_web_unavailable'),
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.cloud_off_outlined,
+                  size: 56,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(height: AppSpacing.l),
+                Text(
+                  l10n.offlineMapsNotAvailableOnWebTitle,
+                  textAlign: TextAlign.center,
+                  style: textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
                   ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                Text(
+                  l10n.offlineMapsNotAvailableOnWeb,
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyMedium?.copyWith(
+                    height: 1.45,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
+++ b/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -15,6 +16,25 @@ class OfflineRegionsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final offlineRegionsAsync = ref.watch(offlineRegionsProvider);
+
+    if (kIsWeb) {
+      return Scaffold(
+        appBar: AppBar(title: Text(l10n.offlineMaps)),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.l),
+            child: Text(
+              l10n.offlineMapsNotAvailableOnWeb,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    height: 1.5,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/test/features/tile_storage/offline_regions/download_details_sheet_test.dart
+++ b/test/features/tile_storage/offline_regions/download_details_sheet_test.dart
@@ -169,8 +169,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       // The user sees a snackbar explaining why nothing started.
-      expect(find.textContaining('Offline maps are not available on web'),
-          findsOneWidget);
+      expect(find.textContaining('desktop or mobile app'), findsOneWidget);
       // And the sheet stays open so the choices the user made aren't lost.
       expect(find.byType(DownloadDetailsSheet), findsOneWidget);
     });

--- a/test/features/tile_storage/offline_regions/download_details_sheet_test.dart
+++ b/test/features/tile_storage/offline_regions/download_details_sheet_test.dart
@@ -50,12 +50,13 @@ class _FakeOfflineNotifier extends OfflineRegionsNotifier {
   int createCallCount = 0;
   String? lastName;
   String? lastProviderId;
+  bool createRegionReturns = true;
 
   @override
   Future<List<OfflineRegion>> build() async => const [];
 
   @override
-  Future<void> createRegion({
+  Future<bool> createRegion({
     required String name,
     required LatLngBounds bounds,
     required int minZoom,
@@ -67,6 +68,7 @@ class _FakeOfflineNotifier extends OfflineRegionsNotifier {
     createCallCount++;
     lastName = name;
     lastProviderId = tileProviderId;
+    return createRegionReturns;
   }
 }
 
@@ -150,6 +152,27 @@ void main() {
       expect(notifier.createCallCount, 1);
       expect(notifier.lastName, 'Trondheim local');
       expect(notifier.lastProviderId, 'osm');
+    });
+
+    testWidgets(
+        'when createRegion reports the platform cannot start a download '
+        '(the kIsWeb branch in OfflineRegionsNotifier), the sheet surfaces '
+        'a snackbar instead of silently popping to the root',
+        (tester) async {
+      final notifier = await _openSheet(tester);
+      notifier.createRegionReturns = false;
+
+      await tester.enterText(find.byType(TextFormField), 'My region');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Start Download'));
+      await tester.pump(); // start the snackbar's enter animation
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The user sees a snackbar explaining why nothing started.
+      expect(find.textContaining('Offline maps are not available on web'),
+          findsOneWidget);
+      // And the sheet stays open so the choices the user made aren't lost.
+      expect(find.byType(DownloadDetailsSheet), findsOneWidget);
     });
   });
 }

--- a/test/features/tile_storage/offline_regions/offline_download_user_flow_test.dart
+++ b/test/features/tile_storage/offline_regions/offline_download_user_flow_test.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/data/database_provider.dart';
+import 'package:turbo/core/service/logger.dart';
+import 'package:turbo/features/tile_providers/api.dart';
+import 'package:turbo/features/tile_providers/data/tile_registry.dart';
+import 'package:turbo/features/tile_storage/offline_regions/api.dart';
+import 'package:turbo/features/tile_storage/offline_regions/data/region_repository.dart';
+import 'package:turbo/features/tile_storage/offline_regions/data/tile_job_queue.dart';
+import 'package:turbo/features/tile_storage/offline_regions/widgets/download_details_sheet.dart';
+import 'package:turbo/features/tile_storage/tile_store/api.dart';
+
+class _ServerBackedProvider extends TileProviderConfig {
+  _ServerBackedProvider(this.urlTemplate);
+  @override
+  final String urlTemplate;
+  @override
+  String get id => 'test_provider';
+  @override
+  String name(BuildContext context) => 'Test Tiles';
+  @override
+  String description(BuildContext context) => '';
+  @override
+  String get attributions => 'Test';
+  @override
+  TileProviderCategory get category => TileProviderCategory.global;
+  @override
+  double get minZoom => 1;
+  @override
+  double get maxZoom => 2;
+}
+
+class _FakeRegistry extends TileRegistry {
+  _FakeRegistry(this._urlTemplate);
+  final String _urlTemplate;
+
+  @override
+  TileRegistryState build() {
+    final pcfg = _ServerBackedProvider(_urlTemplate);
+    return TileRegistryState(
+      availableProviders: {pcfg.id: pcfg},
+      activeGlobalIds: [pcfg.id],
+      activeLocalIds: const [],
+      activeOverlayIds: const [],
+      activeOfflineIds: const [],
+    );
+  }
+}
+
+Future<void> _createSchema(Database db, int _) async {
+  final batch = db.batch();
+  batch.execute('''
+    CREATE TABLE offline_regions(
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, minLat REAL NOT NULL,
+      minLng REAL NOT NULL, maxLat REAL NOT NULL, maxLng REAL NOT NULL,
+      minZoom INTEGER NOT NULL, maxZoom INTEGER NOT NULL,
+      urlTemplate TEXT NOT NULL, tileProviderId TEXT NOT NULL,
+      tileProviderName TEXT NOT NULL, status INTEGER NOT NULL,
+      totalTiles INTEGER NOT NULL, downloadedTiles INTEGER NOT NULL,
+      createdAt TEXT NOT NULL
+    )
+  ''');
+  batch.execute('''
+    CREATE TABLE tile_jobs(
+      regionId TEXT NOT NULL, providerId TEXT NOT NULL, z INTEGER NOT NULL,
+      x INTEGER NOT NULL, y INTEGER NOT NULL, url TEXT NOT NULL,
+      status INTEGER NOT NULL, attemptCount INTEGER NOT NULL DEFAULT 0,
+      workerId TEXT, startedAt TEXT, PRIMARY KEY (regionId, z, x, y)
+    )
+  ''');
+  batch.execute('CREATE INDEX idx_job_status ON tile_jobs (status)');
+  batch.execute('''
+    CREATE TABLE tile_store(
+      providerId TEXT NOT NULL, z INTEGER NOT NULL, x INTEGER NOT NULL,
+      y INTEGER NOT NULL, path TEXT NOT NULL, sizeInBytes INTEGER NOT NULL,
+      lastAccessed TEXT NOT NULL, referenceCount INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (providerId, z, x, y)
+    )
+  ''');
+  await batch.commit(noResult: true);
+}
+
+void main() {
+  // User-story test: tap "Start Download" in the real [DownloadDetailsSheet]
+  // and verify the region transitions to DownloadStatus.completed through the
+  // real notifier + orchestrator (no fakes for the download pipeline).
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    setupLogging(level: Level.WARNING);
+    // flutter_test installs a global HttpOverrides that turns every real
+    // network request into an empty 400 response. Disable it so our local
+    // shelf tile server is reachable from inside the test.
+    HttpOverrides.global = null;
+  });
+
+  testWidgets(
+      'tapping Start Download persists a region and the orchestrator '
+      'drives it to completion against a local tile server', (tester) async {
+    late Directory tempDir;
+    late Database db;
+    late HttpServer server;
+    late String urlTemplate;
+    late ProviderContainer container;
+
+    final tileBytes = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0]);
+
+    // Real I/O + a SQLite db + an HTTP server have to run outside the
+    // FakeAsync clock that testWidgets installs by default.
+    await tester.runAsync(() async {
+      SharedPreferences.setMockInitialValues({});
+      tempDir = await Directory.systemTemp.createTemp('offline_user_flow_');
+      db = await databaseFactory.openDatabase(
+        p.join(tempDir.path, 'turbo.db'),
+        options: OpenDatabaseOptions(version: 1, onCreate: _createSchema),
+      );
+      server = await shelf_io.serve(
+        (shelf.Request _) => shelf.Response.ok(tileBytes,
+            headers: {'Content-Type': 'image/png'}),
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      urlTemplate = 'http://127.0.0.1:${server.port}/{z}/{x}/{y}.png';
+
+      container = ProviderContainer(
+        overrides: [
+          databaseProvider.overrideWith((ref) async => db),
+          tileStoreServiceProvider.overrideWith(
+              (ref) async => TileStoreService(db, testDirectory: tempDir.path)),
+          tileRegistryProvider.overrideWith(() => _FakeRegistry(urlTemplate)),
+        ],
+      );
+      await container.read(tileStoreServiceProvider.future);
+      await container.read(regionRepositoryProvider.future);
+      await container.read(tileJobQueueProvider.future);
+      await container.read(offlineRegionsProvider.future);
+      // Mirrors main.dart: a listen() makes the orchestrator start ticking.
+      container.listen(downloadOrchestratorProvider, (_, _) {});
+    });
+
+    addTearDown(() async {
+      await tester.runAsync(() async {
+        container.read(downloadOrchestratorProvider)?.stop();
+        container.dispose();
+        await db.close();
+        await server.close(force: true);
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+    });
+
+    final bounds = LatLngBounds(
+      const LatLng(-85, -180),
+      const LatLng(85, 180),
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DownloadDetailsSheet(bounds: bounds)),
+        ),
+      ),
+    );
+    // Let the addPostFrameCallback fill in the default name + initial provider.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('My Offline Map'), findsOneWidget,
+        reason: 'default region name should be pre-filled');
+    expect(find.text('Test Tiles'), findsWidgets,
+        reason: 'test tile provider should be the active selection');
+
+    // Tap "Start Download" — the user-visible commit point.
+    await tester.tap(find.text('Start Download'));
+    await tester.pump();
+
+    // Wait for the region to appear via createRegion.
+    String? regionId;
+    await tester.runAsync(() async {
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (DateTime.now().isBefore(deadline)) {
+        final regions = container.read(offlineRegionsProvider).value ??
+            const <OfflineRegion>[];
+        if (regions.isNotEmpty) {
+          regionId = regions.first.id;
+          return;
+        }
+        await Future.delayed(const Duration(milliseconds: 50));
+      }
+    });
+    expect(regionId, isNotNull,
+        reason:
+            'Tapping Start Download must persist a region through OfflineRegionsNotifier.createRegion');
+
+    // Let the orchestrator's Timer.periodic tick in real wall-clock time and
+    // drain the queue against the local tile server.
+    OfflineRegion? finished;
+    await tester.runAsync(() async {
+      final deadline = DateTime.now().add(const Duration(seconds: 20));
+      while (DateTime.now().isBefore(deadline)) {
+        final regions = container.read(offlineRegionsProvider).value ??
+            const <OfflineRegion>[];
+        final match = regions
+            .where((r) => r.id == regionId)
+            .cast<OfflineRegion?>()
+            .firstOrNull;
+        if (match != null &&
+            (match.status == DownloadStatus.completed ||
+                match.status == DownloadStatus.failed)) {
+          finished = match;
+          return;
+        }
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+    });
+
+    expect(finished, isNotNull,
+        reason: 'orchestrator should reach a terminal state within deadline');
+    expect(finished!.status, DownloadStatus.completed,
+        reason: 'all tiles served 200, region must complete');
+    expect(finished!.totalTiles, greaterThan(0));
+    expect(finished!.downloadedTiles, finished!.totalTiles,
+        reason: 'every tile must be downloaded');
+  }, timeout: const Timeout(Duration(seconds: 45)));
+}

--- a/test/features/tile_storage/offline_regions/offline_download_user_flow_test.dart
+++ b/test/features/tile_storage/offline_regions/offline_download_user_flow_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -18,7 +17,6 @@ import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/core/data/database_provider.dart';
 import 'package:turbo/core/service/logger.dart';
 import 'package:turbo/features/tile_providers/api.dart';
-import 'package:turbo/features/tile_providers/data/tile_registry.dart';
 import 'package:turbo/features/tile_storage/offline_regions/api.dart';
 import 'package:turbo/features/tile_storage/offline_regions/data/region_repository.dart';
 import 'package:turbo/features/tile_storage/offline_regions/data/tile_job_queue.dart';


### PR DESCRIPTION
Mounts the real DownloadDetailsSheet on top of a real ProviderContainer
(with sqflite-ffi for the queue/repo/tile store and a shelf server as
the tile origin), taps Start Download, then waits for the orchestrator
to drive the persisted region to DownloadStatus.completed. Existing
tests cover the orchestrator directly via createRegion or stub the
notifier behind a fake; this one closes the gap by exercising the
notifier and orchestrator together from the user-visible button.

Two test-environment notes that future authors will hit:
- flutter_test's HttpOverrides.global returns 400 for every request;
  the test resets it in setUpAll so the shelf server is reachable.
- The orchestrator's Timer.periodic and real I/O have to run outside
  the FakeAsync clock, so setup and the completion poll both use
  tester.runAsync.

https://claude.ai/code/session_01NVtf4oAh7P6N17b8mhn85G