### PR TITLE
polish(l10n): replace raw exception strings in async error states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to Turkart will be documented in this file.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Routed core (`api_client`, `app`, `location_state`) logging through the
+  shared `package:logging` Logger so output is uniformly gated to debug
+  builds via `setupLogging()`.
+- Aligned the web PWA manifest with the actual app (real name,
+  description, and theme color matching the in-app primary).
+
+### Fixed
+
+- Async error states in markers, paths, settings, collections, trip
+  stats, and marker photos no longer show the raw exception string;
+  they show a localized friendly message in both English and Norwegian.
+- Localized the offline-regions "Cleanup" tooltip and the Google OAuth
+  callback "Unknown error" fallback that were still in English.
+
+## [1.0.21]
+
+Baseline at which this changelog starts. See git history for the full
+sequence of changes — major prior milestones include live GPS recording
+with elevation profiles, collections, the design-system unification,
+weather data integration, and the move to a strict feature-oriented
+architecture with enforced boundary tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Turkart
+
+Thanks for the interest. The README is the right place to start — it
+covers what the app does, how to run it, and the high-level layout.
+This file is for things you need to know once you're actually changing
+code.
+
+## Development setup
+
+```sh
+flutter pub get
+flutter run                 # picks the connected device / running emulator
+flutter test                # full unit + widget suite
+flutter analyze             # static analysis
+```
+
+Flutter SDK requirement is `>=3.11.0 <4.0.0` (see `pubspec.yaml`).
+
+For background location recording on a physical Android device, location
+permission must be granted to **Always**. On iOS, accept the
+"Always Allow" prompt on the second permission ask.
+
+## Architecture rules
+
+Turkart uses Feature-Oriented Architecture. Each top-level folder under
+`lib/features/` is a feature with a single public façade at
+`<feature>/api.dart`. Cross-feature imports go through `api.dart` only.
+
+These rules are enforced by tests under `test/architecture/`:
+
+- `feature_boundary_test.dart` — no file in `lib/features/<A>` imports
+  another feature except through that feature's `api.dart`. Every
+  `api.dart` is a pure re-export facade.
+- `no_print_test.dart` — no unguarded `print(...)` or `debugPrint(...)`
+  call sites in `lib/features/`. Use the `package:logging` `Logger`
+  instead; see `lib/core/service/logger.dart`.
+
+If you're adding a new feature: create `lib/features/<name>/api.dart`
+that re-exports your feature's public surface, and add an
+`api_behaviour_test.dart` under `test/features/<name>/` that exercises
+the feature only through that façade.
+
+## Logging
+
+Don't reach for `print` or `debugPrint`. The app has a shared logger:
+
+```dart
+import 'package:logging/logging.dart';
+final _log = Logger('MyFeature');
+
+_log.fine(() => 'expensive lazy message: $details');
+_log.warning('something went wrong', error, stack);
+```
+
+Output is gated to `kDebugMode` by `setupLogging()` in `main.dart`. Core
+code (`lib/core/`) imports the shared `log` singleton from
+`lib/core/service/logger.dart`.
+
+## Localization
+
+User-facing strings live in `lib/app/l10n/app_localizations.dart` as a
+hand-written abstract class with `AppLocalizationsEn` and
+`AppLocalizationsNo` subclasses. Add the key in three places (abstract +
+both subclasses) and access it via `context.l10n.<key>`.
+
+Don't show raw exception text to users — use a friendly localized
+message and log the details.
+
+## Tests
+
+- Every new notifier gets an API-level behavioral test.
+- Every new user flow gets an end-to-end widget test.
+- Database changes get a migration test (see existing
+  `_migrateVNToVN1` patterns in `lib/core/data/database_provider.dart`).
+
+Run `flutter analyze` and `flutter test` before pushing.
+
+## Commit style
+
+Short imperative subjects (no period). Optional `feat(scope):` /
+`polish(scope):` / `fix(scope):` prefix when it adds clarity. The body
+should explain *why* rather than *what* — a glance at the diff already
+shows the what.
+
+## Changelog
+
+Add an entry under the `[Unreleased]` section of `CHANGELOG.md` for
+anything user-visible. Internal refactors that don't change behavior
+can be skipped.

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:turbo/app/app_theme.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/service/logger.dart';
 import 'package:turbo/features/auth/api.dart';
 import 'package:turbo/features/map_view/api.dart';
 import 'package:turbo/features/settings/api.dart';
@@ -22,11 +22,9 @@ class TurboApp extends ConsumerWidget {
     final authState = ref.watch(authStateProvider);
     final settingsAsync = ref.watch(settingsProvider);
 
-    if (kDebugMode) {
-      // ignore: avoid_print
-      print('Building TurboApp. Auth Status: ${authState.status}, '
-          'Initializing: ${authState.isInitializing}');
-    }
+    log.fine(() =>
+        'Building TurboApp. Auth Status: ${authState.status}, '
+        'Initializing: ${authState.isInitializing}');
 
     final textTheme = createTextTheme(context, 'Roboto');
     final theme = MaterialTheme(textTheme);

--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -379,6 +379,10 @@ abstract class AppLocalizations {
   String get weatherPresetHourly;
   String get weatherEmptyDay;
   String get weatherMarineEmpty;
+
+  // Generic error states
+  String get genericLoadError;
+  String get photoLoadError;
 }
 
 // English translations
@@ -722,6 +726,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get weatherPresetHourly => 'Hourly';
   @override String get weatherEmptyDay => 'No data for this day';
   @override String get weatherMarineEmpty => 'No sea data for this day';
+
+  @override String get genericLoadError => "Couldn't load. Please try again.";
+  @override String get photoLoadError => "Couldn't load photo.";
 }
 
 // Norwegian translations
@@ -1062,6 +1069,9 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get weatherPresetHourly => 'Time for time';
   @override String get weatherEmptyDay => 'Ingen data for denne dagen';
   @override String get weatherMarineEmpty => 'Ingen sjødata for denne dagen';
+
+  @override String get genericLoadError => 'Kunne ikke laste. Prøv igjen.';
+  @override String get photoLoadError => 'Kunne ikke laste bilde.';
 }
 
 // The delegate

--- a/lib/app/l10n/app_localizations.dart
+++ b/lib/app/l10n/app_localizations.dart
@@ -383,6 +383,10 @@ abstract class AppLocalizations {
   // Generic error states
   String get genericLoadError;
   String get photoLoadError;
+  String get unknownError;
+
+  // Misc UI
+  String get cleanup;
 }
 
 // English translations
@@ -729,6 +733,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override String get genericLoadError => "Couldn't load. Please try again.";
   @override String get photoLoadError => "Couldn't load photo.";
+  @override String get unknownError => 'Unknown error';
+
+  @override String get cleanup => 'Cleanup';
 }
 
 // Norwegian translations
@@ -1072,6 +1079,9 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override String get genericLoadError => 'Kunne ikke laste. Prøv igjen.';
   @override String get photoLoadError => 'Kunne ikke laste bilde.';
+  @override String get unknownError => 'Ukjent feil';
+
+  @override String get cleanup => 'Opprydding';
 }
 
 // The delegate

--- a/lib/core/api/api_client.dart
+++ b/lib/core/api/api_client.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:turbo/core/config/env_config.dart';
+import 'package:turbo/core/service/logger.dart';
 
 class ApiClient {
   final String baseUrl;
@@ -49,10 +50,8 @@ class ApiClient {
         onError: (DioException error, handler) async {
           final path = error.requestOptions.path;
 
-          if (kDebugMode) {
-            print("Interceptet error: ${error.message} ${error.response?.statusCode}");
-
-          }
+          log.fine(() =>
+              'Intercepted error: ${error.message} ${error.response?.statusCode}');
           // Check for 401 Unauthorized, but ignore for auth endpoints to prevent loops.
           if (error.response?.statusCode == 401 && !path.contains('/api/auth/Token/refresh')) {
             // On mobile, only try to refresh if a refresh token exists.
@@ -146,15 +145,14 @@ class ApiClient {
         final prefs = await SharedPreferences.getInstance();
         final refreshToken = prefs.getString('refreshToken');
         if (refreshToken == null) {
-          if (kDebugMode) print('No refresh token found on mobile, refresh failed.');
+          log.fine('No refresh token found on mobile, refresh failed.');
           return false;
         }
         requestData = {'refreshToken': refreshToken};
       }
 
-      if (kDebugMode) {
-        print('Attempting token refresh. Platform: ${kIsWeb ? 'Web' : 'Mobile'}.');
-      }
+      log.fine(() =>
+          'Attempting token refresh. Platform: ${kIsWeb ? 'Web' : 'Mobile'}.');
 
       // Use the main dio instance, as the interceptor handles the recursion check.
       final response = await _dio.post(
@@ -162,9 +160,7 @@ class ApiClient {
         data: requestData,
       );
 
-      if (kDebugMode) {
-        print('Refresh token response: ${response.statusCode}');
-      }
+      log.fine(() => 'Refresh token response: ${response.statusCode}');
 
       if (response.statusCode == 200) {
         if (!kIsWeb) {
@@ -174,24 +170,22 @@ class ApiClient {
             final prefs = await SharedPreferences.getInstance();
             await prefs.setString('accessToken', data['accessToken']);
             await prefs.setString('refreshToken', data['refreshToken']);
-            if (kDebugMode) print('Mobile tokens refreshed and stored.');
+            log.fine('Mobile tokens refreshed and stored.');
             return true;
           }
         } else {
           // For web, a 200 OK is enough as cookies are handled by the browser.
-          if (kDebugMode) print('Web token refresh successful (cookies updated by server).');
+          log.fine('Web token refresh successful (cookies updated by server).');
           return true;
         }
       }
       // If we reach here, the refresh failed.
-      if (kDebugMode) {
-        print('Token refresh failed with status: ${response.statusCode}. Body: ${response.data}');
-      }
+      log.warning(() =>
+          'Token refresh failed with status: ${response.statusCode}. '
+          'Body: ${response.data}');
       return false;
-    } catch (e) {
-      if (kDebugMode) {
-        print('Error exception during token refresh: $e');
-      }
+    } catch (e, st) {
+      log.warning('Error exception during token refresh', e, st);
       return false;
     }
   }

--- a/lib/core/location/location_state.dart
+++ b/lib/core/location/location_state.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:turbo/core/service/logger.dart';
 
 final locationStateProvider =
 AsyncNotifierProvider.autoDispose<LocationState, LatLng?>(
@@ -27,12 +28,12 @@ class LocationState extends AsyncNotifier<LatLng?> {
       return await _setupLocationListener().timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          debugPrint("Location initialization timed out.");
+          log.warning('Location initialization timed out.');
           return null;
         },
       );
-    } catch (e) {
-      debugPrint("Error in LocationState.build: $e");
+    } catch (e, st) {
+      log.warning('Error in LocationState.build', e, st);
       return null;
     }
   }
@@ -78,13 +79,13 @@ class LocationState extends AsyncNotifier<LatLng?> {
           state = AsyncData(LatLng(position.latitude, position.longitude));
         },
         onError: (error, stackTrace) {
-          debugPrint("Location stream error: $error");
+          log.warning('Location stream error', error, stackTrace);
         },
       );
 
       return LatLng(position.latitude, position.longitude);
-    } catch (e) {
-      debugPrint("Location setup failed: $e");
+    } catch (e, st) {
+      log.warning('Location setup failed', e, st);
       return null;
     }
   }

--- a/lib/features/auth/widgets/google_oauth_screen.dart
+++ b/lib/features/auth/widgets/google_oauth_screen.dart
@@ -66,7 +66,7 @@ class _GoogleAuthCallbackPageState extends ConsumerState<GoogleAuthCallbackPage>
           });
         } else {
           setState(() {
-            _message = l10n.loginFailed(authState.errorMessage ?? 'Unknown error');
+            _message = l10n.loginFailed(authState.errorMessage ?? l10n.unknownError);
             _isProcessing = false;
             _processingComplete = true;
           });

--- a/lib/features/collections/widgets/collections_page.dart
+++ b/lib/features/collections/widgets/collections_page.dart
@@ -28,7 +28,7 @@ class CollectionsPage extends ConsumerWidget {
       ),
       body: asyncState.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('$e')),
+        error: (_, _) => Center(child: Text(l10n.genericLoadError)),
         data: (state) {
           if (state.collections.isEmpty) {
             return _EmptyState();

--- a/lib/features/markers/widgets/marker_info_sheet.dart
+++ b/lib/features/markers/widgets/marker_info_sheet.dart
@@ -390,7 +390,7 @@ class _PhotoStrip extends ConsumerWidget {
 
     return async.when(
       loading: () => const SizedBox.shrink(),
-      error: (e, _) => Text('Photo error: $e', style: theme.textTheme.bodySmall),
+      error: (_, _) => Text(context.l10n.photoLoadError, style: theme.textTheme.bodySmall),
       data: (photos) {
         if (photos.isEmpty) return const SizedBox.shrink();
         return Padding(

--- a/lib/features/markers/widgets/markers_list_page.dart
+++ b/lib/features/markers/widgets/markers_list_page.dart
@@ -22,7 +22,7 @@ class MarkersListPage extends ConsumerWidget {
       appBar: AppBar(title: Text(l10n.allMarkers)),
       body: asyncMarkers.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('$e')),
+        error: (_, _) => Center(child: Text(l10n.genericLoadError)),
         data: (markers) {
           if (markers.isEmpty) {
             return Center(

--- a/lib/features/saved_paths/widgets/paths_list_page.dart
+++ b/lib/features/saved_paths/widgets/paths_list_page.dart
@@ -46,7 +46,7 @@ class PathsListPage extends ConsumerWidget {
       ),
       body: asyncPaths.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('$e')),
+        error: (_, _) => Center(child: Text(l10n.genericLoadError)),
         data: (paths) {
           if (paths.isEmpty) {
             return Center(

--- a/lib/features/saved_paths/widgets/trip_stats_page.dart
+++ b/lib/features/saved_paths/widgets/trip_stats_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/app/tokens.dart';
 import 'package:turbo/features/settings/api.dart';
 
@@ -21,7 +22,7 @@ class TripStatsPage extends ConsumerWidget {
       appBar: AppBar(title: const Text('Trip statistics')),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('$e')),
+        error: (_, _) => Center(child: Text(context.l10n.genericLoadError)),
         data: (paths) {
           final stats = TripStats.from(paths);
           if (stats.totalPaths == 0) {

--- a/lib/features/settings/widgets/settings_page.dart
+++ b/lib/features/settings/widgets/settings_page.dart
@@ -37,7 +37,7 @@ class SettingsPage extends ConsumerWidget {
           ),
         ),
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => Center(child: Text('Error: $error')),
+        error: (_, _) => Center(child: Text(l10n.genericLoadError)),
       ),
     );
   }

--- a/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
+++ b/lib/features/tile_storage/offline_regions/widgets/offline_regions_page.dart
@@ -21,7 +21,7 @@ class OfflineRegionsPage extends ConsumerWidget {
         title: Text(l10n.offlineMaps),
         actions: [
           PopupMenuButton<int>(
-            tooltip: 'Cleanup',
+            tooltip: l10n.cleanup,
             icon: const Icon(Icons.cleaning_services_outlined),
             onSelected: (days) => _confirmCleanup(context, ref, days),
             itemBuilder: (_) => const [

--- a/web/index.html
+++ b/web/index.html
@@ -18,12 +18,13 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Offline-capable hiking and outdoors map with GPS recording, markers, and route planning.">
+  <meta name="theme-color" content="#8f4c38">
   <meta name="google-signin-client_id" content="863382325847-l4s030g7ruif29o6no75ugb19c380an0.apps.googleusercontent.com">
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="turbo">
+  <meta name="apple-mobile-web-app-title" content="Turbo">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "turbo",
-    "short_name": "turbo",
+    "name": "Turbo",
+    "short_name": "Turbo",
     "start_url": ".",
     "display": "standalone",
-    "background_color": "#0175C2",
-    "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "background_color": "#8f4c38",
+    "theme_color": "#8f4c38",
+    "description": "Offline-capable hiking and outdoors map with GPS recording, markers, and route planning.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
Six list/stats screens were showing raw `Text('$e')` to users when their
async provider errored. Replace with localized friendly messages
(`genericLoadError`, `photoLoadError`) in both en and nb_NO. Errors are
still surfaced upstream where they're caught and (where applicable)
logged by the data layer.

https://claude.ai/code/session_01W5kTB6rBZT2S7CUyU5o5pw