### PR TITLE
fix(path_recording): stop nagging on background-location prompt

### DIFF
--- a/lib/features/path_recording/widgets/permission_dialogs.dart
+++ b/lib/features/path_recording/widgets/permission_dialogs.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:turbo/features/settings/api.dart';
 
 /// Outcome of the runtime permission request flow. Foreground means we can
 /// record while the app is visible; background unlocks lock-screen and
@@ -9,13 +13,15 @@ enum RecordingPermissionResult { granted, foregroundOnly, denied }
 
 /// Two-stage permission flow:
 ///   1. Request "while in use" — required to record at all.
-///   2. If foreground granted, ask the user whether they want background
-///      recording, then request `always`.
+///   2. If foreground granted and the user hasn't been asked yet, offer to
+///      upgrade to background ("Always"). The choice is persisted so we
+///      never block subsequent recording starts with the same dialog.
 ///
 /// The rationale dialogs use plain English copy; production code can swap
 /// these for l10n strings without changing the call sites.
 Future<RecordingPermissionResult> requestRecordingPermissions(
   BuildContext context,
+  WidgetRef ref,
 ) async {
   final serviceEnabled = await Geolocator.isLocationServiceEnabled();
   if (!serviceEnabled) {
@@ -58,7 +64,14 @@ Future<RecordingPermissionResult> requestRecordingPermissions(
     return RecordingPermissionResult.granted;
   }
 
-  // Foreground granted; offer to upgrade.
+  // Foreground granted; offer to upgrade — but only the first time. If the
+  // user has already answered this prompt, respect their previous choice
+  // and don't block recording on it again.
+  final settings = ref.read(settingsProvider).value;
+  if (settings != null && settings.backgroundLocationPromptSeen) {
+    return RecordingPermissionResult.foregroundOnly;
+  }
+
   if (!context.mounted) return RecordingPermissionResult.foregroundOnly;
   final wantsBackground = await _showConfirmDialog(
     context,
@@ -69,7 +82,14 @@ Future<RecordingPermissionResult> requestRecordingPermissions(
         'we will warn you if a recording is interrupted.',
     confirmLabel: 'Enable background',
     cancelLabel: 'Foreground only',
+    barrierDismissible: false,
   );
+  // Persist the fact that we've asked. Whatever the user picks (or if they
+  // back out), we honour it next time — no nagging.
+  unawaited(ref
+      .read(settingsProvider.notifier)
+      .setBackgroundLocationPromptSeen(true));
+
   if (wantsBackground != true) {
     return RecordingPermissionResult.foregroundOnly;
   }
@@ -87,9 +107,11 @@ Future<bool?> _showConfirmDialog(
   required String message,
   required String confirmLabel,
   String cancelLabel = 'Not now',
+  bool barrierDismissible = true,
 }) {
   return showDialog<bool>(
     context: context,
+    barrierDismissible: barrierDismissible,
     builder: (ctx) => AlertDialog(
       title: Text(title),
       content: Text(message),

--- a/lib/features/path_recording/widgets/start_recording_flow.dart
+++ b/lib/features/path_recording/widgets/start_recording_flow.dart
@@ -26,7 +26,7 @@ Future<void> startRecordingFlow(BuildContext context, WidgetRef ref) async {
     return;
   }
 
-  final result = await requestRecordingPermissions(context);
+  final result = await requestRecordingPermissions(context, ref);
   if (result == RecordingPermissionResult.denied) {
     if (context.mounted) {
       AppSnackbars.error(

--- a/lib/features/settings/data/settings_provider.dart
+++ b/lib/features/settings/data/settings_provider.dart
@@ -68,6 +68,12 @@ class SettingsState {
   /// Tradeoff between GPS accuracy and battery use during recording.
   final GpsAccuracyMode gpsAccuracyMode;
 
+  /// Set once the user has answered the "enable background recording" prompt
+  /// at least once. We respect that choice and don't ask again on every
+  /// recording start — they can re-enable background recording from settings
+  /// or by granting "Always" location in the OS.
+  final bool backgroundLocationPromptSeen;
+
   const SettingsState({
     required this.themeMode,
     required this.locale,
@@ -90,6 +96,7 @@ class SettingsState {
     this.lastPathLineStyleKey,
     this.keepScreenOnWhileRecording = true,
     this.gpsAccuracyMode = GpsAccuracyMode.high,
+    this.backgroundLocationPromptSeen = false,
   });
 
   // Default initial state
@@ -123,6 +130,7 @@ class SettingsState {
     String? Function()? lastPathLineStyleKey,
     bool? keepScreenOnWhileRecording,
     GpsAccuracyMode? gpsAccuracyMode,
+    bool? backgroundLocationPromptSeen,
   }) {
     return SettingsState(
       themeMode: themeMode ?? this.themeMode,
@@ -146,6 +154,8 @@ class SettingsState {
       lastPathLineStyleKey: lastPathLineStyleKey != null ? lastPathLineStyleKey() : this.lastPathLineStyleKey,
       keepScreenOnWhileRecording: keepScreenOnWhileRecording ?? this.keepScreenOnWhileRecording,
       gpsAccuracyMode: gpsAccuracyMode ?? this.gpsAccuracyMode,
+      backgroundLocationPromptSeen:
+          backgroundLocationPromptSeen ?? this.backgroundLocationPromptSeen,
     );
   }
 }
@@ -176,6 +186,8 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
   static const _lastPathLineStyleKey = 'lastPathLineStyle';
   static const _keepScreenOnWhileRecordingKey = 'keepScreenOnWhileRecording';
   static const _gpsAccuracyModeKey = 'gpsAccuracyMode';
+  static const _backgroundLocationPromptSeenKey =
+      'backgroundLocationPromptSeen';
 
   @override
   Future<SettingsState> build() async {
@@ -247,6 +259,8 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
           prefs.getBool(_keepScreenOnWhileRecordingKey) ?? true,
       gpsAccuracyMode:
           GpsAccuracyMode.fromName(prefs.getString(_gpsAccuracyModeKey)),
+      backgroundLocationPromptSeen:
+          prefs.getBool(_backgroundLocationPromptSeenKey) ?? false,
     );
   }
 
@@ -264,6 +278,17 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
     state = AsyncData(state.value!.copyWith(gpsAccuracyMode: mode));
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_gpsAccuracyModeKey, mode.name);
+  }
+
+  /// Records whether the user has been prompted about background recording.
+  /// Once true, the recording start flow won't keep showing the upgrade
+  /// dialog on every session start.
+  Future<void> setBackgroundLocationPromptSeen(bool seen) async {
+    if (state.value == null) return;
+    state = AsyncData(
+        state.value!.copyWith(backgroundLocationPromptSeen: seen));
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_backgroundLocationPromptSeenKey, seen);
   }
 
   /// Updates the draw sensitivity and persists it.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -833,10 +833,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1342,26 +1342,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   turbo_lints:
     dependency: "direct dev"
     description:

--- a/test/features/settings/settings_provider_test.dart
+++ b/test/features/settings/settings_provider_test.dart
@@ -217,5 +217,31 @@ void main() {
         expect(prefs.containsKey('lastPathLineStyle'), isFalse);
       });
     });
+
+    group('background location prompt memo', () {
+      test('defaults to false on a clean install', () async {
+        final container = createContainer({});
+        final state = await container.read(settingsProvider.future);
+        expect(state.backgroundLocationPromptSeen, isFalse);
+      });
+
+      test('setBackgroundLocationPromptSeen persists across reload', () async {
+        final container = createContainer({});
+        await container.read(settingsProvider.future);
+
+        await container
+            .read(settingsProvider.notifier)
+            .setBackgroundLocationPromptSeen(true);
+
+        expect(
+            container.read(settingsProvider).value?.backgroundLocationPromptSeen,
+            isTrue);
+
+        final container2 = ProviderContainer();
+        addTearDown(container2.dispose);
+        final reloaded = await container2.read(settingsProvider.future);
+        expect(reloaded.backgroundLocationPromptSeen, isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
The "Keep recording in the background?" dialog re-appeared on every
recording start whenever the user only had "while in use" permission,
making it feel like the dialog was the destination instead of a one-time
choice. Persist a "backgroundLocationPromptSeen" flag in settings so we
ask exactly once and honour the answer thereafter. Force an explicit
choice (no barrier dismiss) so the dialog can't be tapped away by
accident.