### PR TITLE
feat(activities): capture preferred conditions on fishing and BC ski forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,14 @@ Thumbs.db
 
 # Docker / compose scratch
 infra/compose/data/
+
+# Stray Flutter scaffolding at the repo root. Flutter scaffolds these
+# under whatever cwd it runs from; the real ones live in apps/flutter/.
+# Guard against tools accidentally running `flutter` from the repo root.
+/.dart_tool/
+/.flutter-plugins-dependencies
+/android/
+/ios/
+/linux/
+/macos/
+/windows/

--- a/apps/flutter/lib/features/activity_backcountry_ski/widgets/backcountry_ski_create_screen.dart
+++ b/apps/flutter/lib/features/activity_backcountry_ski/widgets/backcountry_ski_create_screen.dart
@@ -42,6 +42,7 @@ class _BackcountrySkiCreateScreenState
   final _elevMax = TextEditingController(text: '1700');
   AtesRating _ates = AtesRating.challenging;
   Aspect _aspect = Aspect.n;
+  int? _preferredAvalancheMaxLevel;
   bool _saving = false;
 
   @override
@@ -58,6 +59,7 @@ class _BackcountrySkiCreateScreenState
       _elevMax.text = e.details.elevationMaxMeters.toString();
       _ates = e.details.atesRating;
       _aspect = e.details.dominantAspect ?? Aspect.n;
+      _preferredAvalancheMaxLevel = e.details.preferredAvalancheMaxLevel;
       _drawnRoute = List<LatLng>.from(e.route);
     }
   }
@@ -181,6 +183,31 @@ class _BackcountrySkiCreateScreenState
                     .toList(),
                 onChanged: (v) => setState(() => _aspect = v ?? Aspect.n),
               ),
+              const SizedBox(height: 16),
+              Text('Max acceptable avalanche danger',
+                  style: Theme.of(context).textTheme.labelLarge),
+              const SizedBox(height: 4),
+              Text(
+                'Used to flag the route when the Varsom forecast exceeds this level.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 4),
+              DropdownButtonFormField<int?>(
+                initialValue: _preferredAvalancheMaxLevel,
+                decoration:
+                    const InputDecoration(border: OutlineInputBorder()),
+                items: const [
+                  DropdownMenuItem<int?>(value: null, child: Text('Any')),
+                  DropdownMenuItem<int?>(value: 1, child: Text('1 — Low')),
+                  DropdownMenuItem<int?>(value: 2, child: Text('2 — Moderate')),
+                  DropdownMenuItem<int?>(
+                      value: 3, child: Text('3 — Considerable')),
+                  DropdownMenuItem<int?>(value: 4, child: Text('4 — High')),
+                  DropdownMenuItem<int?>(value: 5, child: Text('5 — Extreme')),
+                ],
+                onChanged: (v) =>
+                    setState(() => _preferredAvalancheMaxLevel = v),
+              ),
               const SizedBox(height: 12),
               ListTile(
                 leading: const Icon(Icons.flag_outlined),
@@ -241,6 +268,7 @@ class _BackcountrySkiCreateScreenState
         elevationMaxMeters: int.parse(_elevMax.text),
         atesRating: _ates,
         dominantAspect: _aspect,
+        preferredAvalancheMaxLevel: _preferredAvalancheMaxLevel,
       );
       final repo = ref.read(backcountrySkiRepositoryProvider);
       final existing = widget.existing;

--- a/apps/flutter/lib/features/activity_fishing/widgets/fishing_create_screen.dart
+++ b/apps/flutter/lib/features/activity_fishing/widgets/fishing_create_screen.dart
@@ -36,6 +36,9 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
   final _name = TextEditingController();
   final _description = TextEditingController();
   final _accessNotes = TextEditingController();
+  final _pressureMin = TextEditingController();
+  final _pressureMax = TextEditingController();
+  final _windMax = TextEditingController();
   WaterKind _waterKind = WaterKind.river;
   ShoreOrBoat _shoreOrBoat = ShoreOrBoat.shore;
   bool _saving = false;
@@ -50,6 +53,12 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
       _accessNotes.text = e.details.accessNotes ?? '';
       _waterKind = e.details.waterKind;
       _shoreOrBoat = e.details.shoreOrBoat;
+      final p = e.details.preferred;
+      if (p != null) {
+        _pressureMin.text = p.pressureMinHpa?.toString() ?? '';
+        _pressureMax.text = p.pressureMaxHpa?.toString() ?? '';
+        _windMax.text = p.windMaxMs?.toString() ?? '';
+      }
     }
   }
 
@@ -58,6 +67,9 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
     _name.dispose();
     _description.dispose();
     _accessNotes.dispose();
+    _pressureMin.dispose();
+    _pressureMax.dispose();
+    _windMax.dispose();
     super.dispose();
   }
 
@@ -131,6 +143,28 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
                 ),
                 maxLines: 2,
               ),
+              const SizedBox(height: 20),
+              Text('Preferred conditions (optional)',
+                  style: Theme.of(context).textTheme.labelLarge),
+              const SizedBox(height: 4),
+              Text(
+                'Used to score weather and tides for this spot.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                      child: _preferredIntField(
+                          _pressureMin, 'Pressure min (hPa)')),
+                  const SizedBox(width: 8),
+                  Expanded(
+                      child: _preferredIntField(
+                          _pressureMax, 'Pressure max (hPa)')),
+                ],
+              ),
+              const SizedBox(height: 8),
+              _preferredDoubleField(_windMax, 'Max wind (m/s)'),
               const SizedBox(height: 12),
               ListTile(
                 leading: const Icon(Icons.location_on_outlined),
@@ -157,6 +191,50 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
     );
   }
 
+  Widget _preferredIntField(TextEditingController c, String label) =>
+      TextFormField(
+        controller: c,
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          isDense: true,
+        ),
+        validator: (v) {
+          final t = v?.trim() ?? '';
+          if (t.isEmpty) return null;
+          return int.tryParse(t) == null ? 'Whole number' : null;
+        },
+      );
+
+  Widget _preferredDoubleField(TextEditingController c, String label) =>
+      TextFormField(
+        controller: c,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          isDense: true,
+        ),
+        validator: (v) {
+          final t = v?.trim() ?? '';
+          if (t.isEmpty) return null;
+          return double.tryParse(t) == null ? 'Number' : null;
+        },
+      );
+
+  PreferredConditions? _readPreferred() {
+    final pMin = int.tryParse(_pressureMin.text.trim());
+    final pMax = int.tryParse(_pressureMax.text.trim());
+    final wind = double.tryParse(_windMax.text.trim());
+    if (pMin == null && pMax == null && wind == null) return null;
+    return PreferredConditions(
+      pressureMinHpa: pMin,
+      pressureMaxHpa: pMax,
+      windMaxMs: wind,
+    );
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) return;
     setState(() => _saving = true);
@@ -165,6 +243,7 @@ class _FishingCreateScreenState extends ConsumerState<FishingCreateScreen> {
         waterKind: _waterKind,
         shoreOrBoat: _shoreOrBoat,
         accessNotes: _accessNotes.text.trim().isEmpty ? null : _accessNotes.text.trim(),
+        preferred: _readPreferred(),
       );
       final repo = ref.read(fishingRepositoryProvider);
       final existing = widget.existing;


### PR DESCRIPTION
Fishing forms now expose pressure-min, pressure-max, and max-wind inputs
that hydrate the existing PreferredConditions value object so the
server's conditions advisor can score weather against the user's
preferences. Backcountry ski forms expose the preferredAvalancheMaxLevel
dropdown (Any / 1-5) that already round-tripped through the model but
had no UI.

https://claude.ai/code/session_01AravKWtbWLbzGX7Z6tY1o7