### PR TITLE
Add ocean conditions map layer

### DIFF
--- a/apps/flutter/lib/app/l10n/app_localizations.dart
+++ b/apps/flutter/lib/app/l10n/app_localizations.dart
@@ -150,6 +150,12 @@ abstract class AppLocalizations {
   String get layerDescriptionGoogleSatellite;
   String get layerNameAvalanche;
   String get layerDescriptionAvalanche;
+  String get layerNameOceanConditions;
+  String get layerDescriptionOceanConditions;
+  String get oceanConditionsTitle;
+  String get oceanWaveDirectionLabel;
+  String get oceanCurrentLabel;
+  String get oceanViewFullForecast;
 
   // Measuring Tool
   String get totalDistance;
@@ -617,6 +623,12 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get layerDescriptionGoogleSatellite => 'Satellite imagery from Google';
   @override String get layerNameAvalanche => 'Avalanche Danger';
   @override String get layerDescriptionAvalanche => 'Overlay of slope steepness and run-out zones';
+  @override String get layerNameOceanConditions => 'Ocean Conditions';
+  @override String get layerDescriptionOceanConditions => 'Wave height and direction from MET Norway';
+  @override String get oceanConditionsTitle => 'Ocean conditions';
+  @override String get oceanWaveDirectionLabel => 'Wave direction';
+  @override String get oceanCurrentLabel => 'Current';
+  @override String get oceanViewFullForecast => 'View full forecast';
 
   @override String get totalDistance => 'Total Distance';
   @override String get undoLastPoint => 'Undo Last Point';
@@ -1061,6 +1073,12 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get layerDescriptionGoogleSatellite => 'Satellittbilder fra Google';
   @override String get layerNameAvalanche => 'Snøskredfare';
   @override String get layerDescriptionAvalanche => 'Oversikt over bratthet og utløpssoner';
+  @override String get layerNameOceanConditions => 'Havforhold';
+  @override String get layerDescriptionOceanConditions => 'Bølgehøyde og -retning fra MET';
+  @override String get oceanConditionsTitle => 'Havforhold';
+  @override String get oceanWaveDirectionLabel => 'Bølgeretning';
+  @override String get oceanCurrentLabel => 'Strøm';
+  @override String get oceanViewFullForecast => 'Se hele varselet';
 
   @override String get totalDistance => 'Total distanse';
   @override String get undoLastPoint => 'Angre siste punkt';

--- a/apps/flutter/lib/features/map_view/widgets/buttons/map_layer_button.dart
+++ b/apps/flutter/lib/features/map_view/widgets/buttons/map_layer_button.dart
@@ -383,6 +383,8 @@ class LayerSelectionSheet extends ConsumerWidget {
         return Icons.satellite;
       case 'avalanche_danger':
         return Icons.ac_unit;
+      case 'ocean_conditions':
+        return Icons.waves;
       default:
         return Icons.layers;
     }

--- a/apps/flutter/lib/features/map_view/widgets/main_map_page.dart
+++ b/apps/flutter/lib/features/map_view/widgets/main_map_page.dart
@@ -21,6 +21,7 @@ import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/markers/api.dart' as marker_model;
 import 'package:turbo/features/navigation/api.dart';
 import 'package:turbo/features/sharing/api.dart';
+import 'package:turbo/features/weather/api.dart' show OceanConditionsLayer;
 
 import 'package:turbo/core/location/compass_mode_state.dart';
 import 'package:turbo/core/location/compass_state.dart';
@@ -269,6 +270,10 @@ class _MainMapPageState extends ConsumerState<MainMapPage>
       const NavigationTargetMarker(),
       SavedPathsLayer(mapController: _mapController),
       ...trailVectorLayers,
+      OceanConditionsLayer(
+        mapController: _mapController,
+        visible: activeOverlayIds.contains('ocean_conditions'),
+      ),
       ViewportMarkers(mapController: _mapController),
       const activities.ActivitiesMapLayer(),
     ];

--- a/apps/flutter/lib/features/tile_providers/data/providers/ocean_conditions_overlay.dart
+++ b/apps/flutter/lib/features/tile_providers/data/providers/ocean_conditions_overlay.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/tile_providers/models/tile_provider_config.dart';
+
+/// Vector-only overlay toggle for the live ocean-conditions layer.
+///
+/// Like the OSM/N50 path overlays, this config ships no raster tiles — it
+/// only owns the on/off bit in the registry. The actual geometry (wave
+/// height + direction sampled across the viewport) is drawn by
+/// `OceanConditionsLayer` in the weather feature, which reads MET Norway's
+/// `oceanforecast/2.0` endpoint — the same data source that powers the
+/// weather sheet's "Sea conditions" tab.
+class OceanConditionsOverlayConfig extends TileProviderConfig {
+  @override
+  String get id => 'ocean_conditions';
+
+  @override
+  String name(BuildContext context) => context.l10n.layerNameOceanConditions;
+
+  @override
+  String description(BuildContext context) =>
+      context.l10n.layerDescriptionOceanConditions;
+
+  @override
+  String get attributions => 'MET Norway';
+
+  @override
+  TileProviderCategory get category => TileProviderCategory.overlay;
+
+  @override
+  String get urlTemplate => '';
+
+  @override
+  bool get isVectorOnly => true;
+}

--- a/apps/flutter/lib/features/tile_providers/data/tile_registry.dart
+++ b/apps/flutter/lib/features/tile_providers/data/tile_registry.dart
@@ -7,6 +7,7 @@ import 'package:turbo/features/tile_providers/data/providers/avalanche_overlay.d
 import 'package:turbo/features/tile_providers/data/providers/google_sattelite.dart';
 import 'package:turbo/features/tile_providers/data/providers/nasjonal_turbase_overlay.dart';
 import 'package:turbo/features/tile_providers/data/providers/norges_kart_topo.dart';
+import 'package:turbo/features/tile_providers/data/providers/ocean_conditions_overlay.dart';
 import 'package:turbo/features/tile_providers/data/providers/offline_region_provider_config.dart';
 import 'package:turbo/features/tile_providers/data/providers/osm_tiles.dart';
 import 'package:turbo/features/tile_providers/data/providers/vector_path_overlays.dart';
@@ -29,6 +30,7 @@ class TileRegistry extends Notifier<TileRegistryState> {
       OsmConfig(),
       GoogleSatelliteConfig(),
       AvalancheOverlayConfig(),
+      OceanConditionsOverlayConfig(),
       TrailsFootOverlayConfig(),
       TrailsSkiOverlayConfig(),
       TrailsBikeOverlayConfig(),

--- a/apps/flutter/lib/features/weather/api.dart
+++ b/apps/flutter/lib/features/weather/api.dart
@@ -34,6 +34,9 @@ export 'data/tide_notifier.dart'
         tideForecastProvider,
         kartverketTideServiceProvider,
         TideForecastNotifier;
+export 'data/ocean_conditions_notifier.dart'
+    show oceanConditionsProvider, OceanConditionsNotifier, OceanGridSample;
+export 'widgets/ocean_conditions_layer.dart' show OceanConditionsLayer;
 export 'widgets/weather_summary_row.dart' show WeatherSummaryRow;
 export 'widgets/weather_detail_sheet.dart'
     show WeatherDetailSheet, showWeatherDetailSheet;

--- a/apps/flutter/lib/features/weather/data/ocean_conditions_notifier.dart
+++ b/apps/flutter/lib/features/weather/data/ocean_conditions_notifier.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:flutter_map/flutter_map.dart' show LatLngBounds;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../models/weather_forecast.dart';
+import 'weather_notifier.dart' show yrOceanServiceProvider;
+
+/// A single marine reading positioned at a sampled grid point on the map.
+class OceanGridSample {
+  final LatLng position;
+  final MarinePoint point;
+
+  const OceanGridSample({required this.position, required this.point});
+}
+
+/// In-memory cache entry for one grid coordinate. [point] is `null` when MET
+/// confirmed the coordinate has no marine coverage (land / outside the Nordic
+/// footprint) — we cache those too so panning over a coastline doesn't refetch
+/// the same dry points on every move.
+class _CachedSample {
+  final MarinePoint? point;
+  final DateTime expiresAt;
+
+  const _CachedSample(this.point, this.expiresAt);
+}
+
+/// Samples MET Norway's `oceanforecast/2.0` endpoint across the visible
+/// viewport to drive the ocean-conditions map overlay.
+///
+/// The endpoint is a per-coordinate point query, so we lay a coarse grid over
+/// the current bounds and fetch each cell. Calls are debounced (to coalesce a
+/// pan gesture), capped in concurrency, and cached by rounded coordinate +
+/// MET's `Expires` so repeated viewing of the same area stays cheap and within
+/// MET's fair-use terms.
+final oceanConditionsProvider =
+    AsyncNotifierProvider<OceanConditionsNotifier, List<OceanGridSample>>(
+  OceanConditionsNotifier.new,
+);
+
+class OceanConditionsNotifier extends AsyncNotifier<List<OceanGridSample>> {
+  /// Number of cells per axis — a 5×5 grid yields up to 25 sampled points,
+  /// trimmed by the cache and land/no-coverage responses.
+  static const int _cellsPerAxis = 5;
+
+  /// Maximum simultaneous in-flight requests to MET.
+  static const int _maxConcurrent = 6;
+
+  /// Fallback freshness when MET omits an `Expires` header.
+  static const Duration _fallbackTtl = Duration(minutes: 30);
+
+  Timer? _debounce;
+  LatLngBounds? _pending;
+  int _requestSeq = 0;
+  final Map<String, _CachedSample> _cache = {};
+
+  @override
+  Future<List<OceanGridSample>> build() async {
+    ref.onDispose(() => _debounce?.cancel());
+    return const [];
+  }
+
+  /// Debounced refresh: schedules a sampling pass ~500ms after the last
+  /// invocation so a panning gesture collapses into a single batch.
+  void requestBounds(LatLngBounds bounds) {
+    _pending = bounds;
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), _execute);
+  }
+
+  /// Clears the rendered samples (e.g. when the layer is toggled off). The
+  /// coordinate cache is intentionally retained so re-enabling is instant.
+  void clear() {
+    _debounce?.cancel();
+    _pending = null;
+    state = const AsyncValue.data([]);
+  }
+
+  Future<void> _execute() async {
+    final bounds = _pending;
+    if (bounds == null) return;
+
+    final seq = ++_requestSeq;
+    final service = ref.read(yrOceanServiceProvider);
+    final now = DateTime.now().toUtc();
+    final queue = _buildGrid(bounds);
+    final results = <OceanGridSample>[];
+
+    Future<void> worker() async {
+      while (queue.isNotEmpty) {
+        if (seq != _requestSeq) return;
+        final pos = queue.removeLast();
+        final key = _key(pos);
+
+        MarinePoint? point;
+        final cached = _cache[key];
+        if (cached != null && cached.expiresAt.isAfter(now)) {
+          point = cached.point;
+        } else {
+          try {
+            final res = await service.fetch(pos);
+            point = (res != null && res.points.isNotEmpty)
+                ? res.points.first
+                : null;
+            _cache[key] = _CachedSample(
+              point,
+              res?.expiresAt ?? now.add(_fallbackTtl),
+            );
+          } catch (_) {
+            // Transient failure for one cell — skip it rather than failing
+            // the whole layer. It'll be retried on the next refresh.
+            continue;
+          }
+        }
+
+        if (point != null && point.waveHeightM != null) {
+          results.add(OceanGridSample(position: pos, point: point));
+        }
+      }
+    }
+
+    await Future.wait([for (var i = 0; i < _maxConcurrent; i++) worker()]);
+
+    // A newer request superseded this one while we were fetching — drop the
+    // stale results so the layer reflects the latest viewport only.
+    if (seq != _requestSeq) return;
+    state = AsyncValue.data(results);
+  }
+
+  List<LatLng> _buildGrid(LatLngBounds b) {
+    final latSpan = b.north - b.south;
+    final lonSpan = b.east - b.west;
+    final points = <LatLng>[];
+    for (var row = 0; row < _cellsPerAxis; row++) {
+      for (var col = 0; col < _cellsPerAxis; col++) {
+        // Sample cell centres so points sit inside the viewport rather than
+        // on its edges.
+        final lat = b.south + latSpan * (row + 0.5) / _cellsPerAxis;
+        final lon = b.west + lonSpan * (col + 0.5) / _cellsPerAxis;
+        points.add(LatLng(lat, lon));
+      }
+    }
+    return points;
+  }
+
+  /// ~1 km coordinate bucket — keeps the cache hit-rate high across small pans
+  /// without smearing distinct sea areas together.
+  String _key(LatLng p) =>
+      '${p.latitude.toStringAsFixed(2)},${p.longitude.toStringAsFixed(2)}';
+}

--- a/apps/flutter/lib/features/weather/widgets/ocean_conditions_layer.dart
+++ b/apps/flutter/lib/features/weather/widgets/ocean_conditions_layer.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/app/tokens.dart';
+import 'package:turbo/features/markers/api.dart' as markers show Marker;
+
+import '../data/ocean_conditions_notifier.dart';
+import 'weather_detail_sheet.dart';
+import 'weather_widgets_internal.dart' show WindArrow;
+
+/// Map overlay that visualises live ocean conditions across the viewport.
+///
+/// When [visible], it samples MET Norway's `oceanforecast/2.0` endpoint over a
+/// grid covering the current bounds (via [oceanConditionsProvider]) and draws a
+/// wave-height-coloured chip with a direction arrow at each sea point. Tapping
+/// a chip opens the full weather/ocean forecast sheet for that coordinate.
+///
+/// Mirrors the lifecycle of [VectorDataLayer]: it listens to the map controller
+/// for pan/zoom-end events and refreshes for the new viewport, gated by
+/// [minZoom] so a world-spanning bounds doesn't sample mostly-empty cells.
+class OceanConditionsLayer extends ConsumerStatefulWidget {
+  final MapController mapController;
+  final bool visible;
+
+  /// Below this zoom the viewport is too large for a coarse grid to be
+  /// meaningful — most cells land on shore or far offshore.
+  final double minZoom;
+
+  const OceanConditionsLayer({
+    super.key,
+    required this.mapController,
+    this.visible = true,
+    this.minZoom = 5,
+  });
+
+  @override
+  ConsumerState<OceanConditionsLayer> createState() =>
+      _OceanConditionsLayerState();
+}
+
+class _OceanConditionsLayerState extends ConsumerState<OceanConditionsLayer> {
+  StreamSubscription<MapEvent>? _eventSub;
+  bool _bootstrapped = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _eventSub = widget.mapController.mapEventStream.listen((event) {
+        if (event is MapEventMoveEnd ||
+            event is MapEventRotateEnd ||
+            event is MapEventFlingAnimationEnd ||
+            event is MapEventDoubleTapZoomEnd ||
+            event is MapEventScrollWheelZoom) {
+          _refresh();
+        }
+      });
+      _refresh();
+    });
+  }
+
+  @override
+  void didUpdateWidget(OceanConditionsLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible && !oldWidget.visible) {
+      _refresh();
+    } else if (!widget.visible && oldWidget.visible) {
+      ref.read(oceanConditionsProvider.notifier).clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    _eventSub?.cancel();
+    super.dispose();
+  }
+
+  void _refresh() {
+    if (!mounted || !widget.visible) return;
+    final camera = widget.mapController.camera;
+    if (camera.zoom < widget.minZoom) {
+      _bootstrapped = true;
+      return;
+    }
+    ref
+        .read(oceanConditionsProvider.notifier)
+        .requestBounds(camera.visibleBounds);
+    _bootstrapped = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.visible) return const SizedBox.shrink();
+    if (!_bootstrapped) {
+      // Defer the first read until our listener has fired so the map tree
+      // doesn't flicker.
+      return const SizedBox.shrink();
+    }
+
+    final async = ref.watch(oceanConditionsProvider);
+    final samples = async.asData?.value ?? const <OceanGridSample>[];
+    if (samples.isEmpty) return const SizedBox.shrink();
+
+    return MarkerLayer(
+      markers: [
+        for (final sample in samples)
+          Marker(
+            point: sample.position,
+            width: 76,
+            height: 30,
+            child: _WaveChip(
+              sample: sample,
+              onTap: () => _openForecast(context, sample),
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _openForecast(BuildContext context, OceanGridSample sample) {
+    final title = context.l10n.oceanConditionsTitle;
+    showWeatherDetailSheet(
+      context,
+      markers.Marker(title: title, position: sample.position),
+    );
+  }
+}
+
+/// A wave-height-coloured pill: direction arrow + "N.N m". The fill colour
+/// follows a calm→high sea-state ramp so the field of chips reads as a
+/// heat-map at a glance.
+class _WaveChip extends StatelessWidget {
+  final OceanGridSample sample;
+  final VoidCallback onTap;
+
+  const _WaveChip({required this.sample, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final heightM = sample.point.waveHeightM ?? 0;
+    final fill = waveStateColor(heightM);
+    final onFill = ThemeData.estimateBrightnessForColor(fill) == Brightness.dark
+        ? Colors.white
+        : Colors.black87;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: fill,
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x33000000),
+              blurRadius: 3,
+              offset: Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              WindArrow(
+                fromDeg: sample.point.waveFromDeg,
+                size: 16,
+                color: onFill,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                '${heightM.toStringAsFixed(1)} m',
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: onFill,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Sea-state colour ramp keyed on significant wave height (metres), loosely
+/// following the WMO sea-state scale: calm → slight → moderate → rough → high.
+Color waveStateColor(double meters) {
+  if (meters < 0.5) return const Color(0xFF1A9850); // calm — green
+  if (meters < 1.25) return const Color(0xFF91CF60); // smooth/slight
+  if (meters < 2.5) return const Color(0xFFFEE08B); // moderate — amber
+  if (meters < 4.0) return const Color(0xFFFC8D59); // rough — orange
+  return const Color(0xFFD73027); // high+ — red
+}

--- a/apps/flutter/test/features/tile_providers/tile_registry_test.dart
+++ b/apps/flutter/test/features/tile_providers/tile_registry_test.dart
@@ -72,6 +72,7 @@ void main() {
         'osm',
         'gs',
         'avalanche_danger',
+        'ocean_conditions',
         'trails_foot',
         'trails_ski',
         'trails_bike',

--- a/apps/flutter/test/features/weather/ocean_conditions_notifier_test.dart
+++ b/apps/flutter/test/features/weather/ocean_conditions_notifier_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:flutter_map/flutter_map.dart' show LatLngBounds;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:turbo/features/weather/api.dart';
+import 'package:turbo/features/weather/data/weather_notifier.dart'
+    show yrOceanServiceProvider;
+import 'package:turbo/features/weather/data/yr_ocean_service.dart';
+
+Map<String, dynamic> _payload(double waveHeight) => {
+      'properties': {
+        'timeseries': [
+          {
+            'time': '2026-05-17T12:00:00Z',
+            'data': {
+              'instant': {
+                'details': {
+                  'sea_surface_wave_height': waveHeight,
+                  'sea_surface_wave_from_direction': 280.0,
+                  'sea_water_temperature': 11.3,
+                  'sea_water_speed': 0.2,
+                },
+              },
+            },
+          }
+        ],
+      },
+    };
+
+ProviderContainer _containerWith(YrOceanService service) {
+  final c = ProviderContainer(overrides: [
+    yrOceanServiceProvider.overrideWithValue(service),
+  ]);
+  addTearDown(c.dispose);
+  return c;
+}
+
+// A small bounds (~0.5° square) off the Norwegian coast.
+final _bounds = LatLngBounds(
+  const LatLng(60.0, 5.0),
+  const LatLng(60.5, 5.5),
+);
+
+void main() {
+  group('OceanConditionsNotifier', () {
+    test('samples a grid of sea points after the debounce window', () async {
+      final client = MockClient((_) async {
+        return http.Response(jsonEncode(_payload(1.4)), 200, headers: const {
+          'content-type': 'application/json; charset=utf-8',
+        });
+      });
+      final c = _containerWith(YrOceanService(client: client));
+
+      c.read(oceanConditionsProvider.notifier).requestBounds(_bounds);
+      // Wait past the 500ms debounce plus the concurrent fetch batch.
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+
+      final samples = c.read(oceanConditionsProvider).value!;
+      // 5×5 grid, all sea points.
+      expect(samples, hasLength(25));
+      expect(samples.every((s) => s.point.waveHeightM == 1.4), isTrue);
+      // Every sampled coordinate falls inside the requested bounds.
+      expect(
+        samples.every((s) =>
+            s.position.latitude >= 60.0 &&
+            s.position.latitude <= 60.5 &&
+            s.position.longitude >= 5.0 &&
+            s.position.longitude <= 5.5),
+        isTrue,
+      );
+    });
+
+    test('excludes land / out-of-coverage points (404)', () async {
+      final client = MockClient((_) async => http.Response('not found', 404));
+      final c = _containerWith(YrOceanService(client: client));
+
+      c.read(oceanConditionsProvider.notifier).requestBounds(_bounds);
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+
+      expect(c.read(oceanConditionsProvider).value, isEmpty);
+    });
+
+    test('clear() empties the rendered samples', () async {
+      final client = MockClient((_) async {
+        return http.Response(jsonEncode(_payload(0.8)), 200, headers: const {
+          'content-type': 'application/json; charset=utf-8',
+        });
+      });
+      final c = _containerWith(YrOceanService(client: client));
+
+      c.read(oceanConditionsProvider.notifier).requestBounds(_bounds);
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+      expect(c.read(oceanConditionsProvider).value, isNotEmpty);
+
+      c.read(oceanConditionsProvider.notifier).clear();
+      expect(c.read(oceanConditionsProvider).value, isEmpty);
+    });
+
+    test('caches by coordinate so re-requesting the same bounds is cheap',
+        () async {
+      var requestCount = 0;
+      final client = MockClient((_) async {
+        requestCount++;
+        return http.Response(jsonEncode(_payload(2.1)), 200, headers: const {
+          'content-type': 'application/json; charset=utf-8',
+        });
+      });
+      final c = _containerWith(YrOceanService(client: client));
+      final notifier = c.read(oceanConditionsProvider.notifier);
+
+      notifier.requestBounds(_bounds);
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+      final firstPass = requestCount;
+      expect(firstPass, 25);
+
+      // Same bounds again — every cell is served from cache, no new requests.
+      notifier.requestBounds(_bounds);
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+      expect(requestCount, firstPass);
+      expect(c.read(oceanConditionsProvider).value, hasLength(25));
+    });
+  });
+}


### PR DESCRIPTION
Surface MET Norway's oceanforecast data (the same source behind the
weather sheet's Sea conditions tab) as a toggleable map overlay. The
layer samples a debounced, cached grid of wave height + direction across
the viewport and renders sea-state-coloured chips; tapping one opens the
full ocean forecast for that point.

- OceanConditionsOverlayConfig: vector-only overlay registered in the
  tile registry, toggled from the layer picker (waves icon)
- OceanConditionsNotifier: grid sampling with debounce, capped
  concurrency, and per-coordinate Expires-aware caching
- OceanConditionsLayer: viewport-reactive MarkerLayer rendering
- en/nb localization and tests