### PR TITLE
feat(photo-map): add map layer plotting geotagged device photos

### DIFF
--- a/apps/flutter/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,14 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Photo-locations map layer: read the device photo library and the GPS
+         EXIF embedded in those photos. READ_MEDIA_IMAGES covers Android 13+,
+         READ_EXTERNAL_STORAGE covers <=12, ACCESS_MEDIA_LOCATION is required
+         to read each photo's location. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <application
         android:label="turbo"
         android:name="${applicationName}"

--- a/apps/flutter/lib/app/l10n/app_localizations.dart
+++ b/apps/flutter/lib/app/l10n/app_localizations.dart
@@ -257,6 +257,10 @@ abstract class AppLocalizations {
   String get dataLayers;
   String get showMarkers;
   String get showPaths;
+  String get showPhotos;
+  String get showPhotosSubtitle;
+  String get photoPermissionRequired;
+  String get photosNotAvailableHere;
   String get pathUpdated;
   String get pathDeleted;
   String errorSavingPath(String error);
@@ -711,6 +715,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get dataLayers => 'Data';
   @override String get showMarkers => 'Markers';
   @override String get showPaths => 'Paths';
+  @override String get showPhotos => 'Photos';
+  @override String get showPhotosSubtitle => 'Where your geotagged photos were taken';
+  @override String get photoPermissionRequired => 'Allow photo access to show where your photos were taken';
+  @override String get photosNotAvailableHere => 'Photo locations aren\'t available on this platform';
   @override String get pathUpdated => 'Path updated';
   @override String get pathDeleted => 'Path deleted';
   @override String errorSavingPath(String error) => 'Error saving path: $error';
@@ -1152,6 +1160,10 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get dataLayers => 'Data';
   @override String get showMarkers => 'Markorer';
   @override String get showPaths => 'Ruter';
+  @override String get showPhotos => 'Bilder';
+  @override String get showPhotosSubtitle => 'Hvor bildene dine med posisjon ble tatt';
+  @override String get photoPermissionRequired => 'Gi tilgang til bilder for a vise hvor bildene ble tatt';
+  @override String get photosNotAvailableHere => 'Bildeposisjoner er ikke tilgjengelig pa denne plattformen';
   @override String get pathUpdated => 'Rute oppdatert';
   @override String get pathDeleted => 'Rute slettet';
   @override String errorSavingPath(String error) => 'Feil ved lagring av rute: $error';

--- a/apps/flutter/lib/features/map_view/widgets/buttons/map_layer_button.dart
+++ b/apps/flutter/lib/features/map_view/widgets/buttons/map_layer_button.dart
@@ -6,6 +6,7 @@ import 'package:turbo/core/widgets/app_section_header.dart';
 import 'package:turbo/features/map_view/api.dart';
 import 'package:turbo/features/tile_providers/api.dart';
 import 'package:turbo/features/saved_paths/api.dart';
+import 'package:turbo/features/photo_map/api.dart';
 import 'package:turbo/features/tile_storage/offline_regions/api.dart'
 as offline_regions_api;
 import 'package:turbo/app/l10n/app_localizations.dart';
@@ -255,6 +256,7 @@ class LayerSelectionSheet extends ConsumerWidget {
     final l10n = context.l10n;
     final markersVisible = ref.watch(markersVisibleProvider);
     final pathsVisible = ref.watch(savedPathsVisibleProvider);
+    final photosVisible = ref.watch(photoLayerVisibleProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -276,6 +278,15 @@ class LayerSelectionSheet extends ConsumerWidget {
           title: Text(l10n.showPaths),
           value: pathsVisible,
           onChanged: (_) => ref.read(savedPathsVisibleProvider.notifier).toggle(),
+        ),
+        SwitchListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 24),
+          secondary: const Icon(Icons.photo_camera_outlined),
+          title: Text(l10n.showPhotos),
+          subtitle: Text(l10n.showPhotosSubtitle),
+          value: photosVisible,
+          onChanged: (_) =>
+              ref.read(photoLayerVisibleProvider.notifier).toggle(),
         ),
         const SizedBox(height: 8),
       ],

--- a/apps/flutter/lib/features/map_view/widgets/main_map_page.dart
+++ b/apps/flutter/lib/features/map_view/widgets/main_map_page.dart
@@ -20,6 +20,7 @@ as offline_api;
 import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/markers/api.dart' as marker_model;
 import 'package:turbo/features/navigation/api.dart';
+import 'package:turbo/features/photo_map/api.dart';
 import 'package:turbo/features/sharing/api.dart';
 
 import 'package:turbo/core/location/compass_mode_state.dart';
@@ -271,6 +272,7 @@ class _MainMapPageState extends ConsumerState<MainMapPage>
       ...trailVectorLayers,
       ViewportMarkers(mapController: _mapController),
       const activities.ActivitiesMapLayer(),
+      PhotoMapLayer(mapController: _mapController),
     ];
 
     final overlayWidgets = <Widget>[

--- a/apps/flutter/lib/features/photo_map/api.dart
+++ b/apps/flutter/lib/features/photo_map/api.dart
@@ -1,0 +1,7 @@
+// Public surface of the photo-locations feature: a map layer that plots
+// where the device's geotagged photos were taken, with grid clustering.
+export 'data/photo_layer_visibility_provider.dart'
+    show photoLayerVisibleProvider;
+export 'data/photo_location_repository.dart'
+    show photoLocationRepositoryProvider, PhotoLocationState, PhotoLibraryStatus;
+export 'widgets/photo_map_layer.dart' show PhotoMapLayer;

--- a/apps/flutter/lib/features/photo_map/data/photo_layer_visibility_provider.dart
+++ b/apps/flutter/lib/features/photo_map/data/photo_layer_visibility_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Whether the photo-locations layer is shown on the map. Defaults to off:
+/// the layer triggers an OS photo-access prompt, so it must be opt-in.
+/// Mirrors the persistence pattern of `markersVisibleProvider`.
+final photoLayerVisibleProvider =
+    NotifierProvider<PhotoLayerVisibleNotifier, bool>(
+  PhotoLayerVisibleNotifier.new,
+);
+
+class PhotoLayerVisibleNotifier extends Notifier<bool> {
+  static const _prefsKey = 'photoLayerVisible';
+
+  @override
+  bool build() {
+    _loadFromPrefs();
+    return false;
+  }
+
+  Future<void> _loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getBool(_prefsKey);
+    if (value != null) {
+      state = value;
+    }
+  }
+
+  void toggle() async {
+    state = !state;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefsKey, state);
+  }
+}

--- a/apps/flutter/lib/features/photo_map/data/photo_location_repository.dart
+++ b/apps/flutter/lib/features/photo_map/data/photo_location_repository.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:logging/logging.dart';
+// Hide photo_manager's `LatLng` in favour of latlong2's.
+import 'package:photo_manager/photo_manager.dart' hide LatLng;
+
+import '../models/photo_location.dart';
+
+final _log = Logger('PhotoLocations');
+
+/// Lifecycle of the device photo-library scan that backs the photo map
+/// layer. [unsupported] is a terminal state for platforms without a photo
+/// library (web/desktop); [permissionDenied] is recoverable — the user can
+/// grant access and we reload.
+enum PhotoLibraryStatus {
+  idle,
+  loading,
+  ready,
+  permissionDenied,
+  unsupported,
+  error,
+}
+
+@immutable
+class PhotoLocationState {
+  final PhotoLibraryStatus status;
+  final List<PhotoLocation> photos;
+  final Object? error;
+
+  const PhotoLocationState({
+    this.status = PhotoLibraryStatus.idle,
+    this.photos = const [],
+    this.error,
+  });
+
+  bool get isReady => status == PhotoLibraryStatus.ready;
+
+  PhotoLocationState copyWith({
+    PhotoLibraryStatus? status,
+    List<PhotoLocation>? photos,
+    Object? error,
+  }) {
+    return PhotoLocationState(
+      status: status ?? this.status,
+      photos: photos ?? this.photos,
+      error: error,
+    );
+  }
+}
+
+/// Scans the device photo library for geotagged images and exposes them as
+/// [PhotoLocation]s. The scan is lazy: it only runs once [ensureLoaded] is
+/// called (when the user first turns the layer on), so the OS photo-access
+/// prompt never appears unprompted.
+final photoLocationRepositoryProvider =
+    NotifierProvider<PhotoLocationNotifier, PhotoLocationState>(
+  PhotoLocationNotifier.new,
+);
+
+class PhotoLocationNotifier extends Notifier<PhotoLocationState> {
+  bool _loading = false;
+
+  @override
+  PhotoLocationState build() => const PhotoLocationState();
+
+  /// photo_manager only ships native implementations for these platforms.
+  /// `defaultTargetPlatform` is web-safe (unlike `dart:io`'s `Platform`).
+  bool get _isSupported {
+    if (kIsWeb) return false;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /// Load once. Repeated calls while ready/loading are no-ops, so this is
+  /// safe to call from `build()` of the layer widget on every rebuild.
+  Future<void> ensureLoaded() async {
+    if (state.status == PhotoLibraryStatus.ready ||
+        state.status == PhotoLibraryStatus.loading) {
+      return;
+    }
+    await load();
+  }
+
+  /// Force a fresh scan, e.g. after the user grants access from settings.
+  Future<void> refresh() async {
+    state = const PhotoLocationState();
+    await load();
+  }
+
+  Future<void> load() async {
+    if (_loading) return;
+    if (!_isSupported) {
+      state = const PhotoLocationState(status: PhotoLibraryStatus.unsupported);
+      return;
+    }
+    _loading = true;
+    state = state.copyWith(status: PhotoLibraryStatus.loading);
+    try {
+      final permission = await PhotoManager.requestPermissionExtend();
+      if (!permission.hasAccess) {
+        state =
+            const PhotoLocationState(status: PhotoLibraryStatus.permissionDenied);
+        return;
+      }
+      final photos = await _fetchGeotaggedPhotos();
+      _log.info('Loaded ${photos.length} geotagged photos');
+      state = PhotoLocationState(
+        status: PhotoLibraryStatus.ready,
+        photos: photos,
+      );
+    } catch (e, st) {
+      _log.warning('Failed to load photo locations', e, st);
+      state = PhotoLocationState(status: PhotoLibraryStatus.error, error: e);
+    } finally {
+      _loading = false;
+    }
+  }
+
+  Future<List<PhotoLocation>> _fetchGeotaggedPhotos() async {
+    // `onlyAll` collapses the library into a single virtual album so we
+    // page through every image exactly once instead of per-album.
+    final paths = await PhotoManager.getAssetPathList(
+      type: RequestType.image,
+      onlyAll: true,
+    );
+    if (paths.isEmpty) return const [];
+
+    final album = paths.first;
+    final total = await album.assetCountAsync;
+    if (total == 0) return const [];
+
+    final result = <PhotoLocation>[];
+    const pageSize = 1000;
+    final pageCount = (total / pageSize).ceil();
+
+    for (var page = 0; page < pageCount; page++) {
+      final assets = await album.getAssetListPaged(page: page, size: pageSize);
+      for (final asset in assets) {
+        // The lat/long carried on the asset come straight from MediaStore
+        // (Android) / PHAsset.location (iOS) — cheap, no per-file EXIF read.
+        // Photos without a fix report null or (0, 0); skip those.
+        final lat = asset.latitude;
+        final lng = asset.longitude;
+        if (lat == null || lng == null) continue;
+        if (lat == 0 && lng == 0) continue;
+        result.add(PhotoLocation(
+          id: asset.id,
+          position: LatLng(lat, lng),
+          asset: asset,
+          createdAt: asset.createDateTime,
+        ));
+      }
+    }
+    return result;
+  }
+}

--- a/apps/flutter/lib/features/photo_map/models/photo_location.dart
+++ b/apps/flutter/lib/features/photo_map/models/photo_location.dart
@@ -1,0 +1,22 @@
+import 'package:latlong2/latlong.dart';
+// photo_manager ships its own `LatLng`; hide it so the project-wide
+// latlong2 type stays unambiguous.
+import 'package:photo_manager/photo_manager.dart' hide LatLng;
+
+/// A single geotagged photo from the device library, paired with the
+/// [LatLng] where it was taken. Holds a reference to the underlying
+/// [AssetEntity] so thumbnails and full-resolution bytes can be loaded
+/// lazily when a marker is rendered or opened.
+class PhotoLocation {
+  final String id;
+  final LatLng position;
+  final AssetEntity asset;
+  final DateTime? createdAt;
+
+  const PhotoLocation({
+    required this.id,
+    required this.position,
+    required this.asset,
+    this.createdAt,
+  });
+}

--- a/apps/flutter/lib/features/photo_map/widgets/photo_map_layer.dart
+++ b/apps/flutter/lib/features/photo_map/widgets/photo_map_layer.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:photo_manager/photo_manager.dart' hide LatLng;
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/core/widgets/map/controller/map_utility.dart';
+
+import '../data/photo_layer_visibility_provider.dart';
+import '../data/photo_location_repository.dart';
+import '../models/photo_location.dart';
+import 'photo_thumbnail.dart';
+import 'photo_viewer.dart';
+
+/// Renders geotagged device photos on the map as grid-clustered markers.
+///
+/// Clustering is done in Web-Mercator pixel space at the current zoom: every
+/// in-view photo is bucketed into a fixed-size pixel grid, so nearby photos
+/// collapse into one badge that naturally splits apart as you zoom in. This
+/// keeps the layer independent of flutter_map's internal projection API and
+/// cheap to recompute on each pan/zoom.
+class PhotoMapLayer extends ConsumerStatefulWidget {
+  final MapController mapController;
+
+  const PhotoMapLayer({super.key, required this.mapController});
+
+  @override
+  ConsumerState<PhotoMapLayer> createState() => _PhotoMapLayerState();
+}
+
+class _PhotoMapLayerState extends ConsumerState<PhotoMapLayer>
+    with TickerProviderStateMixin {
+  // Pixel size of each clustering cell. Photos whose projected positions fall
+  // in the same cell merge into a single marker.
+  static const double _clusterCellPx = 72.0;
+  // Below this zoom a cluster tap zooms in to split it; at/above it a tap
+  // opens the grid sheet because zooming further won't separate the photos.
+  static const double _expandZoomCeiling = 16.0;
+
+  StreamSubscription<MapEvent>? _mapEventSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _mapEventSubscription =
+          widget.mapController.mapEventStream.listen((event) {
+        if (event is MapEventMoveEnd ||
+            event is MapEventRotateEnd ||
+            event is MapEventFlingAnimationEnd ||
+            event is MapEventDoubleTapZoomEnd ||
+            event is MapEventScrollWheelZoom) {
+          // Re-cluster against the new camera. Cheap and keyed off cached
+          // thumbnails, so a plain rebuild is fine.
+          if (mounted) setState(() {});
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _mapEventSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isVisible = ref.watch(photoLayerVisibleProvider);
+
+    // Surface terminal/permission outcomes to the user once, the first time
+    // they occur while the layer is on.
+    ref.listen<PhotoLocationState>(photoLocationRepositoryProvider,
+        (prev, next) {
+      if (!ref.read(photoLayerVisibleProvider)) return;
+      if (prev?.status == next.status) return;
+      if (next.status == PhotoLibraryStatus.permissionDenied) {
+        AppSnackbars.info(context, context.l10n.photoPermissionRequired);
+      } else if (next.status == PhotoLibraryStatus.unsupported) {
+        AppSnackbars.info(context, context.l10n.photosNotAvailableHere);
+      }
+    });
+
+    if (!isVisible) return const SizedBox.shrink();
+
+    final libraryState = ref.watch(photoLocationRepositoryProvider);
+
+    // Kick off the (one-time) scan the first time the layer is shown. Done
+    // off the build phase to avoid mutating providers mid-build.
+    if (libraryState.status == PhotoLibraryStatus.idle) {
+      Future.microtask(
+        () => ref.read(photoLocationRepositoryProvider.notifier).ensureLoaded(),
+      );
+      return const SizedBox.shrink();
+    }
+
+    if (libraryState.photos.isEmpty) return const SizedBox.shrink();
+
+    final clusters = _buildClusters(libraryState.photos);
+    return MarkerLayer(
+      markers: [for (final cluster in clusters) _buildMarker(cluster)],
+    );
+  }
+
+  List<_PhotoCluster> _buildClusters(List<PhotoLocation> photos) {
+    final camera = widget.mapController.camera;
+    final zoom = camera.zoom;
+    final bounds = camera.visibleBounds;
+    final buckets = <String, _PhotoCluster>{};
+
+    for (final photo in photos) {
+      if (!bounds.contains(photo.position)) continue;
+      final px = _pixelX(photo.position.longitude, zoom);
+      final py = _pixelY(photo.position.latitude, zoom);
+      final key = '${(px / _clusterCellPx).floor()}:'
+          '${(py / _clusterCellPx).floor()}';
+      buckets.putIfAbsent(key, () => _PhotoCluster()).add(photo);
+    }
+    return buckets.values.toList(growable: false);
+  }
+
+  Marker _buildMarker(_PhotoCluster cluster) {
+    final representative = cluster.representative;
+    final isCluster = cluster.photos.length > 1;
+    final size = isCluster ? 60.0 : 56.0;
+
+    return Marker(
+      point: representative.position,
+      width: size,
+      height: size,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _onMarkerTap(cluster),
+        child: _PhotoMarkerBadge(
+          asset: representative.asset,
+          size: size,
+          count: isCluster ? cluster.photos.length : null,
+        ),
+      ),
+    );
+  }
+
+  void _onMarkerTap(_PhotoCluster cluster) {
+    if (cluster.photos.length == 1) {
+      showPhotoViewer(context, cluster.photos.first);
+      return;
+    }
+    final camera = widget.mapController.camera;
+    if (camera.zoom < _expandZoomCeiling) {
+      // Zoom toward the cluster so it breaks apart into smaller groups.
+      animatedMapMove(
+        cluster.representative.position,
+        math.min(camera.zoom + 2, _expandZoomCeiling),
+        widget.mapController,
+        this,
+      );
+    } else {
+      showPhotoClusterSheet(context, cluster.photos);
+    }
+  }
+
+  // --- Web Mercator pixel projection (independent of flutter_map internals).
+  double _pixelX(double lon, double zoom) {
+    final n = 256.0 * math.pow(2.0, zoom);
+    return (lon + 180.0) / 360.0 * n;
+  }
+
+  double _pixelY(double lat, double zoom) {
+    final n = 256.0 * math.pow(2.0, zoom);
+    final latRad = lat * math.pi / 180.0;
+    return (1.0 -
+            (math.log(math.tan(latRad) + 1.0 / math.cos(latRad)) / math.pi)) /
+        2.0 *
+        n;
+  }
+}
+
+/// A mutable accumulator for photos that fall into one grid cell. The
+/// representative (shown as the marker's thumbnail) is the most recent photo.
+class _PhotoCluster {
+  final List<PhotoLocation> photos = [];
+
+  void add(PhotoLocation photo) => photos.add(photo);
+
+  PhotoLocation get representative {
+    var best = photos.first;
+    for (final p in photos) {
+      final a = p.createdAt;
+      final b = best.createdAt;
+      if (a != null && (b == null || a.isAfter(b))) best = p;
+    }
+    return best;
+  }
+}
+
+/// The on-map visual: a rounded thumbnail with a white frame and shadow,
+/// plus a count badge when it represents more than one photo.
+class _PhotoMarkerBadge extends StatelessWidget {
+  final AssetEntity asset;
+  final double size;
+  final int? count;
+
+  const _PhotoMarkerBadge({
+    required this.asset,
+    required this.size,
+    this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final thumb = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white, width: 2),
+        boxShadow: const [
+          BoxShadow(color: Colors.black26, blurRadius: 4, offset: Offset(0, 2)),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: PhotoThumbnail(asset: asset, size: size),
+    );
+
+    if (count == null) return thumb;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        thumb,
+        Positioned(
+          top: -6,
+          right: -6,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            constraints: const BoxConstraints(minWidth: 22, minHeight: 22),
+            decoration: BoxDecoration(
+              color: colorScheme.primary,
+              shape: BoxShape.rectangle,
+              borderRadius: BorderRadius.circular(11),
+              border: Border.all(color: Colors.white, width: 1.5),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              count! > 99 ? '99+' : '$count',
+              style: TextStyle(
+                color: colorScheme.onPrimary,
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/flutter/lib/features/photo_map/widgets/photo_thumbnail.dart
+++ b/apps/flutter/lib/features/photo_map/widgets/photo_thumbnail.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart' hide LatLng;
+
+/// Process-wide cache of decoded thumbnails keyed by asset id. Map pans and
+/// zooms rebuild the marker layer constantly; without this each rebuild would
+/// re-decode every visible thumbnail. Bytes are small (square 150px) so a
+/// plain map is fine for the lifetime of the app session.
+final Map<String, Uint8List> _thumbCache = {};
+
+/// A square thumbnail for a photo-library [asset]. Loads once, then serves
+/// from [_thumbCache] on subsequent rebuilds. Shows a neutral placeholder
+/// while loading or if the asset can't be decoded.
+class PhotoThumbnail extends StatefulWidget {
+  final AssetEntity asset;
+  final double size;
+  final BoxFit fit;
+
+  const PhotoThumbnail({
+    super.key,
+    required this.asset,
+    required this.size,
+    this.fit = BoxFit.cover,
+  });
+
+  @override
+  State<PhotoThumbnail> createState() => _PhotoThumbnailState();
+}
+
+class _PhotoThumbnailState extends State<PhotoThumbnail> {
+  Uint8List? _bytes;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final cached = _thumbCache[widget.asset.id];
+    if (cached != null) {
+      _bytes = cached;
+      return;
+    }
+    final data = await widget.asset.thumbnailDataWithSize(
+      const ThumbnailSize.square(150),
+    );
+    if (data != null) {
+      _thumbCache[widget.asset.id] = data;
+    }
+    if (mounted) {
+      setState(() => _bytes = data);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bytes = _bytes;
+    if (bytes == null) {
+      return Container(
+        width: widget.size,
+        height: widget.size,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: Icon(
+          Icons.photo_outlined,
+          size: widget.size * 0.4,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+    return Image.memory(
+      bytes,
+      width: widget.size,
+      height: widget.size,
+      fit: widget.fit,
+      gaplessPlayback: true,
+    );
+  }
+}

--- a/apps/flutter/lib/features/photo_map/widgets/photo_viewer.dart
+++ b/apps/flutter/lib/features/photo_map/widgets/photo_viewer.dart
@@ -1,0 +1,149 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:photo_manager/photo_manager.dart' hide LatLng;
+
+import '../models/photo_location.dart';
+import 'photo_thumbnail.dart';
+
+/// Full-screen viewer for a single geotagged photo. Loads a large preview
+/// (not the full original) to stay memory-safe, and supports pinch-zoom.
+Future<void> showPhotoViewer(BuildContext context, PhotoLocation photo) {
+  return Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (_) => _PhotoViewerPage(photo: photo),
+    ),
+  );
+}
+
+/// Bottom-sheet grid of the photos in a cluster. Tapping one opens the
+/// full-screen viewer. Used when a cluster can't be expanded further by
+/// zooming (already at high zoom) or as the generic "show all" action.
+Future<void> showPhotoClusterSheet(
+  BuildContext context,
+  List<PhotoLocation> photos,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (ctx) => _PhotoClusterSheet(photos: photos),
+  );
+}
+
+class _PhotoViewerPage extends StatelessWidget {
+  final PhotoLocation photo;
+  const _PhotoViewerPage({required this.photo});
+
+  @override
+  Widget build(BuildContext context) {
+    final created = photo.createdAt;
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: created != null
+            ? Text(DateFormat.yMMMMd().add_jm().format(created))
+            : null,
+      ),
+      body: Center(
+        child: InteractiveViewer(
+          maxScale: 5,
+          child: FutureBuilder<Uint8List?>(
+            future: photo.asset.thumbnailDataWithSize(
+              const ThumbnailSize(1080, 1080),
+            ),
+            builder: (context, snapshot) {
+              final bytes = snapshot.data;
+              if (bytes == null) {
+                return const CircularProgressIndicator(color: Colors.white);
+              }
+              return Image.memory(bytes, fit: BoxFit.contain);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PhotoClusterSheet extends StatelessWidget {
+  final List<PhotoLocation> photos;
+  const _PhotoClusterSheet({required this.photos});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.6,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) {
+        return Material(
+          color: colorScheme.surface,
+          borderRadius:
+              const BorderRadius.vertical(top: Radius.circular(24)),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: [
+              const SizedBox(height: 12),
+              Center(
+                child: Container(
+                  width: 32,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colorScheme.outlineVariant,
+                    borderRadius: const BorderRadius.all(Radius.circular(2)),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(Icons.photo_library_outlined,
+                        color: colorScheme.primary),
+                    const SizedBox(width: 12),
+                    Text(
+                      '${photos.length}',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: GridView.builder(
+                  controller: scrollController,
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    mainAxisSpacing: 4,
+                    crossAxisSpacing: 4,
+                  ),
+                  itemCount: photos.length,
+                  itemBuilder: (context, index) {
+                    final photo = photos[index];
+                    return GestureDetector(
+                      onTap: () => showPhotoViewer(context, photo),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: PhotoThumbnail(
+                          asset: photo.asset,
+                          size: double.infinity,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
 import patrol
+import photo_manager
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))
+  PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/apps/flutter/pubspec.lock
+++ b/apps/flutter/pubspec.lock
@@ -1052,6 +1052,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  photo_manager:
+    dependency: "direct main"
+    description:
+      name: photo_manager
+      sha256: fb3bc8ea653370f88742b3baa304700107c83d12748aa58b2b9f2ed3ef15e6c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.0"
   platform:
     dependency: transitive
     description:

--- a/apps/flutter/pubspec.yaml
+++ b/apps/flutter/pubspec.yaml
@@ -71,6 +71,9 @@ dependencies:
   polygon: ^0.1.0
   flutter_compass: ^0.8.1
   image_picker: ^1.1.2
+  # Reads the device photo library (and per-asset GPS) for the
+  # photo-locations map layer. Android/iOS/macOS only — guarded at runtime.
+  photo_manager: ^3.6.4
   logging: ^1.3.0
   connectivity_plus: ^6.1.4
   archive: ^4.0.7

--- a/apps/flutter/test/features/map_view/map_layer_button_test.dart
+++ b/apps/flutter/test/features/map_view/map_layer_button_test.dart
@@ -97,10 +97,11 @@ void main() {
       expect(find.text('Download'), findsOneWidget);
     });
 
-    testWidgets('Markers and Paths SwitchListTiles render with switches',
-        (tester) async {
+    testWidgets('Markers, Paths and Photos SwitchListTiles render with '
+        'switches', (tester) async {
       await _pumpSheet(tester);
-      expect(find.byType(SwitchListTile), findsNWidgets(2));
+      expect(find.byType(SwitchListTile), findsNWidgets(3));
+      expect(find.text('Photos'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Adds an opt-in 'Photos' data layer to the map that scans the device
photo library, reads each photo's GPS location, and plots them as
grid-clustered markers. Nearby photos collapse into a count badge that
splits apart as you zoom in; tapping a single photo opens a full-screen
viewer, tapping a cluster zooms in (or opens a grid sheet when already
zoomed in).

- New feature module lib/features/photo_map (model, repository scan,
  visibility toggle, clustering layer, thumbnail + viewer widgets)
- Lazy, permission-gated load so the OS prompt only appears when the
  layer is first enabled; graceful unsupported/denied handling on
  web/desktop
- Wire layer into main map and add a toggle to the layer-selection sheet
- Android photo + media-location permissions; photo_manager dependency
- Localized strings (en/no) and updated layer-button test