### PR TITLE
refactor(sheets): consolidate detail-sheet actions into adaptive SheetActionBar

### DIFF
--- a/apps/flutter/lib/app/l10n/app_localizations.dart
+++ b/apps/flutter/lib/app/l10n/app_localizations.dart
@@ -22,6 +22,7 @@ abstract class AppLocalizations {
   String get ok;
   String get cancel;
   String get close;
+  String get more;
   String get settings;
   String get theme;
   String get language;
@@ -495,6 +496,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get ok => 'OK';
   @override String get cancel => 'Cancel';
   @override String get close => 'Close';
+  @override String get more => 'More';
   @override String get settings => 'Settings';
   @override String get theme => 'Theme';
   @override String get language => 'Language';
@@ -939,6 +941,7 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get ok => 'OK';
   @override String get cancel => 'Avbryt';
   @override String get close => 'Lukk';
+  @override String get more => 'Mer';
   @override String get settings => 'Innstillinger';
   @override String get theme => 'Tema';
   @override String get language => 'Språk';

--- a/apps/flutter/lib/core/widgets/action_button.dart
+++ b/apps/flutter/lib/core/widgets/action_button.dart
@@ -5,17 +5,25 @@ class ActionButton extends StatelessWidget {
   final String label;
   final VoidCallback? onTap;
 
+  /// Accent for the icon + label. Defaults to the scheme's primary; pass
+  /// `colorScheme.error` for destructive actions. A disabled [onTap] dims
+  /// this automatically.
+  final Color? color;
+
   const ActionButton({
     super.key,
     required this.icon,
     required this.label,
     required this.onTap,
+    this.color,
   });
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+    final base = color ?? colorScheme.primary;
+    final tint = onTap == null ? base.withValues(alpha: 0.38) : base;
 
     return InkWell(
       onTap: onTap,
@@ -25,13 +33,14 @@ class ActionButton extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, color: colorScheme.primary, size: 24),
+            Icon(icon, color: tint, size: 24),
             const SizedBox(height: 4),
             Text(
               label,
-              style: textTheme.labelSmall?.copyWith(
-                color: colorScheme.primary,
-              ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.labelSmall?.copyWith(color: tint),
             ),
           ],
         ),

--- a/apps/flutter/lib/core/widgets/sheet_action_bar.dart
+++ b/apps/flutter/lib/core/widgets/sheet_action_bar.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/app/tokens.dart';
+import 'action_button.dart';
+
+/// A single entry in a [SheetActionBar].
+///
+/// Mark the rare destructive entry (delete, discard) with [isDestructive]
+/// so the bar can tint it with the scheme's error colour both inline and
+/// inside the overflow menu. A `null` [onPressed] renders the action
+/// disabled rather than hiding it.
+class SheetAction {
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+  final bool isDestructive;
+
+  const SheetAction({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.isDestructive = false,
+  });
+}
+
+/// Adaptive action bar for detail / info bottom sheets.
+///
+/// Detail sheets across the app had each grown their own ad-hoc row or
+/// `Wrap` of buttons, which overflowed on narrow phones once a feature
+/// added a fifth or sixth action. This bar gives them one shared layout:
+/// the first few actions render as equal-width icon-over-label buttons,
+/// and any surplus collapses behind a single "More" button that opens a
+/// secondary sheet listing the rest as list tiles.
+///
+/// The result is a sheet that can expose any number of actions without
+/// crowding the row — the high-traffic actions stay one tap away while
+/// the long tail moves one tap deeper.
+class SheetActionBar extends StatelessWidget {
+  final List<SheetAction> actions;
+
+  /// Maximum number of buttons rendered in the row, *including* the
+  /// "More" button when overflow is needed. Four reads comfortably down
+  /// to ~320dp; lower it for sheets with longer labels.
+  final int maxInline;
+
+  const SheetActionBar({
+    super.key,
+    required this.actions,
+    this.maxInline = 4,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final List<SheetAction> inline;
+    final List<SheetAction> overflow;
+    if (actions.length <= maxInline) {
+      inline = actions;
+      overflow = const [];
+    } else {
+      // Reserve the last slot for the "More" affordance.
+      inline = actions.take(maxInline - 1).toList();
+      overflow = actions.skip(maxInline - 1).toList();
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final action in inline)
+          Expanded(
+            child: ActionButton(
+              icon: action.icon,
+              label: action.label,
+              onTap: action.onPressed,
+              color: action.isDestructive ? colorScheme.error : null,
+            ),
+          ),
+        if (overflow.isNotEmpty)
+          Expanded(
+            child: ActionButton(
+              icon: Icons.more_horiz,
+              label: context.l10n.more,
+              onTap: () => _showOverflow(context, overflow),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _showOverflow(
+      BuildContext context, List<SheetAction> overflow) {
+    return showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      builder: (sheetContext) {
+        final colorScheme = Theme.of(sheetContext).colorScheme;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: AppSpacing.s),
+              for (final action in overflow)
+                ListTile(
+                  enabled: action.onPressed != null,
+                  leading: Icon(
+                    action.icon,
+                    color: action.isDestructive ? colorScheme.error : null,
+                  ),
+                  title: Text(
+                    action.label,
+                    style: action.isDestructive
+                        ? TextStyle(color: colorScheme.error)
+                        : null,
+                  ),
+                  onTap: action.onPressed == null
+                      ? null
+                      : () {
+                          // Dismiss the overflow menu first, then run the
+                          // action against the originating sheet's context.
+                          Navigator.of(sheetContext).pop();
+                          action.onPressed!();
+                        },
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/flutter/lib/features/activity_backcountry_ski/widgets/backcountry_ski_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_backcountry_ski/widgets/backcountry_ski_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import '../data/backcountry_ski_repository.dart';
@@ -69,25 +70,23 @@ class BackcountrySkiDetailSheet extends ConsumerWidget {
               ],
               BackcountrySkiConditionsPanel(activityId: a.id),
               const SizedBox(height: 8),
-              Row(
-                children: [
-                  TextButton.icon(
+              SheetActionBar(
+                actions: [
+                  SheetAction(
+                    icon: Icons.close,
+                    label: 'Close',
                     onPressed: () => Navigator.of(context).pop(),
-                    icon: const Icon(Icons.close),
-                    label: const Text('Close'),
                   ),
-                  const Spacer(),
-                  TextButton.icon(
+                  SheetAction(
+                    icon: Icons.edit_outlined,
+                    label: 'Edit',
                     onPressed: () => _openEdit(context, a),
-                    icon: const Icon(Icons.edit_outlined),
-                    label: const Text('Edit'),
                   ),
-                  TextButton.icon(
-                    style: TextButton.styleFrom(
-                        foregroundColor: Theme.of(context).colorScheme.error),
+                  SheetAction(
+                    icon: Icons.delete_outline,
+                    label: 'Delete',
                     onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-                    icon: const Icon(Icons.delete_outline),
-                    label: const Text('Delete'),
+                    isDestructive: true,
                   ),
                 ],
               ),

--- a/apps/flutter/lib/features/activity_fishing/widgets/fishing_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_fishing/widgets/fishing_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import '../data/fishing_repository.dart';
@@ -59,24 +60,23 @@ class FishingDetailSheet extends ConsumerWidget {
               ],
               FishingConditionsPanel(activityId: a.id),
               const SizedBox(height: 8),
-              Row(
-                children: [
-                  TextButton.icon(
+              SheetActionBar(
+                actions: [
+                  SheetAction(
+                    icon: Icons.close,
+                    label: 'Close',
                     onPressed: () => Navigator.of(context).pop(),
-                    icon: const Icon(Icons.close),
-                    label: const Text('Close'),
                   ),
-                  const Spacer(),
-                  TextButton.icon(
+                  SheetAction(
+                    icon: Icons.edit_outlined,
+                    label: 'Edit',
                     onPressed: () => _openEdit(context, a),
-                    icon: const Icon(Icons.edit_outlined),
-                    label: const Text('Edit'),
                   ),
-                  TextButton.icon(
-                    style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+                  SheetAction(
+                    icon: Icons.delete_outline,
+                    label: 'Delete',
                     onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-                    icon: const Icon(Icons.delete_outline),
-                    label: const Text('Delete'),
+                    isDestructive: true,
                   ),
                 ],
               ),

--- a/apps/flutter/lib/features/activity_freediving/widgets/freediving_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_freediving/widgets/freediving_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import '../data/freediving_repository.dart';
@@ -46,18 +47,20 @@ class FreedivingDetailSheet extends ConsumerWidget {
           ],
           FreedivingConditionsPanel(activityId: a.id),
           const SizedBox(height: 8),
-          Row(children: [
-            TextButton.icon(onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.close), label: const Text('Close')),
-            const Spacer(),
-            TextButton.icon(
-              onPressed: () => _openEdit(context, a),
-              icon: const Icon(Icons.edit_outlined),
-              label: const Text('Edit')),
-            TextButton.icon(
-              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+          SheetActionBar(actions: [
+            SheetAction(
+              icon: Icons.close,
+              label: 'Close',
+              onPressed: () => Navigator.of(context).pop()),
+            SheetAction(
+              icon: Icons.edit_outlined,
+              label: 'Edit',
+              onPressed: () => _openEdit(context, a)),
+            SheetAction(
+              icon: Icons.delete_outline,
+              label: 'Delete',
               onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-              icon: const Icon(Icons.delete_outline), label: const Text('Delete')),
+              isDestructive: true),
           ]),
         ]),
       ),

--- a/apps/flutter/lib/features/activity_hiking/widgets/hiking_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_hiking/widgets/hiking_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import '../data/hiking_repository.dart';
@@ -48,18 +49,20 @@ class HikingDetailSheet extends ConsumerWidget {
           ],
           HikingConditionsPanel(activityId: a.id),
           const SizedBox(height: 8),
-          Row(children: [
-            TextButton.icon(onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.close), label: const Text('Close')),
-            const Spacer(),
-            TextButton.icon(
-              onPressed: () => _openEdit(context, a),
-              icon: const Icon(Icons.edit_outlined),
-              label: const Text('Edit')),
-            TextButton.icon(
-              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+          SheetActionBar(actions: [
+            SheetAction(
+              icon: Icons.close,
+              label: 'Close',
+              onPressed: () => Navigator.of(context).pop()),
+            SheetAction(
+              icon: Icons.edit_outlined,
+              label: 'Edit',
+              onPressed: () => _openEdit(context, a)),
+            SheetAction(
+              icon: Icons.delete_outline,
+              label: 'Delete',
               onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-              icon: const Icon(Icons.delete_outline), label: const Text('Delete')),
+              isDestructive: true),
           ]),
         ]),
       ),

--- a/apps/flutter/lib/features/activity_packrafting/widgets/packrafting_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_packrafting/widgets/packrafting_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import 'packrafting_conditions_panel.dart';
@@ -48,18 +49,20 @@ class PackraftingDetailSheet extends ConsumerWidget {
           ],
           PackraftingConditionsPanel(activityId: a.id),
           const SizedBox(height: 8),
-          Row(children: [
-            TextButton.icon(onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.close), label: const Text('Close')),
-            const Spacer(),
-            TextButton.icon(
-              onPressed: () => _openEdit(context, a),
-              icon: const Icon(Icons.edit_outlined),
-              label: const Text('Edit')),
-            TextButton.icon(
-              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+          SheetActionBar(actions: [
+            SheetAction(
+              icon: Icons.close,
+              label: 'Close',
+              onPressed: () => Navigator.of(context).pop()),
+            SheetAction(
+              icon: Icons.edit_outlined,
+              label: 'Edit',
+              onPressed: () => _openEdit(context, a)),
+            SheetAction(
+              icon: Icons.delete_outline,
+              label: 'Delete',
               onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-              icon: const Icon(Icons.delete_outline), label: const Text('Delete')),
+              isDestructive: true),
           ]),
         ]),
       ),

--- a/apps/flutter/lib/features/activity_xc_ski/widgets/xc_ski_detail_sheet.dart
+++ b/apps/flutter/lib/features/activity_xc_ski/widgets/xc_ski_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/features/activities/api.dart' show ActivityGeometry;
 
 import '../data/xc_ski_repository.dart';
@@ -36,18 +37,20 @@ class XcSkiDetailSheet extends ConsumerWidget {
           if (a.details.requiresSeasonPass) _row('Season pass', 'Required'),
           XcSkiConditionsPanel(activityId: a.id),
           const SizedBox(height: 8),
-          Row(children: [
-            TextButton.icon(onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.close), label: const Text('Close')),
-            const Spacer(),
-            TextButton.icon(
-              onPressed: () => _openEdit(context, a),
-              icon: const Icon(Icons.edit_outlined),
-              label: const Text('Edit')),
-            TextButton.icon(
-              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+          SheetActionBar(actions: [
+            SheetAction(
+              icon: Icons.close,
+              label: 'Close',
+              onPressed: () => Navigator.of(context).pop()),
+            SheetAction(
+              icon: Icons.edit_outlined,
+              label: 'Edit',
+              onPressed: () => _openEdit(context, a)),
+            SheetAction(
+              icon: Icons.delete_outline,
+              label: 'Delete',
               onPressed: () => _confirmDelete(context, ref, a.id, a.name),
-              icon: const Icon(Icons.delete_outline), label: const Text('Delete')),
+              isDestructive: true),
           ]),
         ]),
       ),

--- a/apps/flutter/lib/features/markers/widgets/marker_info_sheet.dart
+++ b/apps/flutter/lib/features/markers/widgets/marker_info_sheet.dart
@@ -4,8 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:turbo/core/widgets/action_button.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/activities/api.dart' as activities;
@@ -136,46 +136,42 @@ class _MarkerInfoSheetState extends ConsumerState<MarkerInfoSheet> {
           ),
           const SizedBox(height: 16),
 
-          // Actions row
-          // Action row uses Wrap so the button list flows to a second line
-          // on narrow phones — six buttons (Navigate / Edit / Photo / Export
-          // / Activity / Delete) does not fit a single row at typical mobile
-          // widths and previously overflowed by ~20px.
-          Wrap(
-            alignment: WrapAlignment.spaceEvenly,
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              ActionButton(
+          // Actions: the high-traffic trio (Navigate / Edit / Export) stays
+          // inline; Photo, Save-as-activity and Delete fold into the "More"
+          // overflow so the row never wraps or overflows on narrow phones.
+          SheetActionBar(
+            actions: [
+              SheetAction(
                 icon: Icons.navigation_outlined,
                 label: l10n.navigateToHere,
-                onTap: _startNavigation,
+                onPressed: _startNavigation,
               ),
-              ActionButton(
+              SheetAction(
                 icon: Icons.edit_outlined,
                 label: l10n.edit,
-                onTap: _openEdit,
+                onPressed: _openEdit,
               ),
-              if (!kIsWeb)
-                ActionButton(
-                  icon: Icons.add_a_photo_outlined,
-                  label: 'Photo',
-                  onTap: () => _addPhoto(context),
-                ),
-              ActionButton(
+              SheetAction(
                 icon: Icons.ios_share_outlined,
                 label: l10n.export,
-                onTap: _openExport,
+                onPressed: _openExport,
               ),
-              ActionButton(
+              if (!kIsWeb)
+                SheetAction(
+                  icon: Icons.add_a_photo_outlined,
+                  label: 'Photo',
+                  onPressed: () => _addPhoto(context),
+                ),
+              SheetAction(
                 icon: Icons.outdoor_grill_outlined,
                 label: l10n.saveAsActivity,
-                onTap: _promoteToActivity,
+                onPressed: _promoteToActivity,
               ),
-              ActionButton(
+              SheetAction(
                 icon: Icons.delete_outline,
                 label: l10n.delete,
-                onTap: _isDeleting ? null : _confirmDelete,
+                onPressed: _isDeleting ? null : _confirmDelete,
+                isDestructive: true,
               ),
             ],
           ),

--- a/apps/flutter/lib/features/saved_paths/widgets/path_detail_sheet.dart
+++ b/apps/flutter/lib/features/saved_paths/widgets/path_detail_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:turbo/core/widgets/app_button.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/core/widgets/app_text_field.dart';
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/activities/api.dart' as activities;
 import 'package:turbo/features/settings/api.dart';
@@ -75,22 +76,10 @@ class _PathDetailSheetState extends ConsumerState<PathDetailSheet> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(l10n.editPath, style: textTheme.titleLarge),
-                Row(mainAxisSize: MainAxisSize.min, children: [
-                  if (ref.watch(sharingAvailableProvider))
-                    IconButton(
-                      tooltip: 'Share',
-                      icon: const Icon(Icons.share_outlined),
-                      onPressed: () => ShareSheet.show(
-                        context,
-                        widget.path.uuid,
-                        title: widget.path.title,
-                      ),
-                    ),
-                  IconButton(
-                    onPressed: () => Navigator.pop(context),
-                    icon: const Icon(Icons.close),
-                  ),
-                ]),
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close),
+                ),
               ],
             ),
             const SizedBox(height: 24),
@@ -148,15 +137,29 @@ class _PathDetailSheetState extends ConsumerState<PathDetailSheet> {
               fullWidth: true,
             ),
             const SizedBox(height: 8),
-            // Track promotion: hand this recorded route to the activity
-            // kind picker (filtered to LineString kinds). The user picks
-            // hiking / xc_ski / packrafting / backcountry_ski, fills in
-            // kind-specific details, and a new typed activity is created
-            // sharing this track's geometry.
-            TextButton.icon(
-              onPressed: _isLoading ? null : _promoteToActivity,
-              icon: const Icon(Icons.outdoor_grill_outlined),
-              label: Text(l10n.saveAsActivity),
+            // Secondary actions live in the shared bar beneath the primary
+            // Save CTA. "Save as activity" hands this recorded route to the
+            // activity kind picker (filtered to LineString kinds — hiking /
+            // xc_ski / packrafting / backcountry_ski); Share is gated on the
+            // platform actually supporting it.
+            SheetActionBar(
+              actions: [
+                SheetAction(
+                  icon: Icons.outdoor_grill_outlined,
+                  label: l10n.saveAsActivity,
+                  onPressed: _isLoading ? null : _promoteToActivity,
+                ),
+                if (ref.watch(sharingAvailableProvider))
+                  SheetAction(
+                    icon: Icons.share_outlined,
+                    label: l10n.share,
+                    onPressed: () => ShareSheet.show(
+                      context,
+                      widget.path.uuid,
+                      title: widget.path.title,
+                    ),
+                  ),
+              ],
             ),
           ],
         ),

--- a/apps/flutter/lib/features/saved_paths/widgets/path_info_sheet.dart
+++ b/apps/flutter/lib/features/saved_paths/widgets/path_info_sheet.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:turbo/core/widgets/action_button.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
 import 'package:turbo/core/widgets/app_snackbars.dart';
 import 'package:turbo/features/collections/api.dart';
 import 'package:turbo/features/markers/api.dart';
@@ -136,24 +136,24 @@ class _PathInfoSheetState extends ConsumerState<PathInfoSheet> {
           ),
           const SizedBox(height: 16),
 
-          // Actions row
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              ActionButton(
+          // Actions — same adaptive bar the marker info sheet uses.
+          SheetActionBar(
+            actions: [
+              SheetAction(
                 icon: Icons.edit_outlined,
                 label: l10n.edit,
-                onTap: _openEdit,
+                onPressed: _openEdit,
               ),
-              ActionButton(
+              SheetAction(
                 icon: Icons.ios_share_outlined,
                 label: l10n.export,
-                onTap: _openExport,
+                onPressed: _openExport,
               ),
-              ActionButton(
+              SheetAction(
                 icon: Icons.delete_outline,
                 label: l10n.delete,
-                onTap: _isDeleting ? null : _confirmDelete,
+                onPressed: _isDeleting ? null : _confirmDelete,
+                isDestructive: true,
               ),
             ],
           ),

--- a/apps/flutter/test/core/widgets/sheet_action_bar_test.dart
+++ b/apps/flutter/test/core/widgets/sheet_action_bar_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/sheet_action_bar.dart';
+
+Widget _harness(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: Center(child: child)),
+    );
+
+SheetAction _action(String label, {bool destructive = false, VoidCallback? onPressed}) =>
+    SheetAction(
+      icon: Icons.star,
+      label: label,
+      onPressed: onPressed ?? () {},
+      isDestructive: destructive,
+    );
+
+void main() {
+  group('SheetActionBar', () {
+    testWidgets('renders every action inline when within maxInline',
+        (tester) async {
+      await tester.pumpWidget(_harness(SheetActionBar(actions: [
+        _action('One'),
+        _action('Two'),
+        _action('Three'),
+      ])));
+      await tester.pumpAndSettle();
+
+      expect(find.text('One'), findsOneWidget);
+      expect(find.text('Two'), findsOneWidget);
+      expect(find.text('Three'), findsOneWidget);
+      expect(find.text('More'), findsNothing);
+    });
+
+    testWidgets('collapses the surplus behind a More overflow button',
+        (tester) async {
+      await tester.pumpWidget(_harness(SheetActionBar(actions: [
+        _action('One'),
+        _action('Two'),
+        _action('Three'),
+        _action('Four'),
+        _action('Five'),
+      ])));
+      await tester.pumpAndSettle();
+
+      // With the default maxInline of 4, three actions stay inline and the
+      // rest move behind More.
+      expect(find.text('One'), findsOneWidget);
+      expect(find.text('Two'), findsOneWidget);
+      expect(find.text('Three'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+      expect(find.text('Four'), findsNothing);
+      expect(find.text('Five'), findsNothing);
+    });
+
+    testWidgets('the More menu exposes the overflow actions and fires them',
+        (tester) async {
+      var fourTapped = false;
+      await tester.pumpWidget(_harness(SheetActionBar(actions: [
+        _action('One'),
+        _action('Two'),
+        _action('Three'),
+        _action('Four', onPressed: () => fourTapped = true),
+        _action('Five'),
+      ])));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Four'), findsOneWidget);
+      expect(find.text('Five'), findsOneWidget);
+
+      await tester.tap(find.text('Four'));
+      await tester.pumpAndSettle();
+
+      expect(fourTapped, isTrue);
+      // The overflow menu dismisses itself once an action runs.
+      expect(find.text('Five'), findsNothing);
+    });
+
+    testWidgets('respects a custom maxInline', (tester) async {
+      await tester.pumpWidget(_harness(SheetActionBar(
+        maxInline: 2,
+        actions: [
+          _action('One'),
+          _action('Two'),
+          _action('Three'),
+        ],
+      )));
+      await tester.pumpAndSettle();
+
+      // maxInline 2 → one inline action plus the More button.
+      expect(find.text('One'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
+      expect(find.text('Two'), findsNothing);
+    });
+
+    testWidgets('a null onPressed renders the action disabled', (tester) async {
+      await tester.pumpWidget(_harness(SheetActionBar(actions: [
+        const SheetAction(
+            icon: Icons.delete, label: 'Disabled', onPressed: null),
+      ])));
+      await tester.pumpAndSettle();
+
+      // Still shown, just not tappable — InkWell with a null callback.
+      expect(find.text('Disabled'), findsOneWidget);
+      final inkWell = tester.widget<InkWell>(find.byType(InkWell).first);
+      expect(inkWell.onTap, isNull);
+    });
+  });
+}

--- a/apps/flutter/test/features/markers/marker_info_sheet_test.dart
+++ b/apps/flutter/test/features/markers/marker_info_sheet_test.dart
@@ -190,10 +190,18 @@ void main() {
   });
 
   group('MarkerInfoSheet delete flow', () {
+    // Delete now lives in the "More" overflow menu (the inline row keeps
+    // Navigate / Edit / Export). Open it before reaching for Delete.
+    Future<void> openMoreMenu(WidgetTester tester) async {
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+    }
+
     testWidgets('Delete action opens the destructive confirmation dialog',
         (tester) async {
       await _openSheet(tester);
 
+      await openMoreMenu(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
@@ -206,6 +214,7 @@ void main() {
         'pops the sheet', (tester) async {
       final repo = await _openSheet(tester);
 
+      await openMoreMenu(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
@@ -221,6 +230,7 @@ void main() {
         'invoke deleteMarker', (tester) async {
       final repo = await _openSheet(tester);
 
+      await openMoreMenu(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
@@ -232,15 +242,24 @@ void main() {
   });
 
   group('MarkerInfoSheet Navigate Here action', () {
-    testWidgets('renders 4 action buttons including Navigate Here',
+    testWidgets('renders the inline trio plus a More overflow button',
         (tester) async {
       await _openSheet(tester);
 
+      // High-traffic actions stay inline.
       expect(find.text('Navigate Here'), findsOneWidget);
       expect(find.text('Edit'), findsOneWidget);
       expect(find.text('Export'), findsOneWidget);
-      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('More'), findsOneWidget);
       expect(find.byIcon(Icons.navigation_outlined), findsOneWidget);
+
+      // The long tail (Delete, Save as activity, Photo) is tucked away
+      // until the user opens the overflow menu.
+      expect(find.text('Delete'), findsNothing);
+
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete'), findsOneWidget);
     });
 
     testWidgets('tapping Navigate Here starts navigation, closes the sheet, '


### PR DESCRIPTION
Detail/info bottom sheets had each grown their own ad-hoc row or Wrap of
buttons. The marker info sheet in particular crammed six equal-weight
actions into a Wrap that overflowed on narrow phones, and the six activity
detail sheets each duplicated a Close/Edit/Delete row.

Introduce a shared SheetActionBar + SheetAction pattern: the high-traffic
actions render inline as equal-width icon-over-label buttons, and any
surplus collapses behind a single "More" button that opens a secondary
list sheet. Destructive actions get error tinting inline and in the menu.

- marker info sheet: Navigate/Edit/Export stay inline; Photo, Save-as-
  activity and Delete fold into More (no more overflow).
- six activity detail sheets (fishing, hiking, freediving, xc_ski,
  packrafting, backcountry_ski): replace the duplicated action row with
  the shared bar.
- ActionButton gains an optional color (for destructive tint) plus
  centered, wrap-safe labels for equal-width layouts.
- add 'more' localization (en/nb).