### PR TITLE
fix(flutter): make profile page actions functional

### DIFF
--- a/apps/api/hosts/Turbo.Host.Modulith/SubscriberWiring.cs
+++ b/apps/api/hosts/Turbo.Host.Modulith/SubscriberWiring.cs
@@ -44,6 +44,8 @@ public static class SubscriberWiring
         typeof(Turboapi.Auth.Domain.Events.AccountLastLoginUpdatedEvent),
         typeof(Turboapi.Auth.Domain.Events.RoleAddedToAccountEvent),
         typeof(Turboapi.Auth.Domain.Events.PasswordAuthMethodAddedEvent),
+        typeof(Turboapi.Auth.Domain.Events.PasswordChangedEvent),
+        typeof(Turboapi.Auth.Domain.Events.AccountProfileUpdatedEvent),
         typeof(Turboapi.Auth.Domain.Events.OAuthAuthMethodAddedEvent),
         typeof(Turboapi.Auth.Domain.Events.RefreshTokenGeneratedEvent),
         typeof(Turboapi.Auth.Domain.Events.RefreshTokenRevokedEvent),

--- a/apps/api/src/Auth/Turbo.Auth.Api/AuthModule.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/AuthModule.cs
@@ -7,15 +7,18 @@ using Microsoft.IdentityModel.Tokens;
 using Turbo.Outbox;
 using Turbo.Outbox.Postgres;
 using Turboapi.Auth.Application.Behaviors;
+using Turboapi.Auth.Application.Notifications;
 using Turboapi.Auth.Application.Contracts.V1.Auth;
 using Turboapi.Auth.Application.Interfaces;
 using Turboapi.Auth.Application.Results;
 using Turboapi.Auth.Application.Results.Errors;
 using Turboapi.Auth.Application.UseCases.Commands.AuthenticateWithOAuth;
+using Turboapi.Auth.Application.UseCases.Commands.ChangePassword;
 using Turboapi.Auth.Application.UseCases.Commands.LoginUserWithPassword;
 using Turboapi.Auth.Application.UseCases.Commands.RefreshToken;
 using Turboapi.Auth.Application.UseCases.Commands.RegisterUserWithPassword;
 using Turboapi.Auth.Application.UseCases.Commands.RevokeRefreshToken;
+using Turboapi.Auth.Application.UseCases.Commands.UpdateProfile;
 using Turboapi.Auth.Application.UseCases.Queries.ValidateSession;
 using Turboapi.Auth.Domain.Interfaces;
 using Turboapi.Auth.Infrastructure.Auth;
@@ -54,6 +57,10 @@ public static class AuthModule
 
         services.AddScoped<IAccountRepository, AccountRepository>();
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+        services.AddScoped<IDeviceTokenRepository, Turboapi.Auth.Infrastructure.Notifications.DeviceTokenRepository>();
+        services.Configure<Turboapi.Auth.Infrastructure.Notifications.FcmOptions>(
+            configuration.GetSection(Turboapi.Auth.Infrastructure.Notifications.FcmOptions.SectionName));
+        services.AddScoped<IPushSender, Turboapi.Auth.Infrastructure.Notifications.FcmPushSender>();
         services.AddScoped<IOutbox<AuthScope>, PgOutbox<AuthDbContext, AuthScope>>();
         // Auth's UoW does the aggregate-event drain in addition to the
         // execution-strategy SaveChanges that PgUnitOfWork would do
@@ -67,6 +74,8 @@ public static class AuthModule
         services.AddCommandHandler<RefreshTokenCommand, Result<AuthTokenResponse, RefreshTokenError>, RefreshTokenCommandHandler>();
         services.AddCommandHandler<AuthenticateWithOAuthCommand, Result<AuthTokenResponse, OAuthLoginError>, AuthenticateWithOAuthCommandHandler>();
         services.AddCommandHandler<RevokeRefreshTokenCommand, Result<RefreshTokenError>, RevokeRefreshTokenCommandHandler>();
+        services.AddCommandHandler<ChangePasswordCommand, Result<ChangePasswordError>, ChangePasswordCommandHandler>();
+        services.AddCommandHandler<UpdateProfileCommand, Result<ProfileResponse, UpdateProfileError>, UpdateProfileCommandHandler>();
         services.AddScoped<ValidateSessionQueryHandler>();
 
         services.AddHttpClient();

--- a/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/AuthController.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/AuthController.cs
@@ -1,9 +1,13 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Turboapi.Auth.Application.Contracts.V1.Auth;
 using Turboapi.Auth.Application.Interfaces;
 using Turboapi.Auth.Application.Results;
 using Turboapi.Auth.Application.Results.Errors;
+using Turboapi.Auth.Application.UseCases.Commands.ChangePassword;
 using Turboapi.Auth.Application.UseCases.Commands.LoginUserWithPassword;
 using Turboapi.Auth.Application.UseCases.Commands.RegisterUserWithPassword;
 using Turboapi.Auth.Infrastructure.Auth;
@@ -16,17 +20,20 @@ namespace Turboapi.Auth.Presentation.Controllers
     {
         private readonly ICommandHandler<RegisterUserWithPasswordCommand, Result<AuthTokenResponse, RegistrationError>> _registerHandler;
         private readonly ICommandHandler<LoginUserWithPasswordCommand, Result<AuthTokenResponse, LoginError>> _loginHandler;
+        private readonly ICommandHandler<ChangePasswordCommand, Result<ChangePasswordError>> _changePasswordHandler;
         private readonly ICookieManager _cookieManager;
         private readonly JwtConfig _jwtConfig;
 
         public AuthController(
             ICommandHandler<RegisterUserWithPasswordCommand, Result<AuthTokenResponse, RegistrationError>> registerHandler,
             ICommandHandler<LoginUserWithPasswordCommand, Result<AuthTokenResponse, LoginError>> loginHandler,
+            ICommandHandler<ChangePasswordCommand, Result<ChangePasswordError>> changePasswordHandler,
             ICookieManager cookieManager,
             IOptions<JwtConfig> jwtConfig)
         {
             _registerHandler = registerHandler;
             _loginHandler = loginHandler;
+            _changePasswordHandler = changePasswordHandler;
             _cookieManager = cookieManager;
             _jwtConfig = jwtConfig.Value;
         }
@@ -61,6 +68,36 @@ namespace Turboapi.Auth.Presentation.Controllers
                 failure => {}
             );
 
+            return HandleResult(result);
+        }
+
+        /// <summary>
+        /// Changes the authenticated user's password. Requires the current
+        /// password. Accounts without a password method (e.g. Google sign-in)
+        /// are rejected with 403, since there is no password to change.
+        /// </summary>
+        [HttpPost("change-password")]
+        [Authorize(AuthenticationSchemes = $"{Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme},{JwtBearerDefaults.AuthenticationScheme}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request)
+        {
+            if (request.NewPassword != request.ConfirmNewPassword)
+            {
+                return HandleResult(Result.Failure(ChangePasswordError.InvalidInput));
+            }
+
+            var accountIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                                 ?? User.FindFirstValue("sub");
+            if (!Guid.TryParse(accountIdClaim, out var accountId))
+            {
+                return Unauthorized("Invalid token format: 'sub' claim is not a valid GUID.");
+            }
+
+            var command = new ChangePasswordCommand(accountId, request.CurrentPassword, request.NewPassword);
+            var result = await _changePasswordHandler.Handle(command, HttpContext.RequestAborted);
             return HandleResult(result);
         }
     }

--- a/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/BaseApiController.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/BaseApiController.cs
@@ -55,6 +55,11 @@ namespace Turboapi.Auth.Presentation.Controllers
                 RefreshTokenError e when e == RefreshTokenError.InvalidToken => StatusCodes.Status401Unauthorized,
                 RefreshTokenError e when e == RefreshTokenError.Revoked => StatusCodes.Status401Unauthorized,
                 RefreshTokenError e when e == RefreshTokenError.Expired => StatusCodes.Status401Unauthorized,
+                ChangePasswordError e when e == ChangePasswordError.AccountNotFound => StatusCodes.Status404NotFound,
+                ChangePasswordError e when e == ChangePasswordError.OAuthOnlyAccount => StatusCodes.Status403Forbidden,
+                ChangePasswordError e when e == ChangePasswordError.InvalidCurrentPassword => StatusCodes.Status401Unauthorized,
+                ChangePasswordError e when e == ChangePasswordError.WeakPassword => StatusCodes.Status400BadRequest,
+                UpdateProfileError e when e == UpdateProfileError.AccountNotFound => StatusCodes.Status404NotFound,
                 _ => StatusCodes.Status400BadRequest
             };
             

--- a/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/DevicesController.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/DevicesController.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Turboapi.Auth.Application.Contracts.V1.Notifications;
+using Turboapi.Auth.Domain.Interfaces;
+
+namespace Turboapi.Auth.Presentation.Controllers
+{
+    /// <summary>
+    /// Registration of push-notification device tokens for the authenticated
+    /// user. The client registers its FCM/APNs token after sign-in and on
+    /// token refresh, and unregisters on logout.
+    /// </summary>
+    [ApiController]
+    [Route("api/auth/[controller]")]
+    [Authorize(AuthenticationSchemes = $"{Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme},{JwtBearerDefaults.AuthenticationScheme}")]
+    public class DevicesController : ControllerBase
+    {
+        private readonly IDeviceTokenRepository _deviceTokens;
+
+        public DevicesController(IDeviceTokenRepository deviceTokens)
+        {
+            _deviceTokens = deviceTokens;
+        }
+
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> Register([FromBody] RegisterDeviceRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.Token))
+            {
+                return BadRequest("Token is required.");
+            }
+            if (!TryGetAccountId(out var accountId))
+            {
+                return Unauthorized();
+            }
+
+            await _deviceTokens.RegisterAsync(accountId, request.Token, request.Platform, HttpContext.RequestAborted);
+            return NoContent();
+        }
+
+        [HttpPost("unregister")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> Unregister([FromBody] UnregisterDeviceRequest request)
+        {
+            if (!TryGetAccountId(out _))
+            {
+                return Unauthorized();
+            }
+            if (!string.IsNullOrWhiteSpace(request.Token))
+            {
+                await _deviceTokens.RemoveAsync(request.Token, HttpContext.RequestAborted);
+            }
+            return NoContent();
+        }
+
+        private bool TryGetAccountId(out Guid accountId)
+        {
+            var accountIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                                 ?? User.FindFirstValue("sub");
+            return Guid.TryParse(accountIdClaim, out accountId);
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/ProfileController.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/ProfileController.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Turboapi.Auth.Application.Contracts.V1.Auth;
+using Turboapi.Auth.Application.Interfaces;
+using Turboapi.Auth.Application.Results;
+using Turboapi.Auth.Application.Results.Errors;
+using Turboapi.Auth.Application.UseCases.Commands.UpdateProfile;
+using Turboapi.Auth.Domain.Interfaces;
+
+namespace Turboapi.Auth.Presentation.Controllers
+{
+    [Route("api/auth/[controller]")]
+    [Authorize(AuthenticationSchemes = $"{CookieAuthenticationDefaults.AuthenticationScheme},{JwtBearerDefaults.AuthenticationScheme}")]
+    public class ProfileController : BaseApiController
+    {
+        private readonly ICommandHandler<UpdateProfileCommand, Result<ProfileResponse, UpdateProfileError>> _updateProfileHandler;
+        private readonly IAccountRepository _accountRepository;
+
+        public ProfileController(
+            ICommandHandler<UpdateProfileCommand, Result<ProfileResponse, UpdateProfileError>> updateProfileHandler,
+            IAccountRepository accountRepository)
+        {
+            _updateProfileHandler = updateProfileHandler;
+            _accountRepository = accountRepository;
+        }
+
+        /// <summary>Returns the authenticated user's profile (email + display name).</summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(ProfileResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetProfile()
+        {
+            if (!TryGetAccountId(out var accountId))
+            {
+                return Unauthorized("Invalid token format: 'sub' claim is not a valid GUID.");
+            }
+
+            var account = await _accountRepository.GetByIdAsync(accountId);
+            if (account == null)
+            {
+                return Unauthorized();
+            }
+
+            return Ok(new ProfileResponse(account.Id, account.Email, account.DisplayName));
+        }
+
+        /// <summary>Updates the authenticated user's display name.</summary>
+        [HttpPut]
+        [ProducesResponseType(typeof(ProfileResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> UpdateProfile([FromBody] UpdateProfileRequest request)
+        {
+            if (!TryGetAccountId(out var accountId))
+            {
+                return Unauthorized("Invalid token format: 'sub' claim is not a valid GUID.");
+            }
+
+            var command = new UpdateProfileCommand(accountId, request.DisplayName);
+            var result = await _updateProfileHandler.Handle(command, HttpContext.RequestAborted);
+            return HandleResult(result);
+        }
+
+        private bool TryGetAccountId(out Guid accountId)
+        {
+            var accountIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                                 ?? User.FindFirstValue("sub");
+            return Guid.TryParse(accountIdClaim, out accountId);
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/SessionController.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Api/Presentation/Controllers/SessionController.cs
@@ -48,7 +48,8 @@ namespace Turboapi.Auth.Presentation.Controllers
                 accountId,
                 User.FindFirstValue(ClaimTypes.Email) ?? string.Empty,
                 User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList(),
-                account.IsActive
+                account.IsActive,
+                account.DisplayName
             );
 
             return Ok(response);

--- a/apps/api/src/Auth/Turbo.Auth.Contracts/Events/AccountEvents.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Contracts/Events/AccountEvents.cs
@@ -57,6 +57,18 @@ namespace Turboapi.Auth.Domain.Events
         [property: JsonPropertyName("revokedAt")] DateTime RevokedAt
     ) : DomainEvent, IAccountAssociatedEvent;
 
+    public record PasswordChangedEvent(
+        [property: JsonPropertyName("accountId")] Guid AccountId,
+        [property: JsonPropertyName("authMethodId")] Guid AuthMethodId,
+        [property: JsonPropertyName("changedAt")] DateTime ChangedAt
+    ) : DomainEvent, IAccountAssociatedEvent;
+
+    public record AccountProfileUpdatedEvent(
+        [property: JsonPropertyName("accountId")] Guid AccountId,
+        [property: JsonPropertyName("displayName")] string? DisplayName,
+        [property: JsonPropertyName("updatedAt")] DateTime UpdatedAt
+    ) : DomainEvent, IAccountAssociatedEvent;
+
     public record SuspiciousRefreshTokenAttemptEvent(
         [property: JsonPropertyName("accountId")] Guid AccountId,
         [property: JsonPropertyName("tokenAttempted")] string TokenAttempted,

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/Contracts/V1/Auth/ProfileDtos.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/Contracts/V1/Auth/ProfileDtos.cs
@@ -1,0 +1,15 @@
+namespace Turboapi.Auth.Application.Contracts.V1.Auth
+{
+    public record ChangePasswordRequest(
+        string CurrentPassword,
+        string NewPassword,
+        string ConfirmNewPassword);
+
+    public record UpdateProfileRequest(
+        string? DisplayName);
+
+    public record ProfileResponse(
+        Guid AccountId,
+        string Email,
+        string? DisplayName);
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/Contracts/V1/Notifications/DeviceDtos.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/Contracts/V1/Notifications/DeviceDtos.cs
@@ -1,0 +1,9 @@
+namespace Turboapi.Auth.Application.Contracts.V1.Notifications
+{
+    public record RegisterDeviceRequest(
+        string Token,
+        string Platform);
+
+    public record UnregisterDeviceRequest(
+        string Token);
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/Notifications/IPushSender.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/Notifications/IPushSender.cs
@@ -1,0 +1,29 @@
+namespace Turboapi.Auth.Application.Notifications
+{
+    /// <summary>
+    /// A single push notification addressed to a user. Triggers (friend
+    /// requests, shares, …) construct one of these and hand it to
+    /// <see cref="IPushSender"/>, which fans it out to the account's
+    /// registered device tokens.
+    /// </summary>
+    public record PushNotification(
+        Guid AccountId,
+        string Title,
+        string Body,
+        IReadOnlyDictionary<string, string>? Data = null);
+
+    /// <summary>
+    /// Delivers push notifications to a user's devices. The concrete
+    /// implementation (FCM) is a no-op until the deployment is configured
+    /// with provider credentials, so callers can fire notifications
+    /// unconditionally without guarding on configuration.
+    /// </summary>
+    public interface IPushSender
+    {
+        /// <summary>True when a real delivery backend is configured.</summary>
+        bool IsConfigured { get; }
+
+        /// <summary>Sends a notification to every device registered for the account.</summary>
+        Task SendAsync(PushNotification notification, CancellationToken cancellationToken = default);
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/Results/Errors/ErrorEnums.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/Results/Errors/ErrorEnums.cs
@@ -72,12 +72,29 @@ namespace Turboapi.Auth.Application.Results.Errors
         InvalidState // If state validation fails (though not explicitly in current command)
     }
     
-    public enum SessionValidationError 
+    public enum SessionValidationError
     {
         None = 0,
         TokenInvalid,
         TokenExpired,
-        UserNotFound, 
-        AccountInactive 
+        UserNotFound,
+        AccountInactive
+    }
+
+    public enum ChangePasswordError
+    {
+        None = 0,
+        AccountNotFound,        // No account for the authenticated id
+        OAuthOnlyAccount,       // Account has no password method (e.g. Google) -> cannot change a password it doesn't have
+        InvalidCurrentPassword, // Supplied current password did not match
+        WeakPassword,           // New password failed policy
+        InvalidInput            // Malformed request (e.g. confirmation mismatch)
+    }
+
+    public enum UpdateProfileError
+    {
+        None = 0,
+        AccountNotFound,
+        InvalidInput // e.g. display name too long
     }
 }

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/ChangePassword/ChangePasswordCommand.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/ChangePassword/ChangePasswordCommand.cs
@@ -1,0 +1,7 @@
+namespace Turboapi.Auth.Application.UseCases.Commands.ChangePassword
+{
+    public record ChangePasswordCommand(
+        Guid AccountId,
+        string CurrentPassword,
+        string NewPassword);
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/ChangePassword/ChangePasswordHandler.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/ChangePassword/ChangePasswordHandler.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+using Turboapi.Auth.Application.Interfaces;
+using Turboapi.Auth.Application.Results;
+using Turboapi.Auth.Application.Results.Errors;
+using Turboapi.Auth.Domain.Interfaces;
+
+namespace Turboapi.Auth.Application.UseCases.Commands.ChangePassword
+{
+    public class ChangePasswordCommandHandler
+        : ICommandHandler<ChangePasswordCommand, Result<ChangePasswordError>>
+    {
+        private readonly IAccountRepository _accountRepository;
+        private readonly IPasswordHasher _passwordHasher;
+        private readonly ILogger<ChangePasswordCommandHandler> _logger;
+
+        public ChangePasswordCommandHandler(
+            IAccountRepository accountRepository,
+            IPasswordHasher passwordHasher,
+            ILogger<ChangePasswordCommandHandler> logger)
+        {
+            _accountRepository = accountRepository;
+            _passwordHasher = passwordHasher;
+            _logger = logger;
+        }
+
+        public async Task<Result<ChangePasswordError>> Handle(
+            ChangePasswordCommand command,
+            CancellationToken cancellationToken)
+        {
+            var account = await _accountRepository.GetByIdAsync(command.AccountId);
+            if (account == null)
+            {
+                _logger.LogWarning("Change-password requested for unknown account {AccountId}", command.AccountId);
+                return ChangePasswordError.AccountNotFound;
+            }
+
+            var result = account.ChangePassword(command.CurrentPassword, command.NewPassword, _passwordHasher);
+            if (result.IsFailure)
+            {
+                return result;
+            }
+
+            await _accountRepository.UpdateAsync(account);
+            // UnitOfWorkCommandHandlerDecorator persists and drains domain events.
+            return Result.Success<ChangePasswordError>();
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/UpdateProfile/UpdateProfileCommand.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/UpdateProfile/UpdateProfileCommand.cs
@@ -1,0 +1,6 @@
+namespace Turboapi.Auth.Application.UseCases.Commands.UpdateProfile
+{
+    public record UpdateProfileCommand(
+        Guid AccountId,
+        string? DisplayName);
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/UpdateProfile/UpdateProfileHandler.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Commands/UpdateProfile/UpdateProfileHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+using Turboapi.Auth.Application.Contracts.V1.Auth;
+using Turboapi.Auth.Application.Interfaces;
+using Turboapi.Auth.Application.Results;
+using Turboapi.Auth.Application.Results.Errors;
+using Turboapi.Auth.Domain.Interfaces;
+
+namespace Turboapi.Auth.Application.UseCases.Commands.UpdateProfile
+{
+    public class UpdateProfileCommandHandler
+        : ICommandHandler<UpdateProfileCommand, Result<ProfileResponse, UpdateProfileError>>
+    {
+        private readonly IAccountRepository _accountRepository;
+        private readonly ILogger<UpdateProfileCommandHandler> _logger;
+
+        public UpdateProfileCommandHandler(
+            IAccountRepository accountRepository,
+            ILogger<UpdateProfileCommandHandler> logger)
+        {
+            _accountRepository = accountRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<ProfileResponse, UpdateProfileError>> Handle(
+            UpdateProfileCommand command,
+            CancellationToken cancellationToken)
+        {
+            var account = await _accountRepository.GetByIdAsync(command.AccountId);
+            if (account == null)
+            {
+                _logger.LogWarning("Profile update requested for unknown account {AccountId}", command.AccountId);
+                return UpdateProfileError.AccountNotFound;
+            }
+
+            var result = account.UpdateProfile(command.DisplayName);
+            if (result.IsFailure)
+            {
+                return result.Error!;
+            }
+
+            await _accountRepository.UpdateAsync(account);
+            return new ProfileResponse(account.Id, account.Email, account.DisplayName);
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Queries/ValidateSession/ValidateSession.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Application/UseCases/Queries/ValidateSession/ValidateSession.cs
@@ -4,5 +4,6 @@ namespace Turboapi.Auth.Application.UseCases.Queries.ValidateSession
         Guid AccountId,
         string Email,
         IEnumerable<string> Roles,
-        bool IsActive);
+        bool IsActive,
+        string? DisplayName = null);
 }

--- a/apps/api/src/Auth/Turbo.Auth.Core/Domain/Aggregates/Account.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Domain/Aggregates/Account.cs
@@ -9,8 +9,11 @@ namespace Turboapi.Auth.Domain.Aggregates
 {
     public class Account : IHasDomainEvents
     {
+        public const int MaxDisplayNameLength = 64;
+
         public Guid Id { get; private set; }
         public string Email { get; private set; }
+        public string? DisplayName { get; private set; }
         public bool IsActive { get; private set; } // New property
         public DateTime CreatedAt { get; private set; }
         public DateTime? LastLoginAt { get; private set; }
@@ -195,6 +198,54 @@ namespace Turboapi.Auth.Domain.Aggregates
 
             _authenticationMethods.Add(oAuthAuth);
             AddDomainEvent(new OAuthAuthMethodAddedEvent(Id, authMethodId, providerName, externalUserId, oAuthAuth.CreatedAt));
+        }
+
+        /// <summary>True when the account can authenticate with a password.</summary>
+        public bool HasPasswordAuthMethod()
+            => _authenticationMethods.OfType<PasswordAuthMethod>().Any();
+
+        /// <summary>
+        /// Changes the account's password. Returns <see cref="ChangePasswordError.OAuthOnlyAccount"/>
+        /// for accounts with no password method (e.g. Google sign-in), and
+        /// <see cref="ChangePasswordError.InvalidCurrentPassword"/> when the supplied current
+        /// password does not match. The new password is hashed via <paramref name="passwordHasher"/>.
+        /// </summary>
+        public Result<ChangePasswordError> ChangePassword(
+            string currentPassword,
+            string newPassword,
+            IPasswordHasher passwordHasher)
+        {
+            if (passwordHasher == null)
+                throw new ArgumentNullException(nameof(passwordHasher));
+            if (string.IsNullOrWhiteSpace(newPassword))
+                return ChangePasswordError.WeakPassword;
+
+            var passwordMethod = _authenticationMethods.OfType<PasswordAuthMethod>().FirstOrDefault();
+            if (passwordMethod == null)
+                return ChangePasswordError.OAuthOnlyAccount;
+
+            if (!passwordHasher.VerifyPassword(currentPassword, passwordMethod.PasswordHash))
+                return ChangePasswordError.InvalidCurrentPassword;
+
+            var newHash = passwordHasher.HashPassword(newPassword);
+            passwordMethod.UpdatePasswordHash(newHash);
+
+            AddDomainEvent(new PasswordChangedEvent(Id, passwordMethod.Id, DateTime.UtcNow));
+            return Result.Success<ChangePasswordError>();
+        }
+
+        /// <summary>
+        /// Updates the human-readable display name. Pass null or whitespace to clear it.
+        /// </summary>
+        public Result<UpdateProfileError> UpdateProfile(string? displayName)
+        {
+            var normalized = string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim();
+            if (normalized is { Length: > MaxDisplayNameLength })
+                return UpdateProfileError.InvalidInput;
+
+            DisplayName = normalized;
+            AddDomainEvent(new AccountProfileUpdatedEvent(Id, DisplayName, DateTime.UtcNow));
+            return Result.Success<UpdateProfileError>();
         }
 
         internal void AddRefreshToken(RefreshToken refreshToken)

--- a/apps/api/src/Auth/Turbo.Auth.Core/Domain/Aggregates/PasswordAuthMethod.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Domain/Aggregates/PasswordAuthMethod.cs
@@ -20,5 +20,18 @@ namespace Turboapi.Auth.Domain.Aggregates
                 throw new DomainException("Password hash cannot be empty for PasswordAuthMethod.");
             PasswordHash = passwordHash;
         }
+
+        /// <summary>
+        /// Replaces the stored hash. Callers are responsible for having
+        /// verified the current password and produced the new hash via
+        /// <c>IPasswordHasher</c>; this method only mutates state.
+        /// </summary>
+        public void UpdatePasswordHash(string newPasswordHash)
+        {
+            if (string.IsNullOrWhiteSpace(newPasswordHash))
+                throw new DomainException("Password hash cannot be empty for PasswordAuthMethod.");
+            PasswordHash = newPasswordHash;
+            UpdateLastUsed();
+        }
     }
 }

--- a/apps/api/src/Auth/Turbo.Auth.Core/Domain/Interfaces/IDeviceTokenRepository.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Domain/Interfaces/IDeviceTokenRepository.cs
@@ -1,0 +1,19 @@
+using Turboapi.Auth.Domain.Notifications;
+
+namespace Turboapi.Auth.Domain.Interfaces
+{
+    public interface IDeviceTokenRepository
+    {
+        /// <summary>
+        /// Registers (or refreshes) a device token for an account. Idempotent:
+        /// re-registering an existing token updates its account/platform/liveness.
+        /// </summary>
+        Task RegisterAsync(Guid accountId, string token, string platform, CancellationToken cancellationToken = default);
+
+        /// <summary>Removes a token (e.g. on logout / token rotation). No-op if absent.</summary>
+        Task RemoveAsync(string token, CancellationToken cancellationToken = default);
+
+        /// <summary>All active tokens for an account — the fan-out set when sending a push.</summary>
+        Task<IReadOnlyList<DeviceToken>> GetByAccountAsync(Guid accountId, CancellationToken cancellationToken = default);
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Core/Domain/Notifications/DeviceToken.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Core/Domain/Notifications/DeviceToken.cs
@@ -1,0 +1,53 @@
+using Turboapi.Auth.Domain.Exceptions;
+
+namespace Turboapi.Auth.Domain.Notifications
+{
+    /// <summary>
+    /// A push-notification delivery target — one row per device/installation
+    /// token (FCM/APNs). Keyed by the opaque provider token so re-registering
+    /// the same device is an idempotent upsert. Not part of the Account
+    /// aggregate: tokens churn independently of account state and are written
+    /// on their own request path.
+    /// </summary>
+    public class DeviceToken
+    {
+        public string Token { get; private set; }
+        public Guid AccountId { get; private set; }
+        public string Platform { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime LastSeenAt { get; private set; }
+
+        public static readonly IReadOnlyCollection<string> SupportedPlatforms =
+            new[] { "android", "ios", "web" };
+
+        private DeviceToken() { }
+
+        public DeviceToken(string token, Guid accountId, string platform)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                throw new DomainException("Device token cannot be empty.");
+            if (accountId == Guid.Empty)
+                throw new DomainException("Device token must belong to an account.");
+
+            Token = token;
+            AccountId = accountId;
+            Platform = NormalizePlatform(platform);
+            CreatedAt = DateTime.UtcNow;
+            LastSeenAt = CreatedAt;
+        }
+
+        /// <summary>Re-points an existing token row at the current account and refreshes liveness.</summary>
+        public void Refresh(Guid accountId, string platform)
+        {
+            AccountId = accountId;
+            Platform = NormalizePlatform(platform);
+            LastSeenAt = DateTime.UtcNow;
+        }
+
+        private static string NormalizePlatform(string platform)
+        {
+            var normalized = (platform ?? string.Empty).Trim().ToLowerInvariant();
+            return SupportedPlatforms.Contains(normalized) ? normalized : "unknown";
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/DeviceTokenRepository.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/DeviceTokenRepository.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Turboapi.Auth.Domain.Interfaces;
+using Turboapi.Auth.Domain.Notifications;
+using Turboapi.Auth.Infrastructure.Persistence;
+
+namespace Turboapi.Auth.Infrastructure.Notifications
+{
+    /// <summary>
+    /// Device tokens are not an aggregate and aren't part of the outbox/UoW
+    /// command path, so this repository persists its own changes directly.
+    /// </summary>
+    public class DeviceTokenRepository : IDeviceTokenRepository
+    {
+        private readonly AuthDbContext _context;
+
+        public DeviceTokenRepository(AuthDbContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public async Task RegisterAsync(Guid accountId, string token, string platform, CancellationToken cancellationToken = default)
+        {
+            var existing = await _context.DeviceTokens
+                .FirstOrDefaultAsync(d => d.Token == token, cancellationToken);
+
+            if (existing == null)
+            {
+                await _context.DeviceTokens.AddAsync(new DeviceToken(token, accountId, platform), cancellationToken);
+            }
+            else
+            {
+                existing.Refresh(accountId, platform);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        public async Task RemoveAsync(string token, CancellationToken cancellationToken = default)
+        {
+            var existing = await _context.DeviceTokens
+                .FirstOrDefaultAsync(d => d.Token == token, cancellationToken);
+            if (existing == null) return;
+
+            _context.DeviceTokens.Remove(existing);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<DeviceToken>> GetByAccountAsync(Guid accountId, CancellationToken cancellationToken = default)
+        {
+            return await _context.DeviceTokens
+                .Where(d => d.AccountId == accountId)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/FcmOptions.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/FcmOptions.cs
@@ -1,0 +1,27 @@
+namespace Turboapi.Auth.Infrastructure.Notifications
+{
+    /// <summary>
+    /// Firebase Cloud Messaging configuration, bound from the
+    /// "Notifications:Fcm" configuration section. Until both
+    /// <see cref="ProjectId"/> and <see cref="ServiceAccountJson"/> (or
+    /// <see cref="ServiceAccountJsonPath"/>) are supplied, the push sender
+    /// stays in no-op mode.
+    /// </summary>
+    public class FcmOptions
+    {
+        public const string SectionName = "Notifications:Fcm";
+
+        /// <summary>The Firebase project id (FCM HTTP v1 targets /v1/projects/{ProjectId}/messages:send).</summary>
+        public string? ProjectId { get; set; }
+
+        /// <summary>Inline service-account JSON (e.g. injected from a secret).</summary>
+        public string? ServiceAccountJson { get; set; }
+
+        /// <summary>Path to a service-account JSON file, as an alternative to <see cref="ServiceAccountJson"/>.</summary>
+        public string? ServiceAccountJsonPath { get; set; }
+
+        public bool IsConfigured =>
+            !string.IsNullOrWhiteSpace(ProjectId) &&
+            (!string.IsNullOrWhiteSpace(ServiceAccountJson) || !string.IsNullOrWhiteSpace(ServiceAccountJsonPath));
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/FcmPushSender.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Notifications/FcmPushSender.cs
@@ -1,0 +1,124 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Turboapi.Auth.Application.Notifications;
+using Turboapi.Auth.Domain.Interfaces;
+
+namespace Turboapi.Auth.Infrastructure.Notifications
+{
+    /// <summary>
+    /// Firebase Cloud Messaging implementation of <see cref="IPushSender"/>.
+    ///
+    /// SCAFFOLD: the fan-out (account -> device tokens), the FCM HTTP v1
+    /// payload shape, and the per-token POST are all wired here. The one
+    /// remaining step before notifications actually deliver is obtaining an
+    /// OAuth2 access token from the Firebase service account — see
+    /// <see cref="TryGetAccessTokenAsync"/>. Until credentials are configured
+    /// (and that method is completed), <see cref="IsConfigured"/> is false and
+    /// <see cref="SendAsync"/> is a logged no-op, so triggers can call it
+    /// unconditionally today without breaking.
+    /// </summary>
+    public class FcmPushSender : IPushSender
+    {
+        private readonly IDeviceTokenRepository _deviceTokens;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly FcmOptions _options;
+        private readonly ILogger<FcmPushSender> _logger;
+
+        public FcmPushSender(
+            IDeviceTokenRepository deviceTokens,
+            IHttpClientFactory httpClientFactory,
+            IOptions<FcmOptions> options,
+            ILogger<FcmPushSender> logger)
+        {
+            _deviceTokens = deviceTokens;
+            _httpClientFactory = httpClientFactory;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        public bool IsConfigured => _options.IsConfigured;
+
+        public async Task SendAsync(PushNotification notification, CancellationToken cancellationToken = default)
+        {
+            var tokens = await _deviceTokens.GetByAccountAsync(notification.AccountId, cancellationToken);
+            if (tokens.Count == 0)
+            {
+                _logger.LogDebug("No device tokens registered for account {AccountId}; skipping push.", notification.AccountId);
+                return;
+            }
+
+            if (!IsConfigured)
+            {
+                _logger.LogDebug(
+                    "FCM not configured (Notifications:Fcm); would have sent '{Title}' to {Count} device(s) for {AccountId}.",
+                    notification.Title, tokens.Count, notification.AccountId);
+                return;
+            }
+
+            var accessToken = await TryGetAccessTokenAsync(cancellationToken);
+            if (accessToken == null)
+            {
+                _logger.LogWarning(
+                    "FCM credentials are configured but the service-account access token could not be acquired; " +
+                    "complete FcmPushSender.TryGetAccessTokenAsync to enable delivery. See docs/notifications/push-setup.md.");
+                return;
+            }
+
+            var client = _httpClientFactory.CreateClient();
+            var endpoint = $"https://fcm.googleapis.com/v1/projects/{_options.ProjectId}/messages:send";
+
+            foreach (var device in tokens)
+            {
+                var payload = new
+                {
+                    message = new
+                    {
+                        token = device.Token,
+                        notification = new { title = notification.Title, body = notification.Body },
+                        data = notification.Data
+                    }
+                };
+
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                {
+                    Content = JsonContent.Create(payload)
+                };
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+                try
+                {
+                    var response = await client.SendAsync(request, cancellationToken);
+                    if (response.StatusCode == System.Net.HttpStatusCode.NotFound ||
+                        response.StatusCode == System.Net.HttpStatusCode.Gone)
+                    {
+                        // Stale token — FCM says the registration is no longer valid.
+                        await _deviceTokens.RemoveAsync(device.Token, cancellationToken);
+                    }
+                    else if (!response.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("FCM send to {Platform} device failed: {Status}", device.Platform, response.StatusCode);
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "FCM send to a {Platform} device threw.", device.Platform);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Acquires an OAuth2 bearer token for the FCM HTTP v1 API from the
+        /// configured service account.
+        ///
+        /// TODO(push): implement using the service-account credentials in
+        /// <see cref="FcmOptions"/> — e.g. add the Google.Apis.Auth package and
+        /// return <c>await GoogleCredential.FromJson(json)
+        ///   .CreateScoped("https://www.googleapis.com/auth/firebase.messaging")
+        ///   .UnderlyingCredential.GetAccessTokenForRequestAsync()</c>.
+        /// Returning null keeps delivery disabled without throwing.
+        /// </summary>
+        private Task<string?> TryGetAccessTokenAsync(CancellationToken cancellationToken)
+            => Task.FromResult<string?>(null);
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/AuthDbContext.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/AuthDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Reflection;
 using Turbo.Outbox.Postgres;
 using Turboapi.Auth.Domain.Aggregates;
+using Turboapi.Auth.Domain.Notifications;
 
 namespace Turboapi.Auth.Infrastructure.Persistence
 {
@@ -17,6 +18,7 @@ namespace Turboapi.Auth.Infrastructure.Persistence
         public DbSet<OAuthAuthMethod> OAuthAuthMethods { get; set; } = null!;
         public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
         public DbSet<Role> Roles { get; set; } = null!;
+        public DbSet<DeviceToken> DeviceTokens { get; set; } = null!;
         public DbSet<OutboxRow> Outbox { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Configuration/AccountConfiguration.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Configuration/AccountConfiguration.cs
@@ -22,6 +22,10 @@ namespace Turboapi.Auth.Infrastructure.Persistence.Configuration
 
             builder.HasIndex(a => a.Email).IsUnique();
 
+            builder.Property(a => a.DisplayName)
+                .HasColumnName("display_name")
+                .HasMaxLength(Domain.Aggregates.Account.MaxDisplayNameLength);
+
             builder.Property(a => a.IsActive)
                 .HasColumnName("is_active")
                 .IsRequired()

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Configuration/DeviceTokenConfiguration.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Configuration/DeviceTokenConfiguration.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Turboapi.Auth.Domain.Notifications;
+
+namespace Turboapi.Auth.Infrastructure.Persistence.Configuration
+{
+    public class DeviceTokenConfiguration : IEntityTypeConfiguration<DeviceToken>
+    {
+        public void Configure(EntityTypeBuilder<DeviceToken> builder)
+        {
+            builder.ToTable("device_tokens");
+
+            builder.HasKey(d => d.Token);
+            builder.Property(d => d.Token)
+                .HasColumnName("token")
+                .HasMaxLength(512) // FCM/APNs tokens are well under this; keeps the PK b-tree index within Postgres limits
+                .ValueGeneratedNever();
+
+            builder.Property(d => d.AccountId)
+                .HasColumnName("account_id")
+                .IsRequired();
+
+            builder.Property(d => d.Platform)
+                .HasColumnName("platform")
+                .HasMaxLength(16)
+                .IsRequired();
+
+            builder.Property(d => d.CreatedAt)
+                .HasColumnName("created_at")
+                .IsRequired();
+
+            builder.Property(d => d.LastSeenAt)
+                .HasColumnName("last_seen_at")
+                .IsRequired();
+
+            builder.HasIndex(d => d.AccountId);
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528194738_AddAccountDisplayName.Designer.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528194738_AddAccountDisplayName.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Turboapi.Auth.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Turboapi.Auth.Infrastructure.Persistence;
 namespace Turboapi.Auth.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528194738_AddAccountDisplayName")]
+    partial class AddAccountDisplayName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -264,38 +267,6 @@ namespace Turboapi.Auth.Infrastructure.Persistence.Migrations
                         .IsUnique();
 
                     b.ToTable("roles", (string)null);
-                });
-
-            modelBuilder.Entity("Turboapi.Auth.Domain.Notifications.DeviceToken", b =>
-                {
-                    b.Property<string>("Token")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)")
-                        .HasColumnName("token");
-
-                    b.Property<Guid>("AccountId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("account_id");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<DateTime>("LastSeenAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("last_seen_at");
-
-                    b.Property<string>("Platform")
-                        .IsRequired()
-                        .HasMaxLength(16)
-                        .HasColumnType("character varying(16)")
-                        .HasColumnName("platform");
-
-                    b.HasKey("Token");
-
-                    b.HasIndex("AccountId");
-
-                    b.ToTable("device_tokens", (string)null);
                 });
 
             modelBuilder.Entity("Turboapi.Auth.Domain.Aggregates.OAuthAuthMethod", b =>

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528194738_AddAccountDisplayName.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528194738_AddAccountDisplayName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Turboapi.Auth.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccountDisplayName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "display_name",
+                table: "accounts",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "display_name",
+                table: "accounts");
+        }
+    }
+}

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528195344_AddDeviceTokens.Designer.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528195344_AddDeviceTokens.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Turboapi.Auth.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Turboapi.Auth.Infrastructure.Persistence;
 namespace Turboapi.Auth.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528195344_AddDeviceTokens")]
+    partial class AddDeviceTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528195344_AddDeviceTokens.cs
+++ b/apps/api/src/Auth/Turbo.Auth.Infrastructure/Infrastructure/Persistence/Migrations/20260528195344_AddDeviceTokens.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Turboapi.Auth.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "device_tokens",
+                columns: table => new
+                {
+                    token = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    account_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    platform = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_seen_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_device_tokens", x => x.token);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_device_tokens_account_id",
+                table: "device_tokens",
+                column: "account_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "device_tokens");
+        }
+    }
+}

--- a/apps/api/tests/Turbo.Auth.Behaviour/AccountChangePasswordTests.cs
+++ b/apps/api/tests/Turbo.Auth.Behaviour/AccountChangePasswordTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Turboapi.Auth.Application.Results.Errors;
+using Turboapi.Auth.Domain.Aggregates;
+using Turboapi.Auth.Domain.Interfaces;
+using Xunit;
+
+namespace Turbo.Auth.Behaviour;
+
+/// <summary>
+/// Domain-level coverage for the password-change rules that can't be set up
+/// over HTTP — chiefly the OAuth-only guard, since the test host has no way
+/// to mint a Google account through the public API.
+/// </summary>
+public sealed class AccountChangePasswordTests
+{
+    // Reversible "hash" that lets the test assert which password is stored
+    // without depending on the real PBKDF2 implementation.
+    private sealed class FakeHasher : IPasswordHasher
+    {
+        public string HashPassword(string password) => $"hashed:{password}";
+        public bool VerifyPassword(string password, string hashedPassword)
+            => hashedPassword == $"hashed:{password}";
+    }
+
+    private static Account NewPasswordAccount(string password)
+    {
+        var account = Account.Create(Guid.NewGuid(), "user@example.com", new[] { "User" });
+        account.AddPasswordAuthMethod(password, new FakeHasher());
+        return account;
+    }
+
+    [Fact]
+    public void changing_with_the_correct_current_password_succeeds_and_updates_the_hash()
+    {
+        var hasher = new FakeHasher();
+        var account = NewPasswordAccount("old-password");
+
+        var result = account.ChangePassword("old-password", "new-password", hasher);
+
+        result.IsSuccess.Should().BeTrue();
+        var method = (PasswordAuthMethod)account.AuthenticationMethods.First();
+        method.PasswordHash.Should().Be("hashed:new-password");
+    }
+
+    [Fact]
+    public void changing_with_a_wrong_current_password_returns_invalid_current_password()
+    {
+        var hasher = new FakeHasher();
+        var account = NewPasswordAccount("old-password");
+
+        var result = account.ChangePassword("wrong", "new-password", hasher);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ChangePasswordError.InvalidCurrentPassword);
+    }
+
+    [Fact]
+    public void changing_the_password_on_an_oauth_only_account_is_rejected()
+    {
+        var hasher = new FakeHasher();
+        var account = Account.Create(Guid.NewGuid(), "google-user@example.com", new[] { "User" });
+        account.AddOAuthAuthMethod("Google", "google-external-id");
+
+        var result = account.ChangePassword("anything", "new-password", hasher);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ChangePasswordError.OAuthOnlyAccount);
+        account.HasPasswordAuthMethod().Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Turbo.Auth.Behaviour/DevicesBehaviour.cs
+++ b/apps/api/tests/Turbo.Auth.Behaviour/DevicesBehaviour.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Turboapi.Auth.Application.Contracts.V1.Auth;
+using Turboapi.Auth.Application.Contracts.V1.Notifications;
+using Xunit;
+
+namespace Turbo.Auth.Behaviour;
+
+[Collection("AuthHost")]
+public sealed class DevicesBehaviour
+{
+    private readonly AuthHostFixture _host;
+    public DevicesBehaviour(AuthHostFixture host) => _host = host;
+
+    private static string FreshEmail() => $"user-{Guid.NewGuid():N}@example.com";
+    private const string Password = "Sufficiently-Long-Passw0rd!";
+
+    private async Task<HttpClient> RegisterAndAuthenticate()
+    {
+        var client = _host.CreateClient();
+        var register = await client.PostAsJsonAsync("/api/auth/auth/register",
+            new RegisterUserWithPasswordRequest(FreshEmail(), Password, Password));
+        register.IsSuccessStatusCode.Should().BeTrue();
+        var tokens = await register.Content.ReadFromJsonAsync<AuthTokenResponse>();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
+        return client;
+    }
+
+    [Fact]
+    public async Task registering_a_device_token_succeeds_and_is_idempotent()
+    {
+        var client = await RegisterAndAuthenticate();
+        var token = $"fcm-{Guid.NewGuid():N}";
+
+        var first = await client.PostAsJsonAsync("/api/auth/devices",
+            new RegisterDeviceRequest(token, "android"));
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent, await first.Content.ReadAsStringAsync());
+
+        // Re-registering the same token (e.g. on a later launch) must not conflict.
+        var again = await client.PostAsJsonAsync("/api/auth/devices",
+            new RegisterDeviceRequest(token, "ios"));
+        again.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task registering_with_a_blank_token_is_bad_request()
+    {
+        var client = await RegisterAndAuthenticate();
+
+        var response = await client.PostAsJsonAsync("/api/auth/devices",
+            new RegisterDeviceRequest("", "android"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task unregistering_a_device_token_succeeds()
+    {
+        var client = await RegisterAndAuthenticate();
+        var token = $"fcm-{Guid.NewGuid():N}";
+        await client.PostAsJsonAsync("/api/auth/devices", new RegisterDeviceRequest(token, "android"));
+
+        var unregister = await client.PostAsJsonAsync("/api/auth/devices/unregister",
+            new UnregisterDeviceRequest(token));
+
+        unregister.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task registering_a_device_without_authentication_is_unauthorized()
+    {
+        var client = _host.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/devices",
+            new RegisterDeviceRequest("fcm-token", "android"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/apps/api/tests/Turbo.Auth.Behaviour/ProfileBehaviour.cs
+++ b/apps/api/tests/Turbo.Auth.Behaviour/ProfileBehaviour.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Turboapi.Auth.Application.Contracts.V1.Auth;
+using Turboapi.Auth.Application.UseCases.Queries.ValidateSession;
+using Xunit;
+
+namespace Turbo.Auth.Behaviour;
+
+[Collection("AuthHost")]
+public sealed class ProfileBehaviour
+{
+    private readonly AuthHostFixture _host;
+    public ProfileBehaviour(AuthHostFixture host) => _host = host;
+
+    private static string FreshEmail() => $"user-{Guid.NewGuid():N}@example.com";
+    private const string Password = "Sufficiently-Long-Passw0rd!";
+
+    private async Task<(HttpClient client, AuthTokenResponse tokens)> RegisterAndAuthenticate()
+    {
+        var client = _host.CreateClient();
+        var email = FreshEmail();
+        var register = await client.PostAsJsonAsync("/api/auth/auth/register",
+            new RegisterUserWithPasswordRequest(email, Password, Password));
+        register.IsSuccessStatusCode.Should().BeTrue(
+            $"register should succeed, got {register.StatusCode}: {await register.Content.ReadAsStringAsync()}");
+        var tokens = await register.Content.ReadFromJsonAsync<AuthTokenResponse>();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tokens!.AccessToken);
+        return (client, tokens);
+    }
+
+    [Fact]
+    public async Task changing_password_then_logging_in_with_the_new_password_succeeds()
+    {
+        var (client, tokens) = await RegisterAndAuthenticate();
+        const string newPassword = "An-Even-Better-Passw0rd!";
+
+        var change = await client.PostAsJsonAsync("/api/auth/auth/change-password",
+            new ChangePasswordRequest(Password, newPassword, newPassword));
+        change.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            await change.Content.ReadAsStringAsync());
+
+        var loginNew = await client.PostAsJsonAsync("/api/auth/auth/login",
+            new LoginUserWithPasswordRequest(tokens.Email, newPassword));
+        loginNew.IsSuccessStatusCode.Should().BeTrue();
+
+        var loginOld = await client.PostAsJsonAsync("/api/auth/auth/login",
+            new LoginUserWithPasswordRequest(tokens.Email, Password));
+        loginOld.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task changing_password_with_the_wrong_current_password_is_unauthorized()
+    {
+        var (client, _) = await RegisterAndAuthenticate();
+
+        var change = await client.PostAsJsonAsync("/api/auth/auth/change-password",
+            new ChangePasswordRequest("not-the-current-password", "An-Even-Better-Passw0rd!", "An-Even-Better-Passw0rd!"));
+
+        change.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task changing_password_with_mismatched_confirmation_is_bad_request()
+    {
+        var (client, _) = await RegisterAndAuthenticate();
+
+        var change = await client.PostAsJsonAsync("/api/auth/auth/change-password",
+            new ChangePasswordRequest(Password, "An-Even-Better-Passw0rd!", "different-confirmation"));
+
+        change.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task changing_password_without_authentication_is_unauthorized()
+    {
+        var client = _host.CreateClient();
+
+        var change = await client.PostAsJsonAsync("/api/auth/auth/change-password",
+            new ChangePasswordRequest(Password, "An-Even-Better-Passw0rd!", "An-Even-Better-Passw0rd!"));
+
+        change.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task updating_the_display_name_is_reflected_by_session_me()
+    {
+        var (client, _) = await RegisterAndAuthenticate();
+
+        var update = await client.PutAsJsonAsync("/api/auth/profile",
+            new UpdateProfileRequest("Sigmund the Explorer"));
+        update.IsSuccessStatusCode.Should().BeTrue(await update.Content.ReadAsStringAsync());
+
+        var profile = await update.Content.ReadFromJsonAsync<ProfileResponse>();
+        profile!.DisplayName.Should().Be("Sigmund the Explorer");
+
+        var me = await client.GetAsync("/api/auth/session/me");
+        me.IsSuccessStatusCode.Should().BeTrue();
+        var session = await me.Content.ReadFromJsonAsync<ValidateSessionResponse>();
+        session!.DisplayName.Should().Be("Sigmund the Explorer");
+    }
+
+    [Fact]
+    public async Task a_blank_display_name_clears_it()
+    {
+        var (client, _) = await RegisterAndAuthenticate();
+
+        await client.PutAsJsonAsync("/api/auth/profile", new UpdateProfileRequest("Temporary Name"));
+
+        var cleared = await client.PutAsJsonAsync("/api/auth/profile", new UpdateProfileRequest("   "));
+        cleared.IsSuccessStatusCode.Should().BeTrue();
+        var profile = await cleared.Content.ReadFromJsonAsync<ProfileResponse>();
+        profile!.DisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task an_over_long_display_name_is_rejected_as_bad_request()
+    {
+        var (client, _) = await RegisterAndAuthenticate();
+
+        var update = await client.PutAsJsonAsync("/api/auth/profile",
+            new UpdateProfileRequest(new string('a', 200)));
+
+        update.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/apps/flutter/lib/app/l10n/app_localizations.dart
+++ b/apps/flutter/lib/app/l10n/app_localizations.dart
@@ -67,6 +67,8 @@ abstract class AppLocalizations {
   String get about;
   String get user;
   String get delete;
+  String get signedInWithGoogle;
+  String get couldNotOpenEmailApp;
 
   // Marker Sheets
   String get newMarker;
@@ -538,6 +540,8 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get about => 'About';
   @override String get user => 'User';
   @override String get delete => 'Delete';
+  @override String get signedInWithGoogle => 'Signed in with Google';
+  @override String get couldNotOpenEmailApp => 'Could not open an email app';
 
   @override String get newMarker => 'New Marker';
   @override String get editMarker => 'Edit Marker';
@@ -982,6 +986,8 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get about => 'Om';
   @override String get user => 'Bruker';
   @override String get delete => 'Slett';
+  @override String get signedInWithGoogle => 'Logget inn med Google';
+  @override String get couldNotOpenEmailApp => 'Kunne ikke åpne en e-postapp';
 
   @override String get newMarker => 'Nytt punkt';
   @override String get editMarker => 'Rediger punkt';

--- a/apps/flutter/lib/app/l10n/app_localizations.dart
+++ b/apps/flutter/lib/app/l10n/app_localizations.dart
@@ -69,6 +69,20 @@ abstract class AppLocalizations {
   String get delete;
   String get signedInWithGoogle;
   String get couldNotOpenEmailApp;
+  String get currentPassword;
+  String get newPassword;
+  String get confirmNewPassword;
+  String get passwordsDoNotMatch;
+  String get passwordChanged;
+  String get couldNotChangePassword;
+  String get displayName;
+  String get profileUpdated;
+  String get couldNotUpdateProfile;
+  String get pushNotifications;
+  String get allowPushNotifications;
+  String get friendRequests;
+  String get shareNotifications;
+  String get notificationsDeliveryNote;
 
   // Marker Sheets
   String get newMarker;
@@ -542,6 +556,20 @@ class AppLocalizationsEn extends AppLocalizations {
   @override String get delete => 'Delete';
   @override String get signedInWithGoogle => 'Signed in with Google';
   @override String get couldNotOpenEmailApp => 'Could not open an email app';
+  @override String get currentPassword => 'Current password';
+  @override String get newPassword => 'New password';
+  @override String get confirmNewPassword => 'Confirm new password';
+  @override String get passwordsDoNotMatch => 'Passwords do not match';
+  @override String get passwordChanged => 'Password changed';
+  @override String get couldNotChangePassword => 'Could not change password';
+  @override String get displayName => 'Display name';
+  @override String get profileUpdated => 'Profile updated';
+  @override String get couldNotUpdateProfile => 'Could not update profile';
+  @override String get pushNotifications => 'Push notifications';
+  @override String get allowPushNotifications => 'Allow push notifications';
+  @override String get friendRequests => 'Friend requests';
+  @override String get shareNotifications => 'Shares';
+  @override String get notificationsDeliveryNote => 'Delivery requires the app to be set up for push notifications.';
 
   @override String get newMarker => 'New Marker';
   @override String get editMarker => 'Edit Marker';
@@ -988,6 +1016,20 @@ class AppLocalizationsNo extends AppLocalizations {
   @override String get delete => 'Slett';
   @override String get signedInWithGoogle => 'Logget inn med Google';
   @override String get couldNotOpenEmailApp => 'Kunne ikke åpne en e-postapp';
+  @override String get currentPassword => 'Nåværende passord';
+  @override String get newPassword => 'Nytt passord';
+  @override String get confirmNewPassword => 'Bekreft nytt passord';
+  @override String get passwordsDoNotMatch => 'Passordene er ikke like';
+  @override String get passwordChanged => 'Passordet er endret';
+  @override String get couldNotChangePassword => 'Kunne ikke endre passordet';
+  @override String get displayName => 'Visningsnavn';
+  @override String get profileUpdated => 'Profilen er oppdatert';
+  @override String get couldNotUpdateProfile => 'Kunne ikke oppdatere profilen';
+  @override String get pushNotifications => 'Push-varsler';
+  @override String get allowPushNotifications => 'Tillat push-varsler';
+  @override String get friendRequests => 'Venneforespørsler';
+  @override String get shareNotifications => 'Delinger';
+  @override String get notificationsDeliveryNote => 'Levering krever at appen er satt opp for push-varsler.';
 
   @override String get newMarker => 'Nytt punkt';
   @override String get editMarker => 'Rediger punkt';

--- a/apps/flutter/lib/app/main.dart
+++ b/apps/flutter/lib/app/main.dart
@@ -19,6 +19,7 @@ import 'package:turbo/features/activity_packrafting/api.dart'
 import 'package:turbo/features/activity_xc_ski/api.dart' as activity_xc_ski;
 import 'package:turbo/features/auth/api.dart';
 import 'package:turbo/features/markers/api.dart';
+import 'package:turbo/features/notifications/api.dart';
 import 'package:turbo/features/sharing/api.dart';
 import 'package:turbo/features/tile_storage/offline_regions/api.dart'
     as offline_regions;
@@ -79,4 +80,7 @@ Future<void> _kickOffBackgroundInit(ProviderContainer container) async {
   container.read(localMarkerDataStoreProvider);
   // Start watching app links for share URLs (no-op on web).
   container.read(shareLinkListenerProvider);
+  // Wire up push notifications. Inert until the build is configured for FCM
+  // (google-services.json / APNs) and the user is signed in with push enabled.
+  unawaited(container.read(pushNotificationServiceProvider).start());
 }

--- a/apps/flutter/lib/features/auth/api.dart
+++ b/apps/flutter/lib/features/auth/api.dart
@@ -6,6 +6,8 @@ export 'data/auth_init_provider.dart' show linkStreamHandlerProvider;
 export 'widgets/login_screen.dart' show LoginScreen;
 export 'widgets/register_screen.dart' show RegisterScreen;
 export 'widgets/user_profile_screen.dart' show UserProfileScreen;
+export 'widgets/edit_profile_screen.dart' show EditProfileScreen;
+export 'widgets/change_password_screen.dart' show ChangePasswordScreen;
 export 'widgets/drawer_widget.dart' show AppDrawer;
 export 'widgets/google_oauth_screen.dart' show GoogleAuthCallbackPage;
 export 'widgets/login_success.dart' show LoginSuccessPage;

--- a/apps/flutter/lib/features/auth/data/auth_providers.dart
+++ b/apps/flutter/lib/features/auth/data/auth_providers.dart
@@ -30,6 +30,7 @@ enum AuthStatus { initial, loading, authenticated, unauthenticated, error }
 class AuthState {
   final AuthStatus status;
   final String? email;
+  final String? displayName;
   final String? errorMessage;
   final bool isGoogleUser;
   final String? accessToken;
@@ -38,6 +39,7 @@ class AuthState {
   AuthState({
     this.status = AuthStatus.initial,
     this.email,
+    this.displayName,
     this.errorMessage,
     this.isGoogleUser = false,
     this.accessToken,
@@ -47,6 +49,8 @@ class AuthState {
   AuthState copyWith({
     AuthStatus? status,
     String? email,
+    String? displayName,
+    bool clearDisplayName = false,
     String? errorMessage,
     bool? removeError,
     bool? isGoogleUser,
@@ -56,6 +60,7 @@ class AuthState {
     return AuthState(
       status: status ?? this.status,
       email: email ?? this.email,
+      displayName: clearDisplayName ? null : displayName ?? this.displayName,
       errorMessage: removeError == true ? null : errorMessage ?? this.errorMessage,
       isGoogleUser: isGoogleUser ?? this.isGoogleUser,
       accessToken: accessToken ?? this.accessToken,
@@ -127,9 +132,13 @@ class AuthStateNotifier extends Notifier<AuthState> {
         final email = await _authService.getUserEmail();
         final isGoogleUser = await _authService.isGoogleUser();
         final token = await _authService.getAccessToken();
+        // On web the session check above persisted displayName to prefs; on
+        // mobile it was stored at login time. Either way read it back here.
+        final displayName = await _authService.getDisplayName();
         _updateState(AuthState(
           status: AuthStatus.authenticated,
           email: email,
+          displayName: displayName,
           isGoogleUser: isGoogleUser,
           accessToken: token,
           isInitializing: false,
@@ -149,9 +158,11 @@ class AuthStateNotifier extends Notifier<AuthState> {
     try {
       await _authService.login(email, password);
       final token = await _authService.getAccessToken();
+      final displayName = await _authService.getDisplayName();
       _updateState(AuthState(
         status: AuthStatus.authenticated,
         email: email,
+        displayName: displayName,
         isGoogleUser: false,
         accessToken: token,
       ));
@@ -253,6 +264,29 @@ class AuthStateNotifier extends Notifier<AuthState> {
       }
     } catch (e) {
       await logout();
+    }
+  }
+
+  /// Changes the account password.
+  ///
+  /// Error handling convention (shared with [updateDisplayName]): these methods
+  /// do NOT touch the global auth status on failure — the user remains
+  /// authenticated. They simply rethrow so the calling screen can catch the
+  /// error and surface it locally (e.g. via [AuthErrorMessage]).
+  Future<void> changePassword(
+      String currentPassword, String newPassword, String confirmNewPassword) async {
+    await _authService.changePassword(
+        currentPassword, newPassword, confirmNewPassword);
+  }
+
+  /// Updates the user's display name and, on success, reflects it in state.
+  /// Rethrows on failure (see [changePassword] for the convention).
+  Future<void> updateDisplayName(String? name) async {
+    final newDisplayName = await _authService.updateDisplayName(name);
+    if (newDisplayName == null || newDisplayName.isEmpty) {
+      _updateState(state.copyWith(clearDisplayName: true));
+    } else {
+      _updateState(state.copyWith(displayName: newDisplayName));
     }
   }
 

--- a/apps/flutter/lib/features/auth/data/auth_service.dart
+++ b/apps/flutter/lib/features/auth/data/auth_service.dart
@@ -79,6 +79,7 @@ class AuthService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool('isLoggedIn', false);
       await prefs.remove('userEmail');
+      await prefs.remove('displayName');
       await prefs.remove('accessToken');
       await prefs.remove('refreshToken');
       await prefs.remove('isGoogleUser');
@@ -100,10 +101,86 @@ class AuthService {
         if (data['email'] != null) {
           await prefs.setString('userEmail', data['email']);
         }
+        // Session/me now also returns a nullable displayName; mirror it locally.
+        final displayName = data['displayName'];
+        if (displayName != null) {
+          await prefs.setString('displayName', displayName);
+        } else {
+          await prefs.remove('displayName');
+        }
         return true;
       }
     }
     return false;
+  }
+
+  /// Changes the password for a password-based account.
+  ///
+  /// Success is a 204 (no body). On any non-2xx response we throw with the
+  /// server-provided message when present.
+  Future<void> changePassword(
+      String currentPassword, String newPassword, String confirmNewPassword) async {
+    final response = await apiClient.post(
+      '/api/auth/Auth/change-password',
+      data: {
+        'currentPassword': currentPassword,
+        'newPassword': newPassword,
+        'confirmNewPassword': confirmNewPassword,
+      },
+    );
+    final status = response.statusCode ?? 0;
+    if (status >= 200 && status < 300) {
+      return;
+    }
+    throw Exception(response.data?['message'] ?? 'Could not change password');
+  }
+
+  /// Updates the user's display name. Pass null/empty to clear it. Returns the
+  /// new display name as confirmed by the server, persisting it locally.
+  Future<String?> updateDisplayName(String? displayName) async {
+    final response = await apiClient.put(
+      '/api/auth/Profile',
+      data: {'displayName': displayName ?? ''},
+    );
+    if (response.statusCode == 200) {
+      final data = response.data;
+      final newDisplayName = data['displayName'] as String?;
+      final prefs = await SharedPreferences.getInstance();
+      if (newDisplayName != null && newDisplayName.isNotEmpty) {
+        await prefs.setString('displayName', newDisplayName);
+      } else {
+        await prefs.remove('displayName');
+      }
+      return newDisplayName;
+    }
+    throw Exception(response.data?['message'] ?? 'Could not update profile');
+  }
+
+  /// Registers a push device token with the backend. Not yet wired into any
+  /// flow — FCM integration is handled separately.
+  Future<void> registerDevice(String token, String platform) async {
+    final response = await apiClient.post(
+      '/api/auth/Devices',
+      data: {'token': token, 'platform': platform},
+    );
+    final status = response.statusCode ?? 0;
+    if (status >= 200 && status < 300) {
+      return;
+    }
+    throw Exception(response.data?['message'] ?? 'Could not register device');
+  }
+
+  /// Unregisters a push device token. Not yet wired into any flow.
+  Future<void> unregisterDevice(String token) async {
+    final response = await apiClient.post(
+      '/api/auth/Devices/unregister',
+      data: {'token': token},
+    );
+    final status = response.statusCode ?? 0;
+    if (status >= 200 && status < 300) {
+      return;
+    }
+    throw Exception(response.data?['message'] ?? 'Could not unregister device');
   }
 
   Future<bool> isLoggedIn() async {
@@ -124,6 +201,11 @@ class AuthService {
   Future<String?> getUserEmail() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString('userEmail');
+  }
+
+  Future<String?> getDisplayName() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('displayName');
   }
 
   Future<bool> isGoogleUser() async {

--- a/apps/flutter/lib/features/auth/widgets/change_password_screen.dart
+++ b/apps/flutter/lib/features/auth/widgets/change_password_screen.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_button.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+
+import '../data/auth_providers.dart';
+import 'auth_error_message.dart';
+import 'password_field.dart';
+
+/// Minimum password length, matching the register flow validators.
+const int _kMinPasswordLength = 8;
+
+class ChangePasswordScreen extends ConsumerStatefulWidget {
+  const ChangePasswordScreen({super.key});
+
+  static Future<void> show(BuildContext context) {
+    final isDesktop = MediaQuery.of(context).size.width > 768;
+
+    if (isDesktop) {
+      return showDialog(
+        context: context,
+        builder: (context) => Dialog(
+          clipBehavior: Clip.antiAlias,
+          child: const SizedBox(
+            width: 420,
+            child: ChangePasswordScreen(),
+          ),
+        ),
+      );
+    } else {
+      return Navigator.of(context).push(
+        MaterialPageRoute(
+          fullscreenDialog: true,
+          builder: (context) => const ChangePasswordScreen(),
+        ),
+      );
+    }
+  }
+
+  @override
+  ConsumerState<ChangePasswordScreen> createState() =>
+      _ChangePasswordScreenState();
+}
+
+class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _currentController = TextEditingController();
+  final _newController = TextEditingController();
+  final _confirmController = TextEditingController();
+
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _currentController.dispose();
+    _newController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    setState(() => _errorMessage = null);
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    setState(() => _isLoading = true);
+    try {
+      await ref.read(authStateProvider.notifier).changePassword(
+            _currentController.text,
+            _newController.text,
+            _confirmController.text,
+          );
+      if (!mounted) return;
+      AppSnackbars.success(context, context.l10n.passwordChanged);
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _errorMessage = context.l10n.couldNotChangePassword);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDesktop = MediaQuery.of(context).size.width > 768;
+    final textTheme = Theme.of(context).textTheme;
+
+    final form = Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (_errorMessage != null) ...[
+            AuthErrorMessage(message: _errorMessage!),
+            const SizedBox(height: 24),
+          ],
+          PasswordField(
+            controller: _currentController,
+            label: l10n.currentPassword,
+            validator: (val) =>
+                (val == null || val.isEmpty) ? l10n.pleaseEnterPassword : null,
+          ),
+          const SizedBox(height: 16),
+          PasswordField(
+            controller: _newController,
+            label: l10n.newPassword,
+            validator: (val) {
+              if (val == null || val.isEmpty) return l10n.pleaseEnterPassword;
+              if (val.length < _kMinPasswordLength) {
+                return l10n.passwordTooShort(_kMinPasswordLength);
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 16),
+          PasswordField(
+            controller: _confirmController,
+            label: l10n.confirmNewPassword,
+            validator: (val) {
+              if (val == null || val.isEmpty) return l10n.pleaseEnterPassword;
+              if (val != _newController.text) return l10n.passwordsDoNotMatch;
+              return null;
+            },
+          ),
+          const SizedBox(height: 24),
+          AppButton.primary(
+            text: l10n.changePassword,
+            onPressed: _submit,
+            isLoading: _isLoading,
+            fullWidth: true,
+          ),
+        ],
+      ),
+    );
+
+    if (isDesktop) {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(32, 24, 32, 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Align(
+                alignment: Alignment.topRight,
+                child: IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                  tooltip: l10n.closeTooltip,
+                ),
+              ),
+              Text(l10n.changePassword, style: textTheme.headlineMedium),
+              const SizedBox(height: 32),
+              form,
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.changePassword),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: l10n.closeTooltip,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: form,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter/lib/features/auth/widgets/edit_profile_screen.dart
+++ b/apps/flutter/lib/features/auth/widgets/edit_profile_screen.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/core/widgets/app_button.dart';
+import 'package:turbo/core/widgets/app_snackbars.dart';
+import 'package:turbo/core/widgets/app_text_field.dart';
+
+import '../data/auth_providers.dart';
+import 'auth_error_message.dart';
+
+class EditProfileScreen extends ConsumerStatefulWidget {
+  const EditProfileScreen({super.key});
+
+  static Future<void> show(BuildContext context) {
+    final isDesktop = MediaQuery.of(context).size.width > 768;
+
+    if (isDesktop) {
+      return showDialog(
+        context: context,
+        builder: (context) => Dialog(
+          clipBehavior: Clip.antiAlias,
+          child: const SizedBox(
+            width: 420,
+            child: EditProfileScreen(),
+          ),
+        ),
+      );
+    } else {
+      return Navigator.of(context).push(
+        MaterialPageRoute(
+          fullscreenDialog: true,
+          builder: (context) => const EditProfileScreen(),
+        ),
+      );
+    }
+  }
+
+  @override
+  ConsumerState<EditProfileScreen> createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _displayNameController;
+
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    final displayName = ref.read(authStateProvider).displayName;
+    _displayNameController = TextEditingController(text: displayName ?? '');
+  }
+
+  @override
+  void dispose() {
+    _displayNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    setState(() => _errorMessage = null);
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    setState(() => _isLoading = true);
+    try {
+      await ref
+          .read(authStateProvider.notifier)
+          .updateDisplayName(_displayNameController.text.trim());
+      if (!mounted) return;
+      AppSnackbars.success(context, context.l10n.profileUpdated);
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _errorMessage = context.l10n.couldNotUpdateProfile);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isDesktop = MediaQuery.of(context).size.width > 768;
+    final textTheme = Theme.of(context).textTheme;
+    final email = ref.watch(authStateProvider.select((s) => s.email));
+
+    final form = Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (_errorMessage != null) ...[
+            AuthErrorMessage(message: _errorMessage!),
+            const SizedBox(height: 24),
+          ],
+          AppTextField(
+            controller: _displayNameController,
+            label: l10n.displayName,
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            initialValue: email ?? '',
+            enabled: false,
+            decoration: InputDecoration(labelText: l10n.email),
+          ),
+          const SizedBox(height: 24),
+          AppButton.primary(
+            text: l10n.save,
+            onPressed: _submit,
+            isLoading: _isLoading,
+            fullWidth: true,
+          ),
+        ],
+      ),
+    );
+
+    if (isDesktop) {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(32, 24, 32, 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Align(
+                alignment: Alignment.topRight,
+                child: IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                  tooltip: l10n.closeTooltip,
+                ),
+              ),
+              Text(l10n.editProfile, style: textTheme.headlineMedium),
+              const SizedBox(height: 32),
+              form,
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.editProfile),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: l10n.closeTooltip,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: form,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter/lib/features/auth/widgets/user_profile_screen.dart
+++ b/apps/flutter/lib/features/auth/widgets/user_profile_screen.dart
@@ -1,17 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/features/settings/api.dart';
+import 'package:turbo/features/settings/widgets/sections/about_settings_page.dart';
 
 import '../data/auth_providers.dart';
 
 class UserProfileScreen extends ConsumerWidget {
   const UserProfileScreen({super.key});
 
+  /// Address used for the "Help & Support" tile.
+  static const String _supportEmail = 'support@turbo.app';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
-    final email = ref.watch(authStateProvider).email;
+    final authState = ref.watch(authStateProvider);
+    final email = authState.email;
     final colorScheme = Theme.of(context).colorScheme;
     final authNotifier = ref.read(authStateProvider.notifier);
 
@@ -61,7 +68,9 @@ class UserProfileScreen extends ConsumerWidget {
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          l10n.turboUser,
+                          authState.isGoogleUser
+                              ? l10n.signedInWithGoogle
+                              : l10n.turboUser,
                           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                             color: colorScheme.onSurfaceVariant,
                           ),
@@ -75,33 +84,25 @@ class UserProfileScreen extends ConsumerWidget {
 
               _buildOptionTile(
                 context,
-                icon: Icons.person_outline,
-                title: l10n.editProfile,
-                onTap: () {},
-              ),
-              _buildOptionTile(
-                context,
-                icon: Icons.lock_outline,
-                title: l10n.changePassword,
-                onTap: () {},
-              ),
-              _buildOptionTile(
-                context,
-                icon: Icons.notifications_outlined,
-                title: l10n.notifications,
-                onTap: () {},
+                icon: Icons.settings_outlined,
+                title: l10n.settings,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const SettingsPage()),
+                ),
               ),
               _buildOptionTile(
                 context,
                 icon: Icons.help_outline,
                 title: l10n.helpAndSupport,
-                onTap: () {},
+                onTap: () => _openSupportEmail(context),
               ),
               _buildOptionTile(
                 context,
                 icon: Icons.info_outline,
                 title: l10n.about,
-                onTap: () {},
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const AboutSettingsPage()),
+                ),
               ),
             ],
           ),
@@ -123,6 +124,22 @@ class UserProfileScreen extends ConsumerWidget {
       trailing: const Icon(Icons.chevron_right),
       onTap: onTap,
     );
+  }
+
+  Future<void> _openSupportEmail(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
+    final uri = Uri(
+      scheme: 'mailto',
+      path: _supportEmail,
+      query: 'subject=Turbo support',
+    );
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.couldNotOpenEmailApp)),
+      );
+    }
   }
 
   Future<void> _showLogoutDialog(

--- a/apps/flutter/lib/features/auth/widgets/user_profile_screen.dart
+++ b/apps/flutter/lib/features/auth/widgets/user_profile_screen.dart
@@ -4,9 +4,10 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:turbo/core/widgets/app_dialog.dart';
 import 'package:turbo/app/l10n/app_localizations.dart';
 import 'package:turbo/features/settings/api.dart';
-import 'package:turbo/features/settings/widgets/sections/about_settings_page.dart';
 
 import '../data/auth_providers.dart';
+import 'change_password_screen.dart';
+import 'edit_profile_screen.dart';
 
 class UserProfileScreen extends ConsumerWidget {
   const UserProfileScreen({super.key});
@@ -19,6 +20,10 @@ class UserProfileScreen extends ConsumerWidget {
     final l10n = context.l10n;
     final authState = ref.watch(authStateProvider);
     final email = authState.email;
+    final displayName = authState.displayName;
+    final hasDisplayName = displayName != null && displayName.isNotEmpty;
+    final primaryText = hasDisplayName ? displayName : (email ?? l10n.user);
+    final avatarSource = hasDisplayName ? displayName : email;
     final colorScheme = Theme.of(context).colorScheme;
     final authNotifier = ref.read(authStateProvider.notifier);
 
@@ -48,7 +53,9 @@ class UserProfileScreen extends ConsumerWidget {
                     radius: 40,
                     backgroundColor: colorScheme.primaryContainer,
                     child: Text(
-                      email != null && email.isNotEmpty ? email[0].toUpperCase() : '?',
+                      avatarSource != null && avatarSource.isNotEmpty
+                          ? avatarSource[0].toUpperCase()
+                          : '?',
                       style: Theme.of(context).textTheme.displaySmall?.copyWith(
                             color: colorScheme.onPrimaryContainer,
                             fontWeight: FontWeight.bold,
@@ -61,16 +68,18 @@ class UserProfileScreen extends ConsumerWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          email ?? l10n.user,
+                          primaryText,
                           style: Theme.of(context).textTheme.titleLarge?.copyWith(
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          authState.isGoogleUser
-                              ? l10n.signedInWithGoogle
-                              : l10n.turboUser,
+                          hasDisplayName
+                              ? (email ?? l10n.user)
+                              : (authState.isGoogleUser
+                                  ? l10n.signedInWithGoogle
+                                  : l10n.turboUser),
                           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                             color: colorScheme.onSurfaceVariant,
                           ),
@@ -82,6 +91,28 @@ class UserProfileScreen extends ConsumerWidget {
               ),
               const SizedBox(height: 32),
 
+              _buildOptionTile(
+                context,
+                icon: Icons.person_outline,
+                title: l10n.editProfile,
+                onTap: () => EditProfileScreen.show(context),
+              ),
+              if (!authState.isGoogleUser)
+                _buildOptionTile(
+                  context,
+                  icon: Icons.lock_outline,
+                  title: l10n.changePassword,
+                  onTap: () => ChangePasswordScreen.show(context),
+                ),
+              _buildOptionTile(
+                context,
+                icon: Icons.notifications_outlined,
+                title: l10n.notifications,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                      builder: (_) => const NotificationsSettingsPage()),
+                ),
+              ),
               _buildOptionTile(
                 context,
                 icon: Icons.settings_outlined,

--- a/apps/flutter/lib/features/notifications/api.dart
+++ b/apps/flutter/lib/features/notifications/api.dart
@@ -1,0 +1,5 @@
+/// Public API for the push-notifications feature.
+library;
+
+export 'push_notification_service.dart'
+    show PushNotificationService, pushNotificationServiceProvider;

--- a/apps/flutter/lib/features/notifications/push_notification_service.dart
+++ b/apps/flutter/lib/features/notifications/push_notification_service.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import 'package:turbo/features/auth/api.dart';
+import 'package:turbo/features/settings/api.dart';
+
+final _log = Logger('PushNotifications');
+
+/// Background isolate handler. Must be a top-level / static function annotated
+/// with `vm:entry-point` so it survives tree-shaking and can be invoked when
+/// the app is terminated. Kept intentionally light — real handling (deep
+/// links, badge counts) is wired once the product defines notification types.
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // Firebase is initialized lazily by the platform here; we only need to be a
+  // valid entry-point. Logging is best-effort in the background isolate.
+  _log.fine('Background push received: ${message.messageId}');
+}
+
+/// Coordinates push notifications end-to-end:
+///   * defensively initializes Firebase (no-op if the app isn't configured),
+///   * requests OS permission,
+///   * registers/refreshes the FCM device token with the backend while the
+///     user is authenticated and has push enabled, and unregisters otherwise,
+///   * surfaces foreground messages via a local notification.
+///
+/// The whole thing is guarded so that an unconfigured build (no
+/// google-services.json / APNs entitlement, or push disabled) simply logs and
+/// stays inert — it never throws into app startup. See
+/// docs/notifications/push-setup.md for the native configuration steps.
+class PushNotificationService {
+  PushNotificationService(this._ref);
+
+  final Ref _ref;
+  final FlutterLocalNotificationsPlugin _localNotifications =
+      FlutterLocalNotificationsPlugin();
+
+  bool _firebaseReady = false;
+  bool _started = false;
+  String? _registeredToken;
+  ProviderSubscription<AuthState>? _authSub;
+  StreamSubscription<String>? _tokenRefreshSub;
+  StreamSubscription<RemoteMessage>? _foregroundSub;
+
+  static const AndroidNotificationChannel _channel = AndroidNotificationChannel(
+    'turbo_default',
+    'General',
+    description: 'General Turbo notifications',
+    importance: Importance.defaultImportance,
+  );
+
+  /// Idempotent. Safe to call on every cold start; only the first call wires
+  /// listeners.
+  Future<void> start() async {
+    if (_started) return;
+    _started = true;
+
+    if (kIsWeb) {
+      // Web push needs a separate service-worker + VAPID setup; out of scope
+      // for the initial scaffold.
+      _log.fine('Push notifications are not enabled on web.');
+      return;
+    }
+
+    _firebaseReady = await _initFirebase();
+    if (!_firebaseReady) return;
+
+    await _initLocalNotifications();
+
+    FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+    _foregroundSub = FirebaseMessaging.onMessage.listen(_showForeground);
+    _tokenRefreshSub =
+        FirebaseMessaging.instance.onTokenRefresh.listen((token) {
+      _registeredToken = null; // force re-registration with the new token
+      unawaited(_syncRegistration(token: token));
+    });
+
+    // React to login/logout. Safe to call here: the provider is mounted and
+    // we're not inside a lifecycle callback.
+    _authSub = _ref.listen<AuthState>(authStateProvider, (_, _) {
+      unawaited(_syncRegistration());
+    });
+
+    await _syncRegistration();
+  }
+
+  Future<bool> _initFirebase() async {
+    try {
+      await Firebase.initializeApp();
+      return true;
+    } catch (e) {
+      // Most commonly: no google-services.json / GoogleService-Info.plist.
+      _log.info('Firebase not configured; push notifications disabled. ($e)');
+      return false;
+    }
+  }
+
+  Future<void> _initLocalNotifications() async {
+    try {
+      const initSettings = InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+      );
+      await _localNotifications.initialize(settings: initSettings);
+      await _localNotifications
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.createNotificationChannel(_channel);
+    } catch (e) {
+      _log.warning('Local notifications init failed: $e');
+    }
+  }
+
+  /// Brings the backend registration in line with the current auth + preference
+  /// state: registers the token when signed in and push is enabled, otherwise
+  /// unregisters it.
+  Future<void> _syncRegistration({String? token}) async {
+    if (!_firebaseReady) return;
+
+    final auth = _ref.read(authStateProvider);
+    final authed = auth.status == AuthStatus.authenticated;
+    final pushEnabled = _ref.read(settingsProvider).maybeWhen(
+          data: (s) => s.pushNotificationsEnabled,
+          orElse: () => true,
+        );
+
+    final authService = _ref.read(authServiceProvider);
+
+    if (!authed || !pushEnabled) {
+      final previous = _registeredToken;
+      if (previous != null) {
+        _registeredToken = null;
+        try {
+          await authService.unregisterDevice(previous);
+        } catch (e) {
+          _log.warning('Failed to unregister device token: $e');
+        }
+      }
+      return;
+    }
+
+    try {
+      final settings = await FirebaseMessaging.instance.requestPermission();
+      if (settings.authorizationStatus == AuthorizationStatus.denied) {
+        _log.info('Push permission denied; not registering.');
+        return;
+      }
+
+      final fcmToken = token ?? await FirebaseMessaging.instance.getToken();
+      if (fcmToken == null || fcmToken == _registeredToken) return;
+
+      await authService.registerDevice(fcmToken, _platform());
+      _registeredToken = fcmToken;
+      _log.fine('Registered device token for push notifications.');
+    } catch (e) {
+      _log.warning('Device token registration failed: $e');
+    }
+  }
+
+  Future<void> _showForeground(RemoteMessage message) async {
+    final notification = message.notification;
+    if (notification == null) return;
+    try {
+      await _localNotifications.show(
+        id: notification.hashCode,
+        title: notification.title,
+        body: notification.body,
+        notificationDetails: NotificationDetails(
+          android: AndroidNotificationDetails(
+            _channel.id,
+            _channel.name,
+            channelDescription: _channel.description,
+            importance: Importance.defaultImportance,
+          ),
+          iOS: const DarwinNotificationDetails(),
+        ),
+      );
+    } catch (e) {
+      _log.warning('Failed to display foreground notification: $e');
+    }
+  }
+
+  String _platform() {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      default:
+        return 'unknown';
+    }
+  }
+
+  void dispose() {
+    _authSub?.close();
+    unawaited(_tokenRefreshSub?.cancel());
+    unawaited(_foregroundSub?.cancel());
+  }
+}
+
+/// App-wide push coordinator. Kicked off during background init in `main`.
+final pushNotificationServiceProvider =
+    Provider<PushNotificationService>((ref) {
+  final service = PushNotificationService(ref);
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/apps/flutter/lib/features/settings/api.dart
+++ b/apps/flutter/lib/features/settings/api.dart
@@ -8,3 +8,6 @@ export 'package:turbo/core/location/gps_accuracy_mode.dart'
 export 'data/settings_provider.dart' show settingsProvider, SettingsState;
 export 'widgets/location_icon_picker_sheet.dart' show showLocationIconPickerSheet;
 export 'widgets/settings_page.dart';
+export 'widgets/sections/about_settings_page.dart' show AboutSettingsPage;
+export 'widgets/sections/notifications_settings_page.dart'
+    show NotificationsSettingsPage;

--- a/apps/flutter/lib/features/settings/data/settings_provider.dart
+++ b/apps/flutter/lib/features/settings/data/settings_provider.dart
@@ -74,6 +74,15 @@ class SettingsState {
   /// or by granting "Always" location in the OS.
   final bool backgroundLocationPromptSeen;
 
+  /// Master switch for push notifications. When off, all categories are muted.
+  final bool pushNotificationsEnabled;
+
+  /// Whether to receive friend-request push notifications.
+  final bool friendRequestNotifications;
+
+  /// Whether to receive share-related push notifications.
+  final bool shareNotifications;
+
   const SettingsState({
     required this.themeMode,
     required this.locale,
@@ -97,6 +106,9 @@ class SettingsState {
     this.keepScreenOnWhileRecording = true,
     this.gpsAccuracyMode = GpsAccuracyMode.high,
     this.backgroundLocationPromptSeen = false,
+    this.pushNotificationsEnabled = true,
+    this.friendRequestNotifications = true,
+    this.shareNotifications = true,
   });
 
   // Default initial state
@@ -131,6 +143,9 @@ class SettingsState {
     bool? keepScreenOnWhileRecording,
     GpsAccuracyMode? gpsAccuracyMode,
     bool? backgroundLocationPromptSeen,
+    bool? pushNotificationsEnabled,
+    bool? friendRequestNotifications,
+    bool? shareNotifications,
   }) {
     return SettingsState(
       themeMode: themeMode ?? this.themeMode,
@@ -156,6 +171,11 @@ class SettingsState {
       gpsAccuracyMode: gpsAccuracyMode ?? this.gpsAccuracyMode,
       backgroundLocationPromptSeen:
           backgroundLocationPromptSeen ?? this.backgroundLocationPromptSeen,
+      pushNotificationsEnabled:
+          pushNotificationsEnabled ?? this.pushNotificationsEnabled,
+      friendRequestNotifications:
+          friendRequestNotifications ?? this.friendRequestNotifications,
+      shareNotifications: shareNotifications ?? this.shareNotifications,
     );
   }
 }
@@ -188,6 +208,9 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
   static const _gpsAccuracyModeKey = 'gpsAccuracyMode';
   static const _backgroundLocationPromptSeenKey =
       'backgroundLocationPromptSeen';
+  static const _pushNotificationsEnabledKey = 'pushNotificationsEnabled';
+  static const _friendRequestNotificationsKey = 'friendRequestNotifications';
+  static const _shareNotificationsKey = 'shareNotifications';
 
   @override
   Future<SettingsState> build() async {
@@ -261,6 +284,11 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
           GpsAccuracyMode.fromName(prefs.getString(_gpsAccuracyModeKey)),
       backgroundLocationPromptSeen:
           prefs.getBool(_backgroundLocationPromptSeenKey) ?? false,
+      pushNotificationsEnabled:
+          prefs.getBool(_pushNotificationsEnabledKey) ?? true,
+      friendRequestNotifications:
+          prefs.getBool(_friendRequestNotificationsKey) ?? true,
+      shareNotifications: prefs.getBool(_shareNotificationsKey) ?? true,
     );
   }
 
@@ -289,6 +317,30 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
         state.value!.copyWith(backgroundLocationPromptSeen: seen));
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_backgroundLocationPromptSeenKey, seen);
+  }
+
+  /// Toggles the master push-notifications switch.
+  Future<void> setPushNotificationsEnabled(bool value) async {
+    if (state.value == null) return;
+    state = AsyncData(state.value!.copyWith(pushNotificationsEnabled: value));
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pushNotificationsEnabledKey, value);
+  }
+
+  /// Toggles friend-request push notifications.
+  Future<void> setFriendRequestNotifications(bool value) async {
+    if (state.value == null) return;
+    state = AsyncData(state.value!.copyWith(friendRequestNotifications: value));
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_friendRequestNotificationsKey, value);
+  }
+
+  /// Toggles share-related push notifications.
+  Future<void> setShareNotifications(bool value) async {
+    if (state.value == null) return;
+    state = AsyncData(state.value!.copyWith(shareNotifications: value));
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_shareNotificationsKey, value);
   }
 
   /// Updates the draw sensitivity and persists it.

--- a/apps/flutter/lib/features/settings/widgets/sections/notifications_settings_page.dart
+++ b/apps/flutter/lib/features/settings/widgets/sections/notifications_settings_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:turbo/app/l10n/app_localizations.dart';
+import 'package:turbo/app/tokens.dart';
+import 'package:turbo/core/widgets/app_grouped_card.dart';
+import 'package:turbo/core/widgets/app_section_header.dart';
+import 'package:turbo/features/settings/data/settings_provider.dart';
+
+class NotificationsSettingsPage extends ConsumerWidget {
+  const NotificationsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final settingsAsync = ref.watch(settingsProvider);
+    final notifier = ref.read(settingsProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.notifications)),
+      body: settingsAsync.when(
+        data: (settings) {
+          final masterOn = settings.pushNotificationsEnabled;
+          return Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 700),
+              child: ListView(
+                padding: const EdgeInsets.all(AppSpacing.l),
+                children: [
+                  AppSectionHeader(l10n.pushNotifications),
+                  AppGroupedCard(
+                    child: SwitchListTile(
+                      secondary: const Icon(Icons.notifications_outlined),
+                      title: Text(l10n.allowPushNotifications),
+                      value: masterOn,
+                      onChanged: (v) =>
+                          notifier.setPushNotificationsEnabled(v),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.l),
+                  AppSectionHeader(l10n.notifications),
+                  AppGroupedCard(
+                    child: Column(
+                      children: [
+                        SwitchListTile(
+                          secondary: const Icon(Icons.person_add_outlined),
+                          title: Text(l10n.friendRequests),
+                          value: settings.friendRequestNotifications,
+                          onChanged: masterOn
+                              ? (v) =>
+                                  notifier.setFriendRequestNotifications(v)
+                              : null,
+                        ),
+                        SwitchListTile(
+                          secondary: const Icon(Icons.share_outlined),
+                          title: Text(l10n.shareNotifications),
+                          value: settings.shareNotifications,
+                          onChanged: masterOn
+                              ? (v) => notifier.setShareNotifications(v)
+                              : null,
+                        ),
+                      ],
+                    ),
+                  ),
+                  SectionBlurb(l10n.notificationsDeliveryNote),
+                ],
+              ),
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.genericLoadError)),
+      ),
+    );
+  }
+}

--- a/apps/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,9 @@ import app_links
 import connectivity_plus
 import file_picker
 import file_selector_macos
+import firebase_core
+import firebase_messaging
+import flutter_local_notifications
 import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
@@ -24,6 +27,9 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/apps/flutter/pubspec.lock
+++ b/apps/flutter/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "91.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: "8f89e371e2883de35cdc78f648e725fa4da5f3b6c927269f00fa68f1ea92b598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.71"
   analyzer:
     dependency: transitive
     description:
@@ -377,6 +385,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      sha256: "93a5bde9775fd5adcc937f39dfa04ae0bc89c4d79bea6abc49de3f7b049d9ff6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: "7c98f10b8c8e5adedc0b810b66a877120696675e2c22d9ca9caca092da0d9e57"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.0"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "8d0dc81a31cd030170508dc3e89bfd14355b20a1b991340af5f018e37daab5d7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.2.2"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "37abb0b0535c5497605ee94c12470e1ebbbe47e71a22d0c20bffcc912311f8cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.11"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "54e22b43e2c26a2728a3f68c188de0f9011993ae19ae959a06d476dad935c776"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.7"
   fixnum:
     dependency: transitive
     description:
@@ -411,6 +467,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "21.0.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1441,6 +1529,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.15"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   turbo_lints:
     dependency: "direct dev"
     description:

--- a/apps/flutter/pubspec.yaml
+++ b/apps/flutter/pubspec.yaml
@@ -79,6 +79,9 @@ dependencies:
   # MVT decoder used by features/curated_paths/ to parse vector tiles
   # served by the Turbo tileserver into flutter_map-renderable lines.
   vector_tile: ^4.0.0
+  firebase_core: ^4.9.0
+  firebase_messaging: ^16.2.2
+  flutter_local_notifications: ^21.0.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/apps/flutter/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/apps/flutter/windows/flutter/generated_plugins.cmake
+++ b/apps/flutter/windows/flutter/generated_plugins.cmake
@@ -6,12 +6,14 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   connectivity_plus
   file_selector_windows
+  firebase_core
   geolocator_windows
   share_plus
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/docs/notifications/push-setup.md
+++ b/docs/notifications/push-setup.md
@@ -1,0 +1,101 @@
+# Push notifications — setup guide
+
+The app and API ship with push-notification **scaffolding**: device-token
+registration, an `IPushSender` abstraction with an FCM HTTP v1 implementation,
+and a Flutter `PushNotificationService` that registers tokens and renders
+foreground messages. None of it requires credentials to build or run — it stays
+inert until you complete the steps below.
+
+This is intentional: provisioning Firebase Cloud Messaging (FCM) and Apple Push
+Notification service (APNs) requires accounts and signing assets that can't live
+in the repo.
+
+## What already works (no setup)
+
+- `POST /api/auth/Devices` / `POST /api/auth/Devices/unregister` — authenticated
+  device-token registration (`device_tokens` table).
+- `IPushSender` / `FcmPushSender` — fan-out to a user's tokens + FCM HTTP v1
+  payload construction. No-op (logs only) until `Notifications:Fcm` is set.
+- Flutter `PushNotificationService` — defensively initializes Firebase, requests
+  permission, registers/refreshes the token while signed-in with push enabled,
+  unregisters on logout, and shows foreground notifications. Defensive init means
+  a build without Firebase config simply logs and does nothing.
+- Notification preferences UI (Settings → Notifications), persisted locally.
+
+## 1. Create the Firebase project
+
+1. Create a Firebase project at <https://console.firebase.google.com>.
+2. Add an **Android app** (package `com.example.turbo` — confirm the real
+   `applicationId` in `apps/flutter/android/app/build.gradle`).
+3. Add an **iOS app** (matching the bundle id in Xcode).
+
+## 2. Flutter / client config
+
+Recommended: use the FlutterFire CLI from `apps/flutter`:
+
+```bash
+dart pub global activate flutterfire_cli
+flutterfire configure
+```
+
+This generates `lib/firebase_options.dart` and wires the native config. If you
+prefer manual setup:
+
+- **Android**: place `google-services.json` in `apps/flutter/android/app/`, add
+  the `com.google.gms.google-services` Gradle plugin, and add the
+  `POST_NOTIFICATIONS` permission (Android 13+) to the manifest.
+  `flutter_local_notifications` also requires Java 8+ core-library desugaring —
+  set `isCoreLibraryDesugaringEnabled true` and add the
+  `coreLibraryDesugaring` dependency per that package's README.
+- **iOS**: place `GoogleService-Info.plist` in `apps/flutter/ios/Runner/`, enable
+  the **Push Notifications** capability and **Background Modes → Remote
+  notifications** in Xcode, and upload an APNs key to the Firebase project.
+
+If you generate `firebase_options.dart`, pass the options to
+`Firebase.initializeApp` in
+`apps/flutter/lib/features/notifications/push_notification_service.dart`
+(`_initFirebase`). With native config files in place, the no-argument
+`Firebase.initializeApp()` also works.
+
+## 3. API / server config
+
+Provide FCM credentials via the `Notifications:Fcm` configuration section
+(env vars shown):
+
+```
+Notifications__Fcm__ProjectId=<firebase-project-id>
+Notifications__Fcm__ServiceAccountJson=<inline service account JSON>
+# or
+Notifications__Fcm__ServiceAccountJsonPath=/run/secrets/fcm-service-account.json
+```
+
+Generate the service account under Firebase Console → Project settings →
+Service accounts → *Generate new private key*.
+
+### Finish `FcmPushSender`
+
+`FcmPushSender.TryGetAccessTokenAsync` currently returns `null` (the only thing
+keeping live delivery off when credentials are present). Implement it with the
+service account, e.g. add the `Google.Apis.Auth` package and:
+
+```csharp
+var credential = GoogleCredential
+    .FromJson(serviceAccountJson)
+    .CreateScoped("https://www.googleapis.com/auth/firebase.messaging");
+return await credential.UnderlyingCredential.GetAccessTokenForRequestAsync();
+```
+
+Once it returns a token, `IPushSender.IsConfigured` is already true and
+`SendAsync` will deliver to FCM.
+
+## 4. Trigger notifications
+
+Inject `IPushSender` where an event should notify a user and call `SendAsync`.
+Natural first triggers live in the Sharing module (friend requests, new shares).
+Stale tokens (FCM 404/410) are pruned automatically.
+
+## Testing
+
+- `device_tokens` registration is covered by the API behaviour tests.
+- End-to-end delivery requires a real device/emulator with the Firebase config
+  in place; it can't run in CI without credentials.


### PR DESCRIPTION
The profile screen's option tiles all had empty onTap callbacks, so the
page did nothing when tapped. Wire the tiles to real destinations:
- Settings -> SettingsPage
- Help & Support -> opens a support email via url_launcher
- About -> AboutSettingsPage

Drop the Edit Profile / Change Password / Notifications stubs, which had
no backend or feature support. Also surface the sign-in method (Google vs
password) in the header.