### PR TITLE
Implement offline map caching with tile management and download service

### DIFF
--- a/apps/android/core/data/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/data/SettingsRepository.kt
+++ b/apps/android/core/data/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/data/SettingsRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
 import com.sigmundgranaas.turbo.expressive.domain.ThemeMode
 import com.sigmundgranaas.turbo.expressive.domain.UserSettings
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -24,6 +25,7 @@ interface SettingsRepository {
     suspend fun setThemeMode(mode: ThemeMode)
     suspend fun setCloudSyncEnabled(enabled: Boolean)
     suspend fun setDownloadOverWifiOnly(enabled: Boolean)
+    suspend fun setBaseLayer(layer: BaseLayer)
 }
 
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_settings")
@@ -40,6 +42,7 @@ class DataStoreSettingsRepository @Inject constructor(
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val CLOUD_SYNC = booleanPreferencesKey("cloud_sync_enabled")
         val WIFI_ONLY = booleanPreferencesKey("download_wifi_only")
+        val BASE_LAYER = stringPreferencesKey("base_layer")
     }
 
     override val settings: Flow<UserSettings> = context.settingsDataStore.data.map { prefs ->
@@ -52,6 +55,9 @@ class DataStoreSettingsRepository @Inject constructor(
                 ?: ThemeMode.System,
             cloudSyncEnabled = prefs[Keys.CLOUD_SYNC] ?: true,
             downloadOverWifiOnly = prefs[Keys.WIFI_ONLY] ?: false,
+            baseLayer = prefs[Keys.BASE_LAYER]
+                ?.let { id -> BaseLayer.entries.firstOrNull { it.id == id } }
+                ?: BaseLayer.Norgeskart,
         )
     }
 
@@ -77,5 +83,9 @@ class DataStoreSettingsRepository @Inject constructor(
 
     override suspend fun setDownloadOverWifiOnly(enabled: Boolean) {
         context.settingsDataStore.edit { it[Keys.WIFI_ONLY] = enabled }
+    }
+
+    override suspend fun setBaseLayer(layer: BaseLayer) {
+        context.settingsDataStore.edit { it[Keys.BASE_LAYER] = layer.id }
     }
 }

--- a/apps/android/core/data/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/data/SettingsRepository.kt
+++ b/apps/android/core/data/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/data/SettingsRepository.kt
@@ -23,6 +23,7 @@ interface SettingsRepository {
     suspend fun setMetricUnits(metric: Boolean)
     suspend fun setThemeMode(mode: ThemeMode)
     suspend fun setCloudSyncEnabled(enabled: Boolean)
+    suspend fun setDownloadOverWifiOnly(enabled: Boolean)
 }
 
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_settings")
@@ -38,6 +39,7 @@ class DataStoreSettingsRepository @Inject constructor(
         val METRIC = booleanPreferencesKey("metric_units")
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val CLOUD_SYNC = booleanPreferencesKey("cloud_sync_enabled")
+        val WIFI_ONLY = booleanPreferencesKey("download_wifi_only")
     }
 
     override val settings: Flow<UserSettings> = context.settingsDataStore.data.map { prefs ->
@@ -49,6 +51,7 @@ class DataStoreSettingsRepository @Inject constructor(
                 ?.let { runCatching { ThemeMode.valueOf(it) }.getOrNull() }
                 ?: ThemeMode.System,
             cloudSyncEnabled = prefs[Keys.CLOUD_SYNC] ?: true,
+            downloadOverWifiOnly = prefs[Keys.WIFI_ONLY] ?: false,
         )
     }
 
@@ -70,5 +73,9 @@ class DataStoreSettingsRepository @Inject constructor(
 
     override suspend fun setCloudSyncEnabled(enabled: Boolean) {
         context.settingsDataStore.edit { it[Keys.CLOUD_SYNC] = enabled }
+    }
+
+    override suspend fun setDownloadOverWifiOnly(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.WIFI_ONLY] = enabled }
     }
 }

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/DownloadPolicy.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/DownloadPolicy.kt
@@ -1,0 +1,22 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+/** A snapshot of the device's connectivity, as the download policy needs it. */
+data class NetworkState(
+    val connected: Boolean,
+    /** True on un-metered networks (Wi-Fi / Ethernet); false on metered cellular. */
+    val unmetered: Boolean,
+) {
+    companion object {
+        val Disconnected = NetworkState(connected = false, unmetered = false)
+    }
+}
+
+/**
+ * Pure decision for whether offline downloads may run right now, given the user's
+ * "Wi-Fi only" preference and the current [NetworkState]. Isolated so it is trivially
+ * unit-testable; the connectivity plumbing lives in [NetworkMonitor].
+ */
+object DownloadPolicy {
+    fun shouldDownload(wifiOnly: Boolean, net: NetworkState): Boolean =
+        net.connected && (!wifiOnly || net.unmetered)
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/LocalStyleServer.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/LocalStyleServer.kt
@@ -1,6 +1,7 @@
 package com.sigmundgranaas.turbo.expressive.core.map
 
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
 import com.sigmundgranaas.turbo.expressive.ui.map.MapStyles
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -14,19 +15,22 @@ import java.net.Socket
  * (`file://` and `data:` URIs are rejected). Since our raster styles are generated
  * on-device, this tiny loopback server hands them out over `http://127.0.0.1` so the
  * downloader can read them. It binds to localhost only (never externally reachable)
- * and serves a single GET per base layer: `/<baseId>.json`.
+ * and serves a single GET per base layer: `/<baseId>.json?ov=<Overlay,Overlay>`.
  *
- * The raster *tiles* are still fetched (and stored) straight from their remote source.
+ * The raster *tiles* — base map **and** the requested overlays — are still fetched
+ * (and stored) straight from their remote sources, so downloading a region with the
+ * avalanche/trail overlay on caches those tiles for offline use too.
  */
 internal class LocalStyleServer {
 
     @Volatile private var server: ServerSocket? = null
 
-    /** Starts the server if needed and returns the style URL for [base]. */
+    /** Starts the server if needed and returns the style URL for [base] + [overlays]. */
     @Synchronized
-    fun styleUrl(base: BaseLayer): String {
+    fun styleUrl(base: BaseLayer, overlays: Set<OverlayId> = emptySet()): String {
         val port = ensureStarted()
-        return "http://127.0.0.1:$port/${base.id}.json"
+        val query = if (overlays.isEmpty()) "" else "?ov=" + overlays.joinToString(",") { it.name }
+        return "http://127.0.0.1:$port/${base.id}.json$query"
     }
 
     private fun ensureStarted(): Int {
@@ -48,10 +52,14 @@ internal class LocalStyleServer {
     private fun serve(client: Socket) {
         val reader = BufferedReader(InputStreamReader(client.getInputStream()))
         val requestLine = reader.readLine() ?: return
-        // "GET /topo.json HTTP/1.1" → topo
-        val path = requestLine.split(" ").getOrNull(1).orEmpty()
-        val id = path.trimStart('/').substringBefore(".json")
+        // "GET /topo.json?ov=Avalanche,Trails HTTP/1.1" → topo + {Avalanche, Trails}
+        val target = requestLine.split(" ").getOrNull(1).orEmpty()
+        val id = target.substringBefore('?').trimStart('/').substringBefore(".json")
         val base = BaseLayer.entries.firstOrNull { it.id == id }
+        val overlays = target.substringAfter("?ov=", "")
+            .split(',')
+            .mapNotNull { name -> OverlayId.entries.firstOrNull { it.name == name } }
+            .toSet()
 
         val output = client.getOutputStream()
         if (base == null) {
@@ -59,7 +67,7 @@ internal class LocalStyleServer {
             output.flush()
             return
         }
-        val body = MapStyles.styleJson(base).toByteArray()
+        val body = MapStyles.styleJson(base, overlays).toByteArray()
         val headers = buildString {
             append("HTTP/1.1 200 OK\r\n")
             append("Content-Type: application/json\r\n")

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/NetworkMonitor.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/NetworkMonitor.kt
@@ -1,0 +1,54 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Observes the device's connectivity as a [NetworkState] stream. */
+interface NetworkMonitor {
+    val state: StateFlow<NetworkState>
+}
+
+/**
+ * [NetworkMonitor] backed by [ConnectivityManager]'s default-network callback.
+ * Singleton: it registers once and keeps a hot [StateFlow] the download service
+ * reads to gate (and resume) downloads as Wi-Fi/cellular comes and goes.
+ */
+@Singleton
+class AndroidNetworkMonitor @Inject constructor(
+    @param:ApplicationContext context: Context,
+) : NetworkMonitor {
+
+    private val cm = context.getSystemService(ConnectivityManager::class.java)
+    private val _state = MutableStateFlow(snapshot())
+    override val state: StateFlow<NetworkState> = _state.asStateFlow()
+
+    init {
+        cm?.registerDefaultNetworkCallback(object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) { _state.value = snapshot() }
+            override fun onLost(network: Network) { _state.value = NetworkState.Disconnected }
+            override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+                _state.value = caps.toState()
+            }
+        })
+    }
+
+    private fun snapshot(): NetworkState {
+        val caps = cm?.getNetworkCapabilities(cm.activeNetwork) ?: return NetworkState.Disconnected
+        return caps.toState()
+    }
+
+    private fun NetworkCapabilities.toState(): NetworkState {
+        val online = hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        val unmetered = hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+        return NetworkState(connected = online, unmetered = unmetered)
+    }
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineCoverage.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineCoverage.kt
@@ -1,0 +1,21 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.LatLng
+import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
+
+/**
+ * Pure check for whether a map position is covered by any downloaded offline
+ * region — drives the "outside downloaded area" hint when the device is offline.
+ */
+object OfflineCoverage {
+
+    /** True when [point] lies inside the bounds of any *complete* region. */
+    fun covers(regions: List<OfflineRegionInfo>, point: LatLng): Boolean =
+        regions.any { region ->
+            region.status == OfflineStatus.Complete &&
+                region.bounds?.let { b ->
+                    point.lat in b.south..b.north && point.lng in b.west..b.east
+                } == true
+        }
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineRegionMetadata.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineRegionMetadata.kt
@@ -1,0 +1,79 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+ * MapLibre persists an opaque `byte[]` per offline region. Historically we stored
+ * just the display name; this encodes the *full* region metadata (name, base map,
+ * overlays, extent, zoom span, creation time) so it round-trips and the offline
+ * list can show where a region is and what it covers.
+ *
+ * Pure (no MapLibre / Android dependency) so it is unit-testable on the JVM. The
+ * format is a versioned, `;`-delimited `key=value` line; the free-text name is
+ * Base64-encoded so place names with delimiters or unicode survive intact. A blob
+ * that doesn't start with `v=` is treated as a legacy bare-name string.
+ */
+internal object OfflineRegionMetadata {
+
+    data class Meta(
+        val name: String,
+        val base: BaseLayer,
+        val overlays: Set<OverlayId>,
+        val bounds: GeoBounds?,
+        val minZoom: Double,
+        val maxZoom: Double,
+        val createdAtEpochMs: Long,
+    )
+
+    private const val VERSION = 2
+
+    fun encode(meta: Meta): ByteArray {
+        val name64 = Base64.getEncoder().encodeToString(meta.name.toByteArray(StandardCharsets.UTF_8))
+        val ov = meta.overlays.joinToString(",") { it.name }
+        val b = meta.bounds
+        val bounds = if (b == null) "" else "${b.south},${b.west},${b.north},${b.east}"
+        val line = buildString {
+            append("v=").append(VERSION)
+            append(";name=").append(name64)
+            append(";base=").append(meta.base.id)
+            append(";ov=").append(ov)
+            append(";b=").append(bounds)
+            append(";z=").append(meta.minZoom).append(',').append(meta.maxZoom)
+            append(";t=").append(meta.createdAtEpochMs)
+        }
+        return line.toByteArray(StandardCharsets.UTF_8)
+    }
+
+    /** Decodes [bytes]; never throws — returns null only when nothing usable is present. */
+    fun decode(bytes: ByteArray?): Meta? {
+        if (bytes == null || bytes.isEmpty()) return null
+        val text = String(bytes, StandardCharsets.UTF_8)
+        if (!text.startsWith("v=")) {
+            // Legacy region: the whole blob was the display name.
+            return Meta(text, BaseLayer.Norgeskart, emptySet(), null, 0.0, 0.0, 0L)
+        }
+        val fields = text.split(';')
+            .mapNotNull { part -> part.split('=', limit = 2).takeIf { it.size == 2 }?.let { it[0] to it[1] } }
+            .toMap()
+        val name = fields["name"]?.let {
+            runCatching { String(Base64.getDecoder().decode(it), StandardCharsets.UTF_8) }.getOrNull()
+        } ?: return null
+        val base = BaseLayer.entries.firstOrNull { it.id == fields["base"] } ?: BaseLayer.Norgeskart
+        val overlays = fields["ov"].orEmpty().split(',')
+            .filter { it.isNotBlank() }
+            .mapNotNull { id -> OverlayId.entries.firstOrNull { it.name == id } }
+            .toSet()
+        val bounds = fields["b"].orEmpty().split(',').mapNotNull { it.toDoubleOrNull() }
+            .takeIf { it.size == 4 }
+            ?.let { GeoBounds(south = it[0], west = it[1], north = it[2], east = it[3]) }
+        val zoom = fields["z"].orEmpty().split(',').mapNotNull { it.toDoubleOrNull() }
+        val minZoom = zoom.getOrNull(0) ?: 0.0
+        val maxZoom = zoom.getOrNull(1) ?: 0.0
+        val created = fields["t"]?.toLongOrNull() ?: 0L
+        return Meta(name, base, overlays, bounds, minZoom, maxZoom, created)
+    }
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineServiceLauncher.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineServiceLauncher.kt
@@ -1,0 +1,12 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+/**
+ * Lets the (core:map) tile manager ensure the foreground download service is
+ * running without depending on the feature module that hosts it. The
+ * implementation lives where the service does and is bound via Hilt; in DEBUG
+ * (synthetic manager) there is no service, so nothing injects this.
+ */
+fun interface OfflineServiceLauncher {
+    /** Start/keep the foreground download service alive (idempotent). */
+    fun ensureRunning()
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
@@ -37,7 +37,20 @@ interface OfflineTileManager {
 
     /** Re-activate a [OfflineStatus.Failed] region's download. */
     fun retry(id: Long)
+
+    /** Stop a region's download without discarding the tiles already fetched. */
+    fun pause(id: Long)
+
+    /** Continue a paused region's download (subject to the network policy). */
+    fun resume(id: Long)
     fun delete(id: Long)
+
+    /**
+     * Gate all in-flight downloads on connectivity: when [allowed] is false the
+     * active regions are paused; when it flips back they resume (except ones the
+     * user paused explicitly). Driven by the foreground service's network policy.
+     */
+    fun setNetworkAllowed(allowed: Boolean)
 
     /** Pre-flight tile/byte estimate for [spec] (no I/O). */
     fun estimate(spec: DownloadSpec): OfflineEstimate
@@ -46,6 +59,7 @@ interface OfflineTileManager {
 @Singleton
 class MapLibreOfflineTileManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val serviceLauncher: OfflineServiceLauncher,
 ) : OfflineTileManager {
 
     private val manager: OfflineManager by lazy {
@@ -56,6 +70,9 @@ class MapLibreOfflineTileManager @Inject constructor(
     private val regionsById = mutableMapOf<Long, OfflineRegion>()
     /** Regions that stopped on an error → reason, until the user retries/deletes. */
     private val failures = mutableMapOf<Long, String>()
+    /** Regions the user paused explicitly — must NOT auto-resume on connectivity. */
+    private val userPaused = mutableSetOf<Long>()
+    private var networkAllowed = true
     private val _regions = MutableStateFlow<List<OfflineRegionInfo>>(emptyList())
     override val regions: StateFlow<List<OfflineRegionInfo>> = _regions.asStateFlow()
 
@@ -87,6 +104,7 @@ class MapLibreOfflineTileManager @Inject constructor(
     }
 
     override fun download(spec: DownloadSpec) {
+        serviceLauncher.ensureRunning()
         val definition = OfflineTilePyramidRegionDefinition(
             styleServer.styleUrl(spec.base),
             LatLngBounds.Builder()
@@ -112,7 +130,7 @@ class MapLibreOfflineTileManager @Inject constructor(
             override fun onCreate(offlineRegion: OfflineRegion) {
                 regionsById[offlineRegion.id] = offlineRegion
                 offlineRegion.setObserver(observerFor(offlineRegion))
-                offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE)
+                offlineRegion.setDownloadState(if (networkAllowed) OfflineRegion.STATE_ACTIVE else OfflineRegion.STATE_INACTIVE)
                 refresh()
             }
             override fun onError(error: String) = Unit
@@ -122,17 +140,44 @@ class MapLibreOfflineTileManager @Inject constructor(
     override fun retry(id: Long) {
         val region = regionsById[id] ?: return
         failures.remove(id)
+        userPaused.remove(id)
+        serviceLauncher.ensureRunning()
         region.setObserver(observerFor(region))
-        region.setDownloadState(OfflineRegion.STATE_ACTIVE)
-        // Surface the optimistic "downloading again" state immediately.
-        upsert(region.baseInfo())
+        region.setDownloadState(if (networkAllowed) OfflineRegion.STATE_ACTIVE else OfflineRegion.STATE_INACTIVE)
+        upsert(region.meta())
+    }
+
+    override fun pause(id: Long) {
+        val region = regionsById[id] ?: return
+        userPaused += id
+        region.setDownloadState(OfflineRegion.STATE_INACTIVE)
+    }
+
+    override fun resume(id: Long) {
+        val region = regionsById[id] ?: return
+        userPaused -= id
+        failures.remove(id)
+        serviceLauncher.ensureRunning()
+        if (networkAllowed) region.setDownloadState(OfflineRegion.STATE_ACTIVE)
+    }
+
+    override fun setNetworkAllowed(allowed: Boolean) {
+        networkAllowed = allowed
+        regionsById.forEach { (id, region) ->
+            val status = _regions.value.firstOrNull { it.id == id }?.status
+            if (status == OfflineStatus.Complete || status == OfflineStatus.Failed) return@forEach
+            if (id in userPaused) return@forEach
+            region.setDownloadState(if (allowed) OfflineRegion.STATE_ACTIVE else OfflineRegion.STATE_INACTIVE)
+        }
     }
 
     override fun delete(id: Long) {
         val region = regionsById[id] ?: return
         region.setDownloadState(OfflineRegion.STATE_INACTIVE)
         region.delete(object : OfflineRegion.OfflineRegionDeleteCallback {
-            override fun onDelete() { regionsById.remove(id); failures.remove(id); refresh() }
+            override fun onDelete() {
+                regionsById.remove(id); failures.remove(id); userPaused.remove(id); refresh()
+            }
             override fun onError(error: String) = Unit
         })
     }
@@ -149,7 +194,7 @@ class MapLibreOfflineTileManager @Inject constructor(
 
     private fun markFailed(region: OfflineRegion, reason: String) {
         failures[region.id] = reason
-        val current = _regions.value.firstOrNull { it.id == region.id } ?: region.baseInfo()
+        val current = _regions.value.firstOrNull { it.id == region.id } ?: region.meta()
         upsert(current.copy(status = OfflineStatus.Failed, errorReason = reason))
     }
 
@@ -175,9 +220,6 @@ class MapLibreOfflineTileManager @Inject constructor(
             errorReason = failures[id],
         )
     }
-
-    /** A zero-progress info from the persisted metadata — used before a status arrives. */
-    private fun OfflineRegion.baseInfo(): OfflineRegionInfo = meta()
 
     /** Decode this region's metadata into an [OfflineRegionInfo] shell (status Downloading). */
     private fun OfflineRegion.meta(): OfflineRegionInfo {
@@ -207,7 +249,11 @@ object OfflineModule {
     @Provides
     @Singleton
     fun provideOfflineTileManager(
-        real: MapLibreOfflineTileManager,
+        real: dagger.Lazy<MapLibreOfflineTileManager>,
         synthetic: SyntheticOfflineTileManager,
-    ): OfflineTileManager = if (BuildConfig.DEBUG) synthetic else real
+    ): OfflineTileManager = if (BuildConfig.DEBUG) synthetic else real.get()
+
+    @Provides
+    @Singleton
+    fun provideNetworkMonitor(impl: AndroidNetworkMonitor): NetworkMonitor = impl
 }

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import org.maplibre.android.MapLibre
 import org.maplibre.android.geometry.LatLng as MlLatLng
 import org.maplibre.android.geometry.LatLngBounds
@@ -78,12 +79,15 @@ class MapLibreOfflineTileManager @Inject constructor(
         }
     }
     private val styleServer = LocalStyleServer()
-    private val regionsById = mutableMapOf<Long, OfflineRegion>()
+    // MapLibre delivers callbacks off the registering thread in some paths, and a
+    // refresh()'s batched statuses interleave with the per-region observer — so all
+    // shared mutable state is concurrent and list publication is atomic (see below).
+    private val regionsById = java.util.concurrent.ConcurrentHashMap<Long, OfflineRegion>()
     /** Regions that stopped on an error → reason, until the user retries/deletes. */
-    private val failures = mutableMapOf<Long, String>()
+    private val failures = java.util.concurrent.ConcurrentHashMap<Long, String>()
     /** Regions the user paused explicitly — must NOT auto-resume on connectivity. */
-    private val userPaused = mutableSetOf<Long>()
-    private var networkAllowed = true
+    private val userPaused = java.util.concurrent.ConcurrentHashMap.newKeySet<Long>()
+    @Volatile private var networkAllowed = true
     private val _regions = MutableStateFlow<List<OfflineRegionInfo>>(emptyList())
     override val regions: StateFlow<List<OfflineRegionInfo>> = _regions.asStateFlow()
 
@@ -96,17 +100,28 @@ class MapLibreOfflineTileManager @Inject constructor(
                 regionsById.clear()
                 list.forEach { regionsById[it.id] = it; it.setObserver(observerFor(it)) }
                 if (list.isEmpty()) { _regions.value = emptyList(); return }
-                val acc = mutableListOf<OfflineRegionInfo>()
-                var remaining = list.size
+                val acc = java.util.Collections.synchronizedList(mutableListOf<OfflineRegionInfo>())
+                val remaining = java.util.concurrent.atomic.AtomicInteger(list.size)
+                fun publishIfDone() {
+                    // Merge (don't replace): a region created while statuses were being
+                    // gathered survives, and deleted regions drop out atomically.
+                    if (remaining.decrementAndGet() == 0) {
+                        val byId = acc.associateBy { it.id }
+                        _regions.update { current ->
+                            val currentIds = current.map { it.id }.toSet()
+                            (current.map { byId[it.id] ?: it } + acc.filterNot { it.id in currentIds })
+                                .filter { it.id in regionsById.keys }
+                                .sortedBy { it.name }
+                        }
+                    }
+                }
                 list.forEach { region ->
                     region.getStatus(object : OfflineRegion.OfflineRegionStatusCallback {
                         override fun onStatus(status: OfflineRegionStatus?) {
                             if (status != null) acc += region.toInfo(status)
-                            if (--remaining == 0) _regions.value = acc.sortedBy { it.name }
+                            publishIfDone()
                         }
-                        override fun onError(error: String?) {
-                            if (--remaining == 0) _regions.value = acc.sortedBy { it.name }
-                        }
+                        override fun onError(error: String?) = publishIfDone()
                     })
                 }
             }
@@ -229,7 +244,7 @@ class MapLibreOfflineTileManager @Inject constructor(
     }
 
     private fun upsert(info: OfflineRegionInfo) {
-        _regions.value = (_regions.value.filterNot { it.id == info.id } + info).sortedBy { it.name }
+        _regions.update { current -> (current.filterNot { it.id == info.id } + info).sortedBy { it.name } }
     }
 
     private fun OfflineRegion.toInfo(status: OfflineRegionStatus): OfflineRegionInfo {

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
@@ -106,7 +106,7 @@ class MapLibreOfflineTileManager @Inject constructor(
     override fun download(spec: DownloadSpec) {
         serviceLauncher.ensureRunning()
         val definition = OfflineTilePyramidRegionDefinition(
-            styleServer.styleUrl(spec.base),
+            styleServer.styleUrl(spec.base, spec.overlays),
             LatLngBounds.Builder()
                 .include(MlLatLng(spec.bounds.north, spec.bounds.east))
                 .include(MlLatLng(spec.bounds.south, spec.bounds.west))

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
@@ -2,8 +2,10 @@ package com.sigmundgranaas.turbo.expressive.core.map
 
 import android.content.Context
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
-import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -31,8 +33,14 @@ import javax.inject.Singleton
 interface OfflineTileManager {
     val regions: StateFlow<List<OfflineRegionInfo>>
     fun refresh()
-    fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double)
+    fun download(spec: DownloadSpec)
+
+    /** Re-activate a [OfflineStatus.Failed] region's download. */
+    fun retry(id: Long)
     fun delete(id: Long)
+
+    /** Pre-flight tile/byte estimate for [spec] (no I/O). */
+    fun estimate(spec: DownloadSpec): OfflineEstimate
 }
 
 @Singleton
@@ -42,19 +50,23 @@ class MapLibreOfflineTileManager @Inject constructor(
 
     private val manager: OfflineManager by lazy {
         MapLibre.getInstance(context)
-        OfflineManager.getInstance(context).apply { setOfflineMapboxTileCountLimit(MAX_TILES) }
+        OfflineManager.getInstance(context).apply { setOfflineMapboxTileCountLimit(TileMath.MAX_TILES) }
     }
     private val styleServer = LocalStyleServer()
     private val regionsById = mutableMapOf<Long, OfflineRegion>()
+    /** Regions that stopped on an error → reason, until the user retries/deletes. */
+    private val failures = mutableMapOf<Long, String>()
     private val _regions = MutableStateFlow<List<OfflineRegionInfo>>(emptyList())
     override val regions: StateFlow<List<OfflineRegionInfo>> = _regions.asStateFlow()
+
+    override fun estimate(spec: DownloadSpec): OfflineEstimate = TileMath.estimate(spec)
 
     override fun refresh() {
         manager.listOfflineRegions(object : OfflineManager.ListOfflineRegionsCallback {
             override fun onList(offlineRegions: Array<OfflineRegion>?) {
                 val list = offlineRegions?.toList().orEmpty()
                 regionsById.clear()
-                list.forEach { regionsById[it.id] = it }
+                list.forEach { regionsById[it.id] = it; it.setObserver(observerFor(it)) }
                 if (list.isEmpty()) { _regions.value = emptyList(); return }
                 val acc = mutableListOf<OfflineRegionInfo>()
                 var remaining = list.size
@@ -74,18 +86,29 @@ class MapLibreOfflineTileManager @Inject constructor(
         })
     }
 
-    override fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double) {
+    override fun download(spec: DownloadSpec) {
         val definition = OfflineTilePyramidRegionDefinition(
-            styleUrl(base),
+            styleServer.styleUrl(spec.base),
             LatLngBounds.Builder()
-                .include(MlLatLng(bounds.north, bounds.east))
-                .include(MlLatLng(bounds.south, bounds.west))
+                .include(MlLatLng(spec.bounds.north, spec.bounds.east))
+                .include(MlLatLng(spec.bounds.south, spec.bounds.west))
                 .build(),
-            minZoom,
-            maxZoom,
+            spec.minZoom,
+            spec.maxZoom,
             context.resources.displayMetrics.density,
         )
-        manager.createOfflineRegion(definition, name.toByteArray(), object : OfflineManager.CreateOfflineRegionCallback {
+        val metadata = OfflineRegionMetadata.encode(
+            OfflineRegionMetadata.Meta(
+                name = spec.name,
+                base = spec.base,
+                overlays = spec.overlays,
+                bounds = spec.bounds,
+                minZoom = spec.minZoom,
+                maxZoom = spec.maxZoom,
+                createdAtEpochMs = System.currentTimeMillis(),
+            ),
+        )
+        manager.createOfflineRegion(definition, metadata, object : OfflineManager.CreateOfflineRegionCallback {
             override fun onCreate(offlineRegion: OfflineRegion) {
                 regionsById[offlineRegion.id] = offlineRegion
                 offlineRegion.setObserver(observerFor(offlineRegion))
@@ -96,19 +119,38 @@ class MapLibreOfflineTileManager @Inject constructor(
         })
     }
 
+    override fun retry(id: Long) {
+        val region = regionsById[id] ?: return
+        failures.remove(id)
+        region.setObserver(observerFor(region))
+        region.setDownloadState(OfflineRegion.STATE_ACTIVE)
+        // Surface the optimistic "downloading again" state immediately.
+        upsert(region.baseInfo())
+    }
+
     override fun delete(id: Long) {
         val region = regionsById[id] ?: return
         region.setDownloadState(OfflineRegion.STATE_INACTIVE)
         region.delete(object : OfflineRegion.OfflineRegionDeleteCallback {
-            override fun onDelete() { regionsById.remove(id); refresh() }
+            override fun onDelete() { regionsById.remove(id); failures.remove(id); refresh() }
             override fun onError(error: String) = Unit
         })
     }
 
     private fun observerFor(region: OfflineRegion) = object : OfflineRegion.OfflineRegionObserver {
         override fun onStatusChanged(status: OfflineRegionStatus) = upsert(region.toInfo(status))
-        override fun onError(error: OfflineRegionError) = Unit
-        override fun mapboxTileCountLimitExceeded(limit: Long) = Unit
+        override fun onError(error: OfflineRegionError) =
+            markFailed(region, error.reason?.takeIf { it.isNotBlank() } ?: error.message ?: "Download failed")
+        override fun mapboxTileCountLimitExceeded(limit: Long) {
+            region.setDownloadState(OfflineRegion.STATE_INACTIVE)
+            markFailed(region, "Tile limit exceeded ($limit)")
+        }
+    }
+
+    private fun markFailed(region: OfflineRegion, reason: String) {
+        failures[region.id] = reason
+        val current = _regions.value.firstOrNull { it.id == region.id } ?: region.baseInfo()
+        upsert(current.copy(status = OfflineStatus.Failed, errorReason = reason))
     }
 
     private fun upsert(info: OfflineRegionInfo) {
@@ -116,16 +158,44 @@ class MapLibreOfflineTileManager @Inject constructor(
     }
 
     private fun OfflineRegion.toInfo(status: OfflineRegionStatus): OfflineRegionInfo {
-        val name = runCatching { String(metadata) }.getOrDefault("Region")
         val required = status.requiredResourceCount.coerceAtLeast(1)
-        val progress = if (status.isComplete) 1f else (status.completedResourceCount.toDouble() / required).toFloat().coerceIn(0f, 1f)
-        return OfflineRegionInfo(id, name, status.isComplete, progress, status.completedResourceSize)
+        val progress = if (status.isComplete) 1f
+            else (status.completedResourceCount.toDouble() / required).toFloat().coerceIn(0f, 1f)
+        val st = when {
+            failures.containsKey(id) -> OfflineStatus.Failed
+            status.isComplete -> OfflineStatus.Complete
+            status.downloadState == OfflineRegion.STATE_INACTIVE -> OfflineStatus.Paused
+            else -> OfflineStatus.Downloading
+        }
+        return meta().copy(
+            status = st,
+            progress = progress,
+            sizeBytes = status.completedResourceSize,
+            tileCount = status.completedTileCount,
+            errorReason = failures[id],
+        )
     }
 
-    private fun styleUrl(base: BaseLayer): String = styleServer.styleUrl(base)
+    /** A zero-progress info from the persisted metadata — used before a status arrives. */
+    private fun OfflineRegion.baseInfo(): OfflineRegionInfo = meta()
 
-    private companion object {
-        const val MAX_TILES = 100_000L
+    /** Decode this region's metadata into an [OfflineRegionInfo] shell (status Downloading). */
+    private fun OfflineRegion.meta(): OfflineRegionInfo {
+        val m = OfflineRegionMetadata.decode(metadata)
+        return OfflineRegionInfo(
+            id = id,
+            name = m?.name ?: "Region",
+            status = OfflineStatus.Downloading,
+            progress = 0f,
+            sizeBytes = 0L,
+            tileCount = 0L,
+            base = m?.base ?: BaseLayer.Norgeskart,
+            overlays = m?.overlays ?: emptySet(),
+            bounds = m?.bounds,
+            minZoom = m?.minZoom ?: 0.0,
+            maxZoom = m?.maxZoom ?: 0.0,
+            createdAtEpochMs = m?.createdAtEpochMs ?: 0L,
+        )
     }
 }
 

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineTileManager.kt
@@ -43,7 +43,13 @@ interface OfflineTileManager {
 
     /** Continue a paused region's download (subject to the network policy). */
     fun resume(id: Long)
+
+    /** Rewrite a region's display name (the tiles are untouched). */
+    fun rename(id: Long, name: String)
     fun delete(id: Long)
+
+    /** Drop the ambient (browse) cache; explicit offline regions are untouched. */
+    fun clearAmbientCache()
 
     /**
      * Gate all in-flight downloads on connectivity: when [allowed] is false the
@@ -64,7 +70,12 @@ class MapLibreOfflineTileManager @Inject constructor(
 
     private val manager: OfflineManager by lazy {
         MapLibre.getInstance(context)
-        OfflineManager.getInstance(context).apply { setOfflineMapboxTileCountLimit(TileMath.MAX_TILES) }
+        OfflineManager.getInstance(context).apply {
+            setOfflineMapboxTileCountLimit(TileMath.MAX_TILES)
+            // Size the browse cache up from MapLibre's ~50 MB default so recently
+            // panned areas survive going offline even without an explicit region.
+            setMaximumAmbientCacheSize(AMBIENT_CACHE_BYTES, noopFileSourceCallback)
+        }
     }
     private val styleServer = LocalStyleServer()
     private val regionsById = mutableMapOf<Long, OfflineRegion>()
@@ -171,6 +182,21 @@ class MapLibreOfflineTileManager @Inject constructor(
         }
     }
 
+    override fun rename(id: Long, name: String) {
+        val region = regionsById[id] ?: return
+        val current = OfflineRegionMetadata.decode(region.metadata)
+            ?: OfflineRegionMetadata.Meta(name, BaseLayer.Norgeskart, emptySet(), null, 0.0, 0.0, 0L)
+        region.updateMetadata(
+            OfflineRegionMetadata.encode(current.copy(name = name)),
+            object : OfflineRegion.OfflineRegionUpdateMetadataCallback {
+                override fun onUpdate(metadata: ByteArray) {
+                    _regions.value.firstOrNull { it.id == id }?.let { upsert(it.copy(name = name)) }
+                }
+                override fun onError(error: String) = Unit
+            },
+        )
+    }
+
     override fun delete(id: Long) {
         val region = regionsById[id] ?: return
         region.setDownloadState(OfflineRegion.STATE_INACTIVE)
@@ -180,6 +206,10 @@ class MapLibreOfflineTileManager @Inject constructor(
             }
             override fun onError(error: String) = Unit
         })
+    }
+
+    override fun clearAmbientCache() {
+        manager.clearAmbientCache(noopFileSourceCallback)
     }
 
     private fun observerFor(region: OfflineRegion) = object : OfflineRegion.OfflineRegionObserver {
@@ -238,6 +268,15 @@ class MapLibreOfflineTileManager @Inject constructor(
             maxZoom = m?.maxZoom ?: 0.0,
             createdAtEpochMs = m?.createdAtEpochMs ?: 0L,
         )
+    }
+
+    private val noopFileSourceCallback = object : OfflineManager.FileSourceCallback {
+        override fun onSuccess() = Unit
+        override fun onError(message: String) = Unit
+    }
+
+    private companion object {
+        const val AMBIENT_CACHE_BYTES = 256L * 1024 * 1024
     }
 }
 

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
@@ -52,15 +52,22 @@ class SyntheticOfflineTileManager @Inject constructor() : OfflineTileManager {
         }
     }
 
-    override fun retry(id: Long) = _regions.update { list ->
-        list.map {
-            if (it.id == id && it.status == OfflineStatus.Failed) {
-                it.copy(status = OfflineStatus.Complete, progress = 1f, errorReason = null)
-            } else {
-                it
-            }
-        }
+    override fun retry(id: Long) = complete(id)
+
+    override fun pause(id: Long) = _regions.update { list ->
+        list.map { if (it.id == id) it.copy(status = OfflineStatus.Paused) else it }
     }
 
+    override fun resume(id: Long) = complete(id)
+
+    // The synthetic manager has no real network, so connectivity gating is a no-op.
+    override fun setNetworkAllowed(allowed: Boolean) = Unit
+
     override fun delete(id: Long) = _regions.update { list -> list.filterNot { it.id == id } }
+
+    private fun complete(id: Long) = _regions.update { list ->
+        list.map {
+            if (it.id == id) it.copy(status = OfflineStatus.Complete, progress = 1f, errorReason = null) else it
+        }
+    }
 }

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
@@ -1,23 +1,24 @@
 package com.sigmundgranaas.turbo.expressive.core.map
 
-import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
-import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.abs
 
 /**
  * Offline stand-in for [OfflineTileManager]: the real one pulls tiles from the
  * Kartverket / tileserver WMTS via MapLibre's OfflineManager, which can't be
  * reached from the emulator — so the Offline Maps screen otherwise stays empty
  * and "download this area" does nothing. This keeps an in-memory region list so
- * the list, download-this-area, size estimate and delete can all be driven.
- * Selected in DEBUG via [OfflineModule]. (No MapLibre here — safe in :core:map.)
+ * the list, download-this-area, size estimate, retry and delete can all be driven,
+ * including the [OfflineStatus.Failed] path (a too-large area "fails", and retry
+ * then "succeeds"). Selected in DEBUG via [OfflineModule]. (No MapLibre here.)
  */
 @Singleton
 class SyntheticOfflineTileManager @Inject constructor() : OfflineTileManager {
@@ -27,11 +28,38 @@ class SyntheticOfflineTileManager @Inject constructor() : OfflineTileManager {
 
     override fun refresh() = Unit // state is already in memory
 
-    override fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double) {
-        // Estimate a plausible size from the area + zoom span so the list reads real.
-        val degArea = abs(bounds.north - bounds.south) * abs(bounds.east - bounds.west)
-        val sizeBytes = (degArea * (maxZoom - minZoom + 1) * 9_000_000L).toLong().coerceIn(2_000_000L, 80_000_000L)
-        _regions.update { it + OfflineRegionInfo(id = nextId++, name = name, complete = true, progress = 1f, sizeBytes = sizeBytes) }
+    override fun estimate(spec: DownloadSpec): OfflineEstimate = TileMath.estimate(spec)
+
+    override fun download(spec: DownloadSpec) {
+        val est = estimate(spec)
+        val within = TileMath.isWithinLimits(spec)
+        _regions.update {
+            it + OfflineRegionInfo(
+                id = nextId++,
+                name = spec.name,
+                status = if (within) OfflineStatus.Complete else OfflineStatus.Failed,
+                progress = if (within) 1f else 0f,
+                sizeBytes = if (within) est.bytes else 0L,
+                tileCount = if (within) est.tiles else 0L,
+                base = spec.base,
+                overlays = spec.overlays,
+                bounds = spec.bounds,
+                minZoom = spec.minZoom,
+                maxZoom = spec.maxZoom,
+                createdAtEpochMs = System.currentTimeMillis(),
+                errorReason = if (within) null else "Area too large",
+            )
+        }
+    }
+
+    override fun retry(id: Long) = _regions.update { list ->
+        list.map {
+            if (it.id == id && it.status == OfflineStatus.Failed) {
+                it.copy(status = OfflineStatus.Complete, progress = 1f, errorReason = null)
+            } else {
+                it
+            }
+        }
     }
 
     override fun delete(id: Long) = _regions.update { list -> list.filterNot { it.id == id } }

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManager.kt
@@ -63,7 +63,13 @@ class SyntheticOfflineTileManager @Inject constructor() : OfflineTileManager {
     // The synthetic manager has no real network, so connectivity gating is a no-op.
     override fun setNetworkAllowed(allowed: Boolean) = Unit
 
+    override fun rename(id: Long, name: String) = _regions.update { list ->
+        list.map { if (it.id == id) it.copy(name = name) else it }
+    }
+
     override fun delete(id: Long) = _regions.update { list -> list.filterNot { it.id == id } }
+
+    override fun clearAmbientCache() = Unit // no ambient cache in the simulator
 
     private fun complete(id: Long) = _regions.update { list ->
         list.map {

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
@@ -1,0 +1,79 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.asinh
+import kotlin.math.floor
+import kotlin.math.tan
+
+/**
+ * Pure slippy-map (Web Mercator XYZ) math for estimating how big an offline
+ * download will be, plus a guard against absurdly large areas. No MapLibre — kept
+ * here so it is unit-testable and reusable by the pre-flight estimate UI.
+ */
+object TileMath {
+
+    /** Average bytes for a 256px raster tile — empirical, tunable. */
+    private const val AVG_RASTER_TILE_BYTES = 20_000L
+
+    /** Hard ceiling mirroring MapLibre's tile-count limit; downloads above this fail. */
+    const val MAX_TILES = 100_000L
+
+    /** Reject single-shot downloads whose bounding box spans more than this (degrees). */
+    const val MAX_SPAN_DEGREES = 6.0
+
+    private fun lonToTileX(lon: Double, z: Int): Int {
+        val n = 1 shl z
+        return floor((lon + 180.0) / 360.0 * n).toInt().coerceIn(0, n - 1)
+    }
+
+    private fun latToTileY(lat: Double, z: Int): Int {
+        val n = 1 shl z
+        val clamped = lat.coerceIn(-85.05112878, 85.05112878)
+        val rad = Math.toRadians(clamped)
+        // y = (1 - asinh(tan φ)/π) / 2 · n  — asinh(tan φ) == ln(tan φ + sec φ).
+        val y = (1.0 - asinh(tan(rad)) / PI) / 2.0 * n
+        return floor(y).toInt().coerceIn(0, n - 1)
+    }
+
+    /** Tiles for one source over [bounds] across integer zooms `floor(min)..floor(max)`. */
+    fun tileCount(bounds: GeoBounds, minZoom: Double, maxZoom: Double): Long {
+        val lo = floor(minZoom).toInt().coerceAtLeast(0)
+        val hi = floor(maxZoom).toInt().coerceAtLeast(lo)
+        var total = 0L
+        for (z in lo..hi) {
+            val x0 = lonToTileX(bounds.west, z)
+            val x1 = lonToTileX(bounds.east, z)
+            // Mercator Y grows southward, so north maps to the smaller index.
+            val y0 = latToTileY(bounds.north, z)
+            val y1 = latToTileY(bounds.south, z)
+            val nx = (x1 - x0).toLong() + 1
+            val ny = (y1 - y0).toLong() + 1
+            total += nx * ny
+        }
+        return total
+    }
+
+    /**
+     * Estimate for a [spec]: the base map plus each overlay is its own tile pyramid,
+     * so the tile count is multiplied by the number of sources.
+     */
+    fun estimate(spec: DownloadSpec): OfflineEstimate {
+        val sources = 1 + spec.overlays.size
+        val tiles = tileCount(spec.bounds, spec.minZoom, spec.maxZoom) * sources
+        return OfflineEstimate(tiles = tiles, bytes = tiles * AVG_RASTER_TILE_BYTES)
+    }
+
+    /** Cheap guard: too many tiles, or a box that's simply too wide to be sensible. */
+    fun isWithinLimits(spec: DownloadSpec): Boolean {
+        val span = maxOf(
+            abs(spec.bounds.north - spec.bounds.south),
+            abs(spec.bounds.east - spec.bounds.west),
+        )
+        if (span > MAX_SPAN_DEGREES) return false
+        return estimate(spec).tiles <= MAX_TILES
+    }
+}

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
@@ -64,16 +64,17 @@ object TileMath {
     fun estimate(spec: DownloadSpec): OfflineEstimate {
         val sources = 1 + spec.overlays.size
         val tiles = tileCount(spec.bounds, spec.minZoom, spec.maxZoom) * sources
-        return OfflineEstimate(tiles = tiles, bytes = tiles * AVG_RASTER_TILE_BYTES, withinLimits = isWithinLimits(spec))
-    }
-
-    /** Cheap guard: too many tiles, or a box that's simply too wide to be sensible. */
-    fun isWithinLimits(spec: DownloadSpec): Boolean {
         val span = maxOf(
             abs(spec.bounds.north - spec.bounds.south),
             abs(spec.bounds.east - spec.bounds.west),
         )
-        if (span > MAX_SPAN_DEGREES) return false
-        return estimate(spec).tiles <= MAX_TILES
+        return OfflineEstimate(
+            tiles = tiles,
+            bytes = tiles * AVG_RASTER_TILE_BYTES,
+            withinLimits = span <= MAX_SPAN_DEGREES && tiles <= MAX_TILES,
+        )
     }
+
+    /** Cheap guard: too many tiles, or a box that's simply too wide to be sensible. */
+    fun isWithinLimits(spec: DownloadSpec): Boolean = estimate(spec).withinLimits
 }

--- a/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
+++ b/apps/android/core/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMath.kt
@@ -64,7 +64,7 @@ object TileMath {
     fun estimate(spec: DownloadSpec): OfflineEstimate {
         val sources = 1 + spec.overlays.size
         val tiles = tileCount(spec.bounds, spec.minZoom, spec.maxZoom) * sources
-        return OfflineEstimate(tiles = tiles, bytes = tiles * AVG_RASTER_TILE_BYTES)
+        return OfflineEstimate(tiles = tiles, bytes = tiles * AVG_RASTER_TILE_BYTES, withinLimits = isWithinLimits(spec))
     }
 
     /** Cheap guard: too many tiles, or a box that's simply too wide to be sensible. */

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/DownloadPolicyTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/DownloadPolicyTest.kt
@@ -1,0 +1,29 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadPolicyTest {
+
+    private val wifi = NetworkState(connected = true, unmetered = true)
+    private val cellular = NetworkState(connected = true, unmetered = false)
+
+    @Test
+    fun `wifi-only off allows any connected network`() {
+        assertTrue(DownloadPolicy.shouldDownload(wifiOnly = false, net = wifi))
+        assertTrue(DownloadPolicy.shouldDownload(wifiOnly = false, net = cellular))
+    }
+
+    @Test
+    fun `wifi-only on allows un-metered but blocks metered`() {
+        assertTrue(DownloadPolicy.shouldDownload(wifiOnly = true, net = wifi))
+        assertFalse(DownloadPolicy.shouldDownload(wifiOnly = true, net = cellular))
+    }
+
+    @Test
+    fun `no connectivity always blocks`() {
+        assertFalse(DownloadPolicy.shouldDownload(wifiOnly = false, net = NetworkState.Disconnected))
+        assertFalse(DownloadPolicy.shouldDownload(wifiOnly = true, net = NetworkState.Disconnected))
+    }
+}

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/LocalStyleServerTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/LocalStyleServerTest.kt
@@ -1,0 +1,30 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.URL
+
+class LocalStyleServerTest {
+
+    @Test
+    fun `serves the base map plus the requested overlays`() {
+        val server = LocalStyleServer()
+        val url = server.styleUrl(BaseLayer.Norgeskart, setOf(OverlayId.Avalanche))
+        assertTrue("overlay encoded in url", url.contains("ov=Avalanche"))
+
+        val body = URL(url).readText()
+        assertTrue("base source present", body.contains("\"norgeskart\""))
+        assertTrue("avalanche overlay source present", body.contains("\"ov_Avalanche\""))
+    }
+
+    @Test
+    fun `serves the base map only when no overlays are requested`() {
+        val server = LocalStyleServer()
+        val body = URL(server.styleUrl(BaseLayer.Osm)).readText()
+        assertTrue("base source present", body.contains("\"osm\""))
+        assertFalse("no overlay sources", body.contains("\"ov_"))
+    }
+}

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineCoverageTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineCoverageTest.kt
@@ -1,0 +1,34 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.LatLng
+import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OfflineCoverageTest {
+
+    private fun region(status: OfflineStatus, bounds: GeoBounds?) = OfflineRegionInfo(
+        id = 1, name = "r", status = status, progress = 1f, sizeBytes = 1, bounds = bounds,
+    )
+
+    private val tromso = GeoBounds(south = 69.6, west = 18.9, north = 69.7, east = 19.1)
+
+    @Test
+    fun `a point inside a complete region is covered`() {
+        assertTrue(OfflineCoverage.covers(listOf(region(OfflineStatus.Complete, tromso)), LatLng(69.65, 19.0)))
+    }
+
+    @Test
+    fun `a point outside every region is not covered`() {
+        assertFalse(OfflineCoverage.covers(listOf(region(OfflineStatus.Complete, tromso)), LatLng(60.0, 10.0)))
+    }
+
+    @Test
+    fun `incomplete or legacy regions never cover`() {
+        assertFalse(OfflineCoverage.covers(listOf(region(OfflineStatus.Downloading, tromso)), LatLng(69.65, 19.0)))
+        assertFalse(OfflineCoverage.covers(listOf(region(OfflineStatus.Complete, null)), LatLng(69.65, 19.0)))
+    }
+}

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineRegionMetadataTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/OfflineRegionMetadataTest.kt
@@ -1,0 +1,39 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OfflineRegionMetadataTest {
+
+    @Test
+    fun `round-trips every field including a unicode name with a delimiter`() {
+        val meta = OfflineRegionMetadata.Meta(
+            name = "Tromsø, Nord-Norge",
+            base = BaseLayer.Satellite,
+            overlays = setOf(OverlayId.Avalanche, OverlayId.Trails),
+            bounds = GeoBounds(south = 69.6, west = 18.9, north = 69.7, east = 19.1),
+            minZoom = 8.0,
+            maxZoom = 14.0,
+            createdAtEpochMs = 1_700_000_000_000L,
+        )
+        assertEquals(meta, OfflineRegionMetadata.decode(OfflineRegionMetadata.encode(meta)))
+    }
+
+    @Test
+    fun `a legacy bare-name blob decodes to a name with defaults`() {
+        val decoded = OfflineRegionMetadata.decode("Lofoten".toByteArray())
+        assertEquals("Lofoten", decoded?.name)
+        assertEquals(BaseLayer.Norgeskart, decoded?.base)
+        assertNull(decoded?.bounds)
+    }
+
+    @Test
+    fun `null or empty input decodes to null`() {
+        assertNull(OfflineRegionMetadata.decode(null))
+        assertNull(OfflineRegionMetadata.decode(ByteArray(0)))
+    }
+}

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManagerTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManagerTest.kt
@@ -1,31 +1,54 @@
 package com.sigmundgranaas.turbo.expressive.core.map
 
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SyntheticOfflineTileManagerTest {
 
     private val bounds = GeoBounds(south = 69.6, west = 18.9, north = 69.7, east = 19.1)
+    private fun spec(name: String, b: GeoBounds = bounds, min: Double = 8.0, max: Double = 15.0) =
+        DownloadSpec(name = name, base = BaseLayer.Norgeskart, bounds = b, minZoom = min, maxZoom = max)
 
     @Test
-    fun `download adds a complete region with a plausible size`() {
+    fun `download adds a complete region carrying its metadata`() {
         val m = SyntheticOfflineTileManager()
-        m.download("Tromsø area", BaseLayer.Norgeskart, bounds, minZoom = 8.0, maxZoom = 15.0)
+        m.download(spec("Tromsø area"))
         val r = m.regions.value.single()
         assertEquals("Tromsø area", r.name)
-        assertTrue(r.complete)
+        assertEquals(OfflineStatus.Complete, r.status)
         assertEquals(1f, r.progress)
-        assertTrue("size should be non-trivial", r.sizeBytes >= 2_000_000L)
+        assertTrue("size should be non-trivial", r.sizeBytes > 0)
+        assertTrue("tiles should be counted", r.tileCount > 0)
+        assertEquals(BaseLayer.Norgeskart, r.base)
+        assertEquals(bounds, r.bounds)
+    }
+
+    @Test
+    fun `an over-limit area fails and retry completes it`() {
+        val m = SyntheticOfflineTileManager()
+        val huge = GeoBounds(south = 60.0, west = 5.0, north = 72.0, east = 25.0)
+        m.download(spec("Whole country", b = huge))
+        val failed = m.regions.value.single()
+        assertEquals(OfflineStatus.Failed, failed.status)
+        assertTrue(failed.errorReason != null)
+
+        m.retry(failed.id)
+        val retried = m.regions.value.single()
+        assertEquals(OfflineStatus.Complete, retried.status)
+        assertNull(retried.errorReason)
     }
 
     @Test
     fun `delete removes the region by id`() {
         val m = SyntheticOfflineTileManager()
-        m.download("A", BaseLayer.Norgeskart, bounds, 8.0, 14.0)
-        m.download("B", BaseLayer.Norgeskart, bounds, 8.0, 14.0)
+        m.download(spec("A"))
+        m.download(spec("B"))
         val first = m.regions.value.first().id
         m.delete(first)
         assertEquals(listOf("B"), m.regions.value.map { it.name })

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManagerTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/SyntheticOfflineTileManagerTest.kt
@@ -45,6 +45,14 @@ class SyntheticOfflineTileManagerTest {
     }
 
     @Test
+    fun `rename rewrites the display name in place`() {
+        val m = SyntheticOfflineTileManager()
+        m.download(spec("Old name"))
+        m.rename(m.regions.value.single().id, "New name")
+        assertEquals("New name", m.regions.value.single().name)
+    }
+
+    @Test
     fun `delete removes the region by id`() {
         val m = SyntheticOfflineTileManager()
         m.download(spec("A"))

--- a/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMathTest.kt
+++ b/apps/android/core/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/map/TileMathTest.kt
@@ -1,0 +1,42 @@
+package com.sigmundgranaas.turbo.expressive.core.map
+
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TileMathTest {
+
+    private val small = GeoBounds(south = 60.0, west = 10.0, north = 60.1, east = 10.1)
+
+    @Test
+    fun `a point box is a single tile at zoom 0`() {
+        val point = GeoBounds(south = 60.0, west = 10.0, north = 60.0, east = 10.0)
+        assertEquals(1L, TileMath.tileCount(point, 0.0, 0.0))
+    }
+
+    @Test
+    fun `tile count grows with the zoom span`() {
+        val narrow = TileMath.tileCount(small, 8.0, 10.0)
+        val wide = TileMath.tileCount(small, 8.0, 12.0)
+        assertTrue("more zoom levels means more tiles", wide > narrow)
+    }
+
+    @Test
+    fun `estimate scales with the number of sources`() {
+        val base = DownloadSpec("x", BaseLayer.Norgeskart, small, 8.0, 12.0)
+        val withTwoOverlays = base.copy(overlays = setOf(OverlayId.Trails, OverlayId.Avalanche))
+        assertEquals(TileMath.estimate(base).tiles * 3, TileMath.estimate(withTwoOverlays).tiles)
+    }
+
+    @Test
+    fun `within-limits accepts a small area and rejects a huge span`() {
+        assertTrue(TileMath.isWithinLimits(DownloadSpec("ok", BaseLayer.Norgeskart, small, 8.0, 14.0)))
+        val huge = GeoBounds(south = 0.0, west = 0.0, north = 50.0, east = 50.0)
+        assertFalse(TileMath.isWithinLimits(DownloadSpec("no", BaseLayer.Norgeskart, huge, 8.0, 14.0)))
+    }
+}

--- a/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
+++ b/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
@@ -64,6 +64,15 @@ data class DownloadSpec(
     val overlays: Set<OverlayId> = emptySet(),
 )
 
+/**
+ * The detail-vs-size trade-off for an offline download: how many zoom levels
+ * past the current camera to cache. Standard matches the historical default.
+ */
+enum class DetailLevel(val zoomSpan: Double) {
+    Standard(4.0),
+    Detailed(6.0),
+}
+
 /** A pre-download estimate of how big a [DownloadSpec] will be. */
 data class OfflineEstimate(
     val tiles: Long,

--- a/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
+++ b/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
@@ -8,12 +8,64 @@ data class GeoBounds(
     val east: Double,
 )
 
-/** A downloaded (or downloading) offline map region. */
+/** Lifecycle of an offline region as the user sees it. */
+enum class OfflineStatus {
+    /** Tiles are actively downloading (or queued). */
+    Downloading,
+
+    /** All required tiles are present. */
+    Complete,
+
+    /** Download halted on purpose (e.g. waiting for Wi-Fi) — resumable. */
+    Paused,
+
+    /** Download stopped on an error (network, server, tile-limit) — retryable. */
+    Failed,
+}
+
+/**
+ * A downloaded (or downloading) offline map region. Carries enough metadata to
+ * render the region meaningfully — which base map and overlays it covers, where
+ * it is, and when it was made — not just a name + size.
+ */
 data class OfflineRegionInfo(
     val id: Long,
     val name: String,
-    val complete: Boolean,
+    val status: OfflineStatus,
     /** Download progress 0..1 (1 when complete). */
     val progress: Float,
     val sizeBytes: Long,
+    val tileCount: Long = 0L,
+    val base: BaseLayer = BaseLayer.Norgeskart,
+    val overlays: Set<OverlayId> = emptySet(),
+    /** The downloaded extent, when known (null for legacy regions). */
+    val bounds: GeoBounds? = null,
+    val minZoom: Double = 0.0,
+    val maxZoom: Double = 0.0,
+    val createdAtEpochMs: Long = 0L,
+    /** Human-readable reason when [status] is [OfflineStatus.Failed]. */
+    val errorReason: String? = null,
+) {
+    /** Back-compat convenience for call sites that only care about completion. */
+    val complete: Boolean get() = status == OfflineStatus.Complete
+}
+
+/**
+ * Everything needed to start an offline download: the named area, which base map
+ * + overlays to cache, and the zoom span. Replaces the old positional
+ * `download(name, base, bounds, min, max)` so overlays + naming travel together.
+ */
+data class DownloadSpec(
+    val name: String,
+    val base: BaseLayer,
+    val bounds: GeoBounds,
+    val minZoom: Double,
+    val maxZoom: Double,
+    val overlays: Set<OverlayId> = emptySet(),
+)
+
+/** A pre-download estimate of how big a [DownloadSpec] will be. */
+data class OfflineEstimate(
+    val tiles: Long,
+    val bytes: Long,
 )

--- a/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
+++ b/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/Offline.kt
@@ -68,4 +68,6 @@ data class DownloadSpec(
 data class OfflineEstimate(
     val tiles: Long,
     val bytes: Long,
+    /** False when the area is too large to download (tile limit / span guard). */
+    val withinLimits: Boolean = true,
 )

--- a/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/UserSettings.kt
+++ b/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/UserSettings.kt
@@ -11,4 +11,6 @@ data class UserSettings(
     val themeMode: ThemeMode = ThemeMode.System,
     /** When off, the cloud sync engine is paused even while signed in. */
     val cloudSyncEnabled: Boolean = true,
+    /** When on, offline map downloads only run on un-metered (Wi-Fi) networks. */
+    val downloadOverWifiOnly: Boolean = false,
 )

--- a/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/UserSettings.kt
+++ b/apps/android/core/model/src/main/kotlin/com/sigmundgranaas/turbo/expressive/domain/UserSettings.kt
@@ -13,4 +13,6 @@ data class UserSettings(
     val cloudSyncEnabled: Boolean = true,
     /** When on, offline map downloads only run on un-metered (Wi-Fi) networks. */
     val downloadOverWifiOnly: Boolean = false,
+    /** The last-selected base map, restored on launch. */
+    val baseLayer: BaseLayer = BaseLayer.Norgeskart,
 )

--- a/apps/android/docs/offline-caching-analysis.md
+++ b/apps/android/docs/offline-caching-analysis.md
@@ -1,0 +1,193 @@
+# Offline caching & tile management — analysis and improvement plan
+
+_Android native app (`apps/android`). Written 2026-06-09._
+
+This report analyses how the native Android app caches map tiles and manages
+offline regions today, identifies the gaps, and proposes a prioritised plan to
+improve it.
+
+## 1. How it works today
+
+### 1.1 Tile rendering (online)
+
+- The app renders with **MapLibre Android SDK 13.2.0**
+  (`gradle/libs.versions.toml:23`). All MapLibre access is confined to
+  `:core:map` by design.
+- Map styles are **raster** and generated on-device by
+  `MapStyles.styleJson(...)`
+  (`core/map/.../ui/map/MapStyles.kt`). Three base layers are wired:
+  - **Norgeskart** — Kartverket topo WMTS
+    (`https://cache.kartverket.no/v1/wmts/.../{z}/{y}/{x}.png`)
+  - **OSM** — `https://tile.openstreetmap.org/{z}/{x}/{y}.png`
+  - **Satellite** — Esri `World_Imagery` ArcGIS tile cache
+- Transparent data overlays are composited on top: **Trails** (Waymarked
+  Trails) and **Avalanche** (NVE Bratthetskart). **Waves/Wind** are declared
+  but unwired (`overlayTiles(...)` returns `null`), so they are dead toggles.
+- `TurboMap` (`core/map/.../ui/map/TurboMap.kt`) builds the style from JSON and
+  loads it into a `MapView`. Tiles are fetched **straight from their remote
+  source at runtime**.
+- **Runtime cache:** the only thing caching browsed tiles is MapLibre's
+  built-in *ambient cache* (a SQLite/`mbtiles`-style DB, default ceiling ~50 MB,
+  LRU-evicted). It is **never configured** anywhere — no
+  `setMaximumAmbientCacheSize`, no prefetch/concurrency tuning, no "clear
+  cache". Online panning therefore warms only a small, silently-capped cache
+  that is shared with the explicit offline regions in the same DB.
+
+### 1.2 Offline regions (explicit download)
+
+- Seam: `OfflineTileManager`
+  (`core/map/.../core/map/OfflineTileManager.kt`). The real implementation,
+  `MapLibreOfflineTileManager`, wraps MapLibre's `OfflineManager` +
+  `OfflineTilePyramidRegionDefinition`.
+- `LocalStyleServer` (`core/map/.../core/map/LocalStyleServer.kt`) is a small
+  loopback HTTP server that hands the on-device style JSON to MapLibre's
+  downloader (which only accepts `http(s)` for the style document). Clean
+  workaround. **Note: it serves the *base-only* style** — overlays are not
+  passed to `styleUrl(base)`.
+- Tile-count limit: `setOfflineMapboxTileCountLimit(100_000)`.
+- Downloads are triggered in two places, both via `OfflineViewModel.download`:
+  1. **"Download this area"** from the layers sheet
+     (`feature/map/.../MapScreenModals.kt:96`) → current visible bounds, zoom
+     `floor(zoom)..floor(zoom)+4`, clamped to `8..16`
+     (`feature/map/.../offline/OfflineViewModel.kt:42`).
+  2. **Download along a route** (`RouteViewModel.downloadAlongRoute`,
+     `feature/map/.../RouteViewModel.kt:243`) → a 1.5 km-padded corridor
+     (`RouteCorridor.bounds`), fixed zoom `8..15`.
+- Region naming is reverse-geocoded (place name, else coordinates).
+- In **DEBUG** builds the manager is swapped for an in-memory
+  `SyntheticOfflineTileManager` so the screen is driveable on an emulator
+  (`OfflineModule`, `OfflineTileManager.kt:132`).
+
+### 1.3 Offline UI
+
+- `OfflineMapsScreen` (`feature/map/.../offline/OfflineMapsScreen.kt`): a list
+  of regions with total size, per-region progress (wavy indicator), and
+  delete-with-confirm. There is **no** add/download entry point from this
+  screen (downloads start elsewhere), no rename, no map preview of a region's
+  extent, and no pause/resume/retry.
+- Domain model `OfflineRegionInfo` (`core/model/.../domain/Offline.kt`) carries
+  only `id, name, complete, progress, sizeBytes`.
+
+## 2. Problems & gaps
+
+Ordered roughly by severity.
+
+### P0 — correctness / robustness
+
+1. **Failures are swallowed silently.** Every `onError` in
+   `MapLibreOfflineTileManager` is `= Unit` — create, status, delete, and the
+   observer's `mapboxTileCountLimitExceeded` are all ignored
+   (`OfflineTileManager.kt:95,104,110,111`). `OfflineRegionInfo` has **no
+   error/failed state**, so a download that fails (no network, server 5xx,
+   tile-limit exceeded) simply sticks at a percentage forever with no message
+   and no retry. This is the single biggest functional gap.
+2. **Downloads don't survive backgrounding.** Downloading runs only while the
+   process is alive and the region is `STATE_ACTIVE`. There is no foreground
+   service or `WorkManager` job, so backgrounding the app or an OS kill stalls
+   a multi-MB download with no resume. There is also no way to **pause or
+   cancel** an in-flight download — `delete` is the only escape.
+3. **No connectivity / metered-network awareness.** Downloads fire on any
+   network, including metered cellular. There is no "download over Wi-Fi only"
+   option and no auto-pause when connectivity drops.
+4. **No size guardrail before committing.** The user is never shown an estimate
+   ("~N tiles / ~120 MB") before a download starts. `RouteCorridor.spanDegrees`
+   exists as an "absurd area" guard but is **unused**. A province-sized box at
+   z16 can silently exceed the 100k tile limit — which then fails silently per
+   (1).
+
+### P1 — features / UX
+
+5. **Safety-critical overlays are never available offline.** The download
+   definition uses `styleUrl(base)` and `LocalStyleServer` serves a base-only
+   style, so **avalanche (NVE Bratthet) and trail overlays are not downloaded**.
+   For a Norwegian backcountry app this is the layer most needed offline.
+6. **Base layer is not persisted and not tracked per region.** `baseLayer`
+   lives only in in-memory `MapUiState` (`MapViewModel.kt:31,101`) and resets to
+   Norgeskart every launch, despite a DataStore `SettingsRepository` already
+   existing. A region is downloaded for **one** base layer; switch to Satellite
+   offline and you see nothing, with no indication of which base a region
+   covers.
+7. **Thin region metadata.** No bounds, base layer, zoom range, created date, or
+   tile count on `OfflineRegionInfo`. Consequences: can't show a region on a
+   map, can't sort by date, can't dedupe/merge overlapping regions, can't
+   "update" a stale one, and reverse-geocoded names collide.
+8. **Coarse, fixed zoom policy with no user control.** `8..16` (area) and
+   `8..15` (route) are hard-coded. No detail-vs-size trade-off control; z16 may
+   be too shallow for detailed Kartverket topo, while a long route corridor at
+   z8..15 can be huge.
+9. **No update / staleness handling.** Tiles are fetched once and never
+   refreshed; Kartverket topo updates over time with no TTL or "update region".
+
+### P2 — polish / longer-term
+
+10. **Unmanaged ambient cache & misleading disk reporting.** The runtime cache
+    is left at MapLibre defaults; for a mapping app it should be sized up so
+    recently-browsed areas survive going offline. The Offline screen's "total
+    size" counts only explicit regions, **understating** true disk use, and
+    there is no "clear cache" control.
+11. **Thread-safety / refresh design.** `regionsById` is a plain `mutableMapOf`
+    mutated from MapLibre callback threads. `refresh()` re-lists everything with
+    a manual countdown and replaces the sorted list, which can interleave with
+    the observer's `upsert` during active downloads and momentarily flicker/drop
+    in-progress regions.
+12. **Tile-licensing risk for offline caching.** Bulk-downloading from
+    `tile.openstreetmap.org` violates the OSM tile usage policy, and Esri's
+    public `World_Imagery` endpoint has terms that restrict bulk/offline
+    caching. Caching these into offline regions is a compliance risk worth a
+    review.
+
+## 3. Recommendations
+
+### P0 — make downloads trustworthy
+
+- **Add a failure state and surface it.** Extend `OfflineRegionInfo` with a
+  status (`Downloading | Complete | Failed(reason) | Paused`) and wire every
+  `onError` + `mapboxTileCountLimitExceeded` to it. Show an error row with a
+  **Retry** action.
+- **Run downloads in a foreground service or `WorkManager`** with a network
+  constraint, a persistent notification, and **pause/resume/cancel**, so they
+  survive backgrounding and process death.
+- **Add a "Download over Wi-Fi only" setting** (persisted) and auto-pause on
+  metered/no connectivity.
+- **Pre-flight size estimate + guardrail.** Estimate tile count/bytes from
+  bounds × zoom span, show it in the confirm dialog, and reject areas above a
+  threshold using the existing `RouteCorridor.spanDegrees`.
+
+### P1 — make offline actually usable in the field
+
+- **Include active overlays (esp. avalanche) in the download**, or at minimum
+  record which layers a region covers and warn when they're missing offline.
+- **Persist base layer + overlay selection** via the existing DataStore, and
+  **store the base layer in region metadata**; warn when the current base
+  differs from any downloaded region.
+- **Enrich `OfflineRegionInfo`** (bounds, base, zoom range, date, tile count),
+  render a region's extent on a mini-map, and allow **rename**.
+- **Let the user pick a detail level** (e.g. Standard / Detailed) that maps to a
+  zoom span, with the live size estimate from the guardrail above.
+
+### P2 — strategic / housekeeping
+
+- **Tune the ambient cache** (`setMaximumAmbientCacheSize`), expose **Clear
+  cache**, and report *true* disk usage (ambient + regions).
+- **Region update/refresh** for stale tiles and **merge/dedupe** of overlapping
+  regions.
+- **Harden concurrency**: guard `regionsById`, and replace the `refresh()`
+  countdown with structured coroutines.
+- **Move toward the planned custom tile server** (`apps/tileserver`, reserved in
+  the monorepo) and **vector tiles + MBTiles** packaging. Vector tiles are far
+  smaller offline, restylable on-device (dark mode, overlays without separate
+  downloads), and route around the third-party tile-licensing risk — the
+  highest-leverage long-term fix for both size and legal exposure.
+
+## 4. Suggested sequencing
+
+1. P0 error-state + retry + foreground/WorkManager downloads (correctness).
+2. P0 Wi-Fi-only + pre-flight size estimate (cost control).
+3. P1 overlay inclusion + base-layer persistence/metadata (field usefulness).
+4. P1 richer region model + UI (rename, extent preview, detail level).
+5. P2 ambient-cache tuning, updates/dedupe, and the tileserver/vector-tiles
+   migration.
+
+The first two items remove the "stuck at 47% with no explanation" and
+"downloaded 400 MB on cellular" failure modes and are small, well-bounded
+changes behind the existing `OfflineTileManager` seam.

--- a/apps/android/docs/offline-caching-analysis.md
+++ b/apps/android/docs/offline-caching-analysis.md
@@ -136,6 +136,42 @@ Ordered roughly by severity.
     caching. Caching these into offline regions is a compliance risk worth a
     review.
 
+### Folded in from the feature/UX review
+
+13. **No offline / blank-tile affordance on the map (P1).** When the device is
+    offline, or the camera pans **outside** a downloaded region, tiles simply
+    fail to load and the user sees the bare background colour
+    (`TurboMap.kt`/`MapStyles` `bg`) with no loading state and no explanation.
+    For a backcountry app this is exactly the moment the user most needs to
+    understand *why the map is blank* ("You're offline — showing downloaded
+    areas"). There is no connectivity indicator and no "outside offline
+    coverage" hint anywhere in the map UI.
+14. **`overlayRow` mislabels Waves/Wind (P2, latent).** In
+    `feature/map/.../layers/MapLayersSheet.kt`, `overlayRow(Waves|Wind)` returns
+    the **Trails** title/subtitle strings (`R.string.layers_trails*`). Harmless
+    today because Waves/Wind are filtered out of `MapStyles.renderableOverlays`,
+    but it is a wrong-label bug that surfaces the moment either overlay is
+    wired — it should be exhaustive with correct strings (or those entries
+    removed until wired).
+
+### UX-level gaps on the Offline screen (P1, refine #7)
+
+These sharpen finding #7 with the concrete experience problems found in review
+of `OfflineMapsScreen.kt`:
+
+- **Region cards are not tappable** — no open-on-map, no detail view; the only
+  per-region action is destructive **delete**.
+- **No add/download entry point from the screen** — the empty state instructs
+  the user to leave and use the layers sheet; a "Download current area" entry
+  (e.g. a FAB or pick-on-map) belongs here.
+- **Cards carry no distinguishing info** (base layer, extent, date), so two
+  reverse-geocoded "Tromsø" regions are indistinguishable.
+- **No rename at creation** — names are auto reverse-geocoded (coordinates on
+  failure) with no chance to edit.
+- **Delete is immediate after confirm** — no undo snackbar.
+- **Stopping a download means deleting it** — there is no non-destructive
+  pause/cancel for an in-flight region (ties to #2).
+
 ## 3. Recommendations
 
 ### P0 — make downloads trustworthy
@@ -161,11 +197,18 @@ Ordered roughly by severity.
   **store the base layer in region metadata**; warn when the current base
   differs from any downloaded region.
 - **Enrich `OfflineRegionInfo`** (bounds, base, zoom range, date, tile count),
-  render a region's extent on a mini-map, and allow **rename**.
+  render a region's extent on a mini-map, make **cards tappable** (open on map /
+  detail), add a **"Download current area"** entry on the screen, support
+  **rename** (at creation and after), and add an **undo** snackbar on delete.
 - **Let the user pick a detail level** (e.g. Standard / Detailed) that maps to a
   zoom span, with the live size estimate from the guardrail above.
+- **Add an offline / out-of-coverage affordance on the map** — a connectivity
+  indicator and a hint when panning outside downloaded regions (#13).
 
 ### P2 — strategic / housekeeping
+
+- **Fix the `overlayRow` Waves/Wind mislabel** (#14) — correct strings or drop
+  the entries until those overlays are wired.
 
 - **Tune the ambient cache** (`setMaximumAmbientCacheSize`), expose **Clear
   cache**, and report *true* disk usage (ambient + regions).

--- a/apps/android/docs/offline-caching-implementation-plan.md
+++ b/apps/android/docs/offline-caching-implementation-plan.md
@@ -235,11 +235,48 @@ These are prerequisites for almost everything else, so they land first.
 - **Files:**
   - ✎ `feature/map/.../offline/OfflineMapsScreen.kt`
   - ✎ `OfflineTileManager` (`rename`, `updateRegion`)
-- **Approach:** card shows created date + tile count; a small static map
-  thumbnail of `bounds`; **Rename** (edit metadata via 0.2); **Update** (re-run
-  the same `DownloadSpec` to refresh tiles). Sort options (name/date/size).
-- 🧪 ✎ `OfflineMapsScreenTest` — rename/update actions invoke the manager;
-  metadata renders.
+- **Approach:** card shows base layer + created date + tile count and a small
+  static map thumbnail of `bounds`; **tap a card to open the region on the map**
+  (frame to its bounds) and/or open a detail view; add a **"Download current
+  area"** entry on the screen itself (FAB or pick-on-map) so the empty state no
+  longer has to send the user elsewhere; **Rename** at creation *and* after
+  (edit metadata via 0.2); **Update** (re-run the same `DownloadSpec`); **undo**
+  snackbar on delete. Sort options (name/date/size). Resolves the offline-screen
+  UX gaps from the feature review (refines #7).
+- 🧪 ✎ `OfflineMapsScreenTest` — tap-to-open, rename/update, undo-delete, and the
+  on-screen download entry invoke the right callbacks; metadata renders.
+
+### 2.5 Offline / out-of-coverage affordance on the map
+
+- **Goal:** tell the user when the map is blank because they're offline or
+  outside a downloaded region. Fixes finding **#13**.
+- **Files:**
+  - ✚ connectivity observer reuse from 1.3 (`DownloadPolicy` / network state)
+  - ✎ `feature/map/.../MapScreen.kt` (status chip / banner)
+  - ✎ `core/map/.../ui/map/TurboMap.kt` (expose "is camera inside any offline
+    region" via the region bounds from 0.1)
+  - ✎ string resources (`values*/strings.xml`)
+- **Approach:** subscribe to connectivity (from 1.3) and to the offline region
+  list (bounds now available per 0.1). When **offline** show a small "You're
+  offline" chip; when offline **and** the camera centre is outside every region
+  bounds, show "Outside downloaded area — pan to a saved region or download
+  this one." Keep it a lightweight, dismissible chip — never a blocking dialog.
+- 🧪 ✚ pure `OfflineCoverage.contains(regions, center): Boolean` test; ✎
+  `MapScreen`/`TurboMap` test asserting the chip shows when offline + outside.
+
+### 2.6 Quick fix — `overlayRow` Waves/Wind mislabel
+
+- **Goal:** stop `overlayRow` returning Trails strings for Waves/Wind. Fixes
+  finding **#14**.
+- **Files:**
+  - ✎ `feature/map/.../layers/MapLayersSheet.kt`
+  - ✎ string resources if Waves/Wind get real labels
+- **Approach:** make the `when` exhaustive with correct title/subtitle strings,
+  or remove the Waves/Wind arms until those overlays are wired (they're already
+  filtered out of `renderableOverlays`, so this is a latent-bug fix, not new
+  UI). A genuine quick win — can land independently at any time.
+- 🧪 ✎ `MapLayersSheetTest` (✚ if absent) — each renderable overlay shows its own
+  label (guards against future mislabels).
 
 ---
 
@@ -300,14 +337,17 @@ These are prerequisites for almost everything else, so they land first.
            └───────────────────────────────  2.1 overlays
                                               2.2 persist base
                                               2.3 detail level (needs 1.4)
-                                              2.4 region UX (needs 0.2)
+                                              2.4 region UX   (needs 0.2)
+                                              2.5 offline affordance (needs 0.1 bounds + 1.3 net)
+2.6 overlayRow mislabel (independent quick win)
                                               3.1 / 3.2 / 3.3 (independent)
 ```
 
-Recommended merge order: **0.x → 1.1 → 1.3 → 1.2 → 1.4 → 2.1 → 2.2 → 2.3 →
-2.4 → 3.1 → 3.2 → 3.3.** The Phase 0 + 1.1/1.4 slice alone removes the two worst
-failure modes ("stuck at X% with no error" and "huge download with no warning")
-and is shippable on its own.
+Recommended merge order: **2.6 (anytime) → 0.x → 1.1 → 1.3 → 1.2 → 1.4 → 2.1 →
+2.2 → 2.3 → 2.4 → 2.5 → 3.1 → 3.2 → 3.3.** `2.6` is a one-line latent-bug fix
+that can ship immediately. The Phase 0 + 1.1/1.4 slice alone removes the two
+worst failure modes ("stuck at X% with no error" and "huge download with no
+warning") and is shippable on its own.
 
 ## Cross-cutting checklist
 

--- a/apps/android/docs/offline-caching-implementation-plan.md
+++ b/apps/android/docs/offline-caching-implementation-plan.md
@@ -10,6 +10,28 @@ change minimally.
 
 Legend: ✚ new file · ✎ edit · 🧪 test
 
+## Status (as of 2026-06-09, branch `claude/android-caching-tile-analysis-7sr9hy`)
+
+| Task | Status |
+| --- | --- |
+| 0.1 rich model · 0.2 metadata codec · 0.3 estimator · 0.4 seam | ✅ done |
+| 1.1 failures + retry | ✅ done |
+| 1.2 foreground download service | ✅ done — *resume after process death deferred (regions reappear Paused; user resumes)* |
+| 1.3 Wi-Fi-only policy | ✅ done |
+| 1.4 pre-flight estimate + guardrail | ✅ done |
+| 2.1 overlays in downloads | ✅ done |
+| 2.2 persist base layer | ✅ done — *per-region base recorded in metadata; "current base differs" banner not built* |
+| 2.3 detail level | ✅ done (Standard/Detailed segmented choice in the confirm dialog) |
+| 2.4 region UX | ✅ rename, undo-delete snackbar, date on cards — *extent thumbnail, tap-to-open-on-map, on-screen download entry, sort: not built* |
+| 2.5 offline / out-of-coverage chip | ✅ done |
+| 2.6 overlayRow mislabel | ✅ done |
+| 3.1 ambient cache (256 MB ceiling + clear-cache action) | ✅ done — *true disk total (ambient + regions) not reported* |
+| 3.2 concurrency hardening | ✅ done (concurrent collections + atomic merge publication; not the coroutine rewrite) |
+| 3.3 licensing posture / tileserver | ⬜ open — product decision (gate OSM/Esri offline or restrict to Kartverket) + its own design doc |
+
+All work verified on a real SDK: full unit-test suite, `assembleDebug`,
+`assembleRelease`, detekt.
+
 ---
 
 ## Phase 0 — Foundation: model, seam, and a testable core

--- a/apps/android/docs/offline-caching-implementation-plan.md
+++ b/apps/android/docs/offline-caching-implementation-plan.md
@@ -1,0 +1,324 @@
+# Offline caching & tile management — implementation plan
+
+_Companion to `offline-caching-analysis.md`. Android native app (`apps/android`)._
+
+This plan turns every finding in the analysis into concrete, sequenced work. It
+is organised into four phases (P0 → P3). Each task lists the **goal**, the
+**files** touched, the **approach**, and the **tests**. Everything stays behind
+the existing `OfflineTileManager` seam in `:core:map`, so feature code and tests
+change minimally.
+
+Legend: ✚ new file · ✎ edit · 🧪 test
+
+---
+
+## Phase 0 — Foundation: model, seam, and a testable core
+
+These are prerequisites for almost everything else, so they land first.
+
+### 0.1 Rich region model + status
+
+- **Goal:** replace the thin `OfflineRegionInfo` with a model that carries
+  status (incl. failure), extent, base layer, overlays, zoom range, tile count
+  and creation time. Fixes findings **#1, #7**.
+- **Files:**
+  - ✎ `core/model/.../domain/Offline.kt`
+- **Approach:**
+  ```kotlin
+  enum class OfflineStatus { Downloading, Complete, Paused, Failed }
+
+  data class OfflineRegionInfo(
+      val id: Long,
+      val name: String,
+      val status: OfflineStatus,
+      val progress: Float,            // 0..1
+      val sizeBytes: Long,
+      val tileCount: Long,
+      val base: BaseLayer,
+      val overlays: Set<OverlayId>,
+      val bounds: GeoBounds,
+      val minZoom: Double,
+      val maxZoom: Double,
+      val createdAtEpochMs: Long,
+      val errorReason: String? = null,
+  ) {
+      val complete get() = status == OfflineStatus.Complete   // keep call sites compiling
+  }
+  ```
+  Keep a `complete` convenience getter so existing UI keeps working during the
+  migration.
+- 🧪 No new test (pure data); downstream tests updated in their own tasks.
+
+### 0.2 Region metadata codec
+
+- **Goal:** MapLibre only persists an opaque `byte[]` per region. Today it
+  stores just the name. Encode the full metadata (name, base, overlays, bounds,
+  zoom, createdAt) as JSON so it round-trips. Fixes findings **#6, #7, #9**.
+- **Files:**
+  - ✚ `core/map/.../core/map/OfflineRegionMetadata.kt`
+- **Approach:** a pure object with `encode(meta): ByteArray` /
+  `decode(bytes): Meta?` using `org.json` (already available) — no MapLibre
+  imports, fully unit-testable. Be defensive: legacy regions whose metadata is a
+  bare name string decode to a `Meta` with sensible defaults.
+- 🧪 ✚ `OfflineRegionMetadataTest` — round-trip, legacy-name fallback, malformed
+  bytes → null.
+
+### 0.3 Tile-count / size estimator + area guard
+
+- **Goal:** a pure estimator for "how many tiles / bytes will this download
+  be?" plus the absurd-area guard. Fixes finding **#4** (and feeds #8).
+- **Files:**
+  - ✚ `core/map/.../core/map/TileMath.kt`
+  - ✎ `core/map/.../core/map/RouteCorridor.kt` (reuse `spanDegrees`)
+- **Approach:** standard slippy-map math. For each integer zoom `z` in
+  `min..max`, tile range from `lon2tileX/lat2tileY` over the bounds; sum the
+  tile counts; `bytes ≈ tiles × AVG_RASTER_TILE_BYTES` (≈ 20 KB, tunable).
+  Multiply by the number of active sources (base + overlays). Expose
+  `estimate(bounds, min, max, sources): OfflineEstimate(tiles, bytes)` and
+  `isWithinLimits(estimate, span)`.
+- 🧪 ✚ `TileMathTest` — known bbox/zoom → expected tile count; monotonic in zoom
+  span; limit predicate.
+
+### 0.4 Expand the `OfflineTileManager` seam
+
+- **Goal:** add the operations the new UX needs, and update **all three**
+  implementations. Fixes the plumbing for **#1, #2, #8, #9, #10**.
+- **Files:**
+  - ✎ `core/map/.../core/map/OfflineTileManager.kt` (interface + real impl)
+  - ✎ `core/map/.../core/map/SyntheticOfflineTileManager.kt`
+  - ✎ `feature/map/.../offline/...Test` `StubOfflineTileManager`
+- **Approach:** new interface surface:
+  ```kotlin
+  fun download(spec: DownloadSpec)        // spec carries base, overlays, bounds, min/max zoom, detail, name
+  fun retry(id: Long)
+  fun pause(id: Long)
+  fun resume(id: Long)
+  fun cancel(id: Long)                     // alias/clarity over delete for in-flight
+  fun delete(id: Long)
+  fun estimate(spec: DownloadSpec): OfflineEstimate
+  fun clearAmbientCache()
+  ```
+  `DownloadSpec` replaces the long positional `download(...)` parameter list.
+  `SyntheticOfflineTileManager` grows status transitions (a coroutine that ramps
+  progress, can be paused/failed) so the screen and its tests can drive every
+  state without MapLibre.
+- 🧪 ✎ `SyntheticOfflineTileManagerTest` — pause/resume/retry/cancel and a
+  forced-failure path.
+
+---
+
+## Phase 1 — P0 correctness & robustness
+
+### 1.1 Surface failures + retry
+
+- **Goal:** stop swallowing errors. Fixes finding **#1**.
+- **Files:**
+  - ✎ `core/map/.../core/map/OfflineTileManager.kt`
+  - ✎ `feature/map/.../offline/OfflineMapsScreen.kt`
+  - ✎ `feature/map/.../offline/OfflineViewModel.kt`
+  - ✎ string resources (`feature/map/.../res/values*/strings.xml`)
+- **Approach:** wire every `onError` and `mapboxTileCountLimitExceeded` in
+  `MapLibreOfflineTileManager` to set `OfflineStatus.Failed` with a reason
+  string via `upsert`. Add a **Failed** card variant with an error message and a
+  **Retry** button (`viewModel.retry(id)` → `manager.retry`).
+- 🧪 ✎ `OfflineMapsScreenTest` — a failed region renders the error + retry;
+  retry calls the manager.
+
+### 1.2 Foreground download service (survives backgrounding)
+
+- **Goal:** downloads continue when the app is backgrounded and can be
+  paused/resumed/cancelled; recover after process death. Fixes finding **#2**.
+- **Files:**
+  - ✚ `feature/recording`-style service module or `core/map`:
+    `OfflineDownloadService` (foreground service)
+  - ✚ `core/map/.../core/map/OfflineDownloadStore.kt` (persisted desired-state)
+  - ✎ `app/.../AndroidManifest.xml` (service + `FOREGROUND_SERVICE*` perms)
+  - ✎ `OfflineTileManager` real impl (drive state via the service)
+- **Approach:** MapLibre keeps downloading only while the process lives and the
+  region is `STATE_ACTIVE`. A foreground service with a progress notification
+  keeps the process alive and exposes pause/resume/cancel notification actions.
+  Persist each region's *desired* state (active/paused) in a small DataStore so
+  that on cold start we can re-activate incomplete regions (gated by the
+  Wi-Fi-only policy from 1.3). The service stops itself when no region is
+  active. Mirror the existing `RecordingService` pattern already in the repo for
+  consistency.
+- 🧪 service logic is hard to unit-test; cover the **desired-state store** and
+  the **resume-decision** function (pure) instead. 🧪 ✚ `OfflineDownloadStoreTest`.
+
+### 1.3 Connectivity / Wi-Fi-only policy
+
+- **Goal:** never download on metered networks unless allowed; auto-pause when
+  constraints break. Fixes finding **#3**.
+- **Files:**
+  - ✚ `core/map/.../core/map/DownloadPolicy.kt` (pure decision fn)
+  - ✚ connectivity observer (ConnectivityManager `NetworkCallback`) in the
+    service/manager
+  - ✎ `core/model/.../domain/UserSettings.kt` (+`downloadOverWifiOnly`)
+  - ✎ `core/data/.../SettingsRepository.kt` (persist the flag)
+  - ✎ `feature/settings/...` (a toggle in settings)
+- **Approach:** `DownloadPolicy.shouldRun(settings, network): Boolean` is pure
+  and tested. The observer feeds `(isWifi, isMetered, isConnected)`; when the
+  policy flips to false the service pauses active regions (`setDownloadState
+  INACTIVE`, status → `Paused`), and resumes when it flips back.
+- 🧪 ✚ `DownloadPolicyTest` — wifi-only × {wifi, metered, none}; allow-cellular
+  case.
+
+### 1.4 Pre-flight estimate + guardrail in the UX
+
+- **Goal:** show size before committing and block absurd areas. Fixes finding
+  **#4** (uses 0.3).
+- **Files:**
+  - ✎ `feature/map/.../MapScreenModals.kt` (the "download this area" path)
+  - ✚ a confirm dialog (or extend `MapLayersSheet`) showing tiles/MB + detail
+    level
+  - ✎ `feature/map/.../offline/OfflineViewModel.kt` (`estimate(spec)`)
+  - ✎ `feature/map/.../RouteViewModel.kt` (`downloadAlongRoute` shows estimate)
+- **Approach:** before `download`, call `manager.estimate(spec)`; render
+  "~N tiles · ~120 MB". If `!isWithinLimits`, disable confirm with an
+  explanation ("Area too large — zoom in or lower detail"). Replaces the current
+  fire-and-forget `offlineViewModel.download(...)`.
+- 🧪 ✎ `OfflineViewModelTest` — estimate surfaced; over-limit blocks download.
+
+---
+
+## Phase 2 — P1 features / field usefulness
+
+### 2.1 Include overlays in offline downloads
+
+- **Goal:** download avalanche/trail overlays alongside the base. Fixes finding
+  **#5**.
+- **Files:**
+  - ✎ `core/map/.../core/map/LocalStyleServer.kt` (serve base **+ overlays**)
+  - ✎ `core/map/.../core/map/OfflineTileManager.kt` (style URL carries overlays)
+  - ✎ `core/map/.../ui/map/MapStyles.kt` (already supports overlays in
+    `styleJson(base, overlays)` — reuse)
+- **Approach:** encode overlays in the style URL (e.g.
+  `/topo.json?ov=Avalanche,Trails`); `LocalStyleServer.serve` parses the query
+  and calls `MapStyles.styleJson(base, overlays)`. The downloader then fetches
+  overlay tiles into the region. Persist the overlay set in region metadata
+  (0.2) and show it on the card.
+- 🧪 ✎ `LocalStyleServerTest` (✚ if absent) — requested overlays appear in the
+  served JSON; unknown overlay ignored.
+
+### 2.2 Persist base layer + record it per region
+
+- **Goal:** base-layer choice survives relaunch; each region knows its base;
+  warn on mismatch offline. Fixes finding **#6** (+ surfaces #7 data).
+- **Files:**
+  - ✎ `core/model/.../domain/UserSettings.kt` (+`baseLayer`, `overlays`)
+  - ✎ `core/data/.../SettingsRepository.kt`
+  - ✎ `feature/map/.../MapViewModel.kt` (load initial base from settings;
+    `setBaseLayer` persists)
+  - ✎ `feature/map/.../offline/OfflineMapsScreen.kt` (show base/overlays chips)
+- **Approach:** seed `MapUiState.baseLayer` from settings on init; persist on
+  change. Region cards display the base (and overlay chips). Optional: a banner
+  when the active base differs from all downloaded regions.
+- 🧪 ✎ `MapViewModelTest` — initial base from settings; change persists.
+
+### 2.3 Detail level (zoom span) control
+
+- **Goal:** user picks Standard/Detailed; estimate updates live. Fixes finding
+  **#8**.
+- **Files:**
+  - ✎ `core/model` (✚ `DetailLevel` enum → zoom span mapping) or keep in
+    `DownloadSpec`
+  - ✎ the download confirm UI (2.x / 1.4)
+  - ✎ `OfflineViewModel` / `RouteViewModel` (map detail → min/max zoom)
+- **Approach:** replace the hard-coded `floor(zoom)..+4` / `8..15` with a
+  `DetailLevel` → `(minZoom, maxZoom)` table; recompute the estimate when the
+  user changes it. Keep current values as the **Standard** default.
+- 🧪 ✎ `OfflineViewModelTest` — detail level maps to expected zoom span.
+
+### 2.4 Region management UX (rename, extent preview, update)
+
+- **Goal:** richer Offline screen. Fixes findings **#7, #9**.
+- **Files:**
+  - ✎ `feature/map/.../offline/OfflineMapsScreen.kt`
+  - ✎ `OfflineTileManager` (`rename`, `updateRegion`)
+- **Approach:** card shows created date + tile count; a small static map
+  thumbnail of `bounds`; **Rename** (edit metadata via 0.2); **Update** (re-run
+  the same `DownloadSpec` to refresh tiles). Sort options (name/date/size).
+- 🧪 ✎ `OfflineMapsScreenTest` — rename/update actions invoke the manager;
+  metadata renders.
+
+---
+
+## Phase 3 — P2 polish / strategic
+
+### 3.1 Ambient-cache tuning + accurate disk usage + clear cache
+
+- **Goal:** size the runtime cache, report true disk use, allow clearing. Fixes
+  finding **#10**.
+- **Files:**
+  - ✎ `core/map/.../core/map/OfflineTileManager.kt`
+    (`setMaximumAmbientCacheSize`, `clearAmbientCache`)
+  - ✎ `feature/map/.../offline/OfflineMapsScreen.kt` ("Clear cache" + real disk
+    total)
+- **Approach:** configure the ambient ceiling on init (e.g. 256 MB, tunable);
+  report disk usage from the offline DB file size (regions + ambient) rather
+  than summing region sizes only; add a **Clear cache** action (regions
+  untouched).
+- 🧪 ✎ `OfflineMapsScreenTest` — clear-cache action wired.
+
+### 3.2 Concurrency hardening
+
+- **Goal:** remove the racy `refresh()` and unsynchronised map. Fixes finding
+  **#11**.
+- **Files:**
+  - ✎ `core/map/.../core/map/OfflineTileManager.kt`
+- **Approach:** wrap the MapLibre list/status callbacks in
+  `suspendCancellableCoroutine`, gather with `async`/`awaitAll` on a confined
+  dispatcher; confine `regionsById` to that single context (or guard with a
+  mutex). Removes the manual countdown and the upsert/replace interleave.
+- 🧪 covered indirectly; add a focused test on the status-aggregation helper if
+  it can be extracted purely.
+
+### 3.3 Licensing posture + tileserver/vector path (strategic)
+
+- **Goal:** de-risk caching third-party tiles and set up the long-term fix.
+  Fixes finding **#12**.
+- **Files:** docs + a feature flag.
+- **Approach (incremental):**
+  1. Gate offline downloads of OSM/Esri behind a flag (or restrict offline to
+     **Kartverket**, which permits caching) until licensing is cleared.
+  2. Track the planned **`apps/tileserver`** + **vector tiles / MBTiles**
+     migration as the durable fix: smaller offline footprint, on-device
+     restyling (dark mode, overlays without separate downloads), and
+     licence-clean sources. This is a larger workstream — capture it as its own
+     design doc rather than a single task here.
+
+---
+
+## Dependency / sequencing summary
+
+```
+0.1 model ─┬─ 0.2 metadata ─┐
+           ├─ 0.3 estimator ─┼─ 0.4 seam ─┬─ 1.1 failures+retry
+           │                 │            ├─ 1.2 fg service ── (needs 1.3 policy)
+           │                 │            ├─ 1.3 wifi policy
+           │                 │            └─ 1.4 estimate UX
+           └───────────────────────────────  2.1 overlays
+                                              2.2 persist base
+                                              2.3 detail level (needs 1.4)
+                                              2.4 region UX (needs 0.2)
+                                              3.1 / 3.2 / 3.3 (independent)
+```
+
+Recommended merge order: **0.x → 1.1 → 1.3 → 1.2 → 1.4 → 2.1 → 2.2 → 2.3 →
+2.4 → 3.1 → 3.2 → 3.3.** The Phase 0 + 1.1/1.4 slice alone removes the two worst
+failure modes ("stuck at X% with no error" and "huge download with no warning")
+and is shippable on its own.
+
+## Cross-cutting checklist
+
+- **Backwards compat:** legacy regions (name-only metadata) must decode to a
+  valid `OfflineRegionInfo` (0.2) — they predate the new fields.
+- **DEBUG parity:** every new seam method must be implemented in
+  `SyntheticOfflineTileManager` and the test `StubOfflineTileManager`, or the
+  Offline screen breaks on emulator and tests stop compiling.
+- **Architecture boundary:** no MapLibre imports leak out of `:core:map`
+  (enforced by `ArchitectureBoundaryTest`) — keep pure logic (`TileMath`,
+  `DownloadPolicy`, `OfflineRegionMetadata`) MapLibre-free.
+- **Strings/i18n:** new user-facing strings in both `values/` and `values-nb/`.
+- **Permissions:** foreground-service + connectivity permissions added to the
+  manifest with the narrowest type.

--- a/apps/android/feature/map/src/main/AndroidManifest.xml
+++ b/apps/android/feature/map/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+        <service
+            android:name="com.sigmundgranaas.turbo.expressive.feature.offline.OfflineDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+    </application>
+</manifest>

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/layers/MapLayersSheet.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/layers/MapLayersSheet.kt
@@ -19,12 +19,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Air
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Map
 import androidx.compose.material.icons.rounded.Hiking
 import androidx.compose.material.icons.rounded.Satellite
 import androidx.compose.material.icons.rounded.Terrain
+import androidx.compose.material.icons.rounded.Waves
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -125,7 +127,8 @@ fun MapLayersSheet(
 private fun overlayRow(overlay: OverlayId): Triple<ImageVector, Int, Int> = when (overlay) {
     OverlayId.Trails -> Triple(Icons.Rounded.Hiking, R.string.layers_trails, R.string.layers_trails_sub)
     OverlayId.Avalanche -> Triple(Icons.Rounded.Terrain, R.string.layers_avalanche, R.string.layers_avalanche_sub)
-    OverlayId.Waves, OverlayId.Wind -> Triple(Icons.Rounded.Map, R.string.layers_trails, R.string.layers_trails_sub)
+    OverlayId.Waves -> Triple(Icons.Rounded.Waves, R.string.layers_waves, R.string.layers_waves_sub)
+    OverlayId.Wind -> Triple(Icons.Rounded.Air, R.string.layers_wind, R.string.layers_wind_sub)
 }
 
 @Composable

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreen.kt
@@ -530,7 +530,9 @@ fun MapScreen(
                     }
                 },
                 onMapReady = { ui.controller = it },
-                onBearingChange = { ui.bearing = it.toFloat() },
+                // Fired on every camera-idle; also bump the idle tick so camera-reading
+                // chrome (the offline-coverage chip) recomposes after a pan, not only rotation.
+                onBearingChange = { ui.bearing = it.toFloat(); ui.cameraIdleTick++ },
                 modifier = Modifier.fillMaxSize(),
             )
 
@@ -575,8 +577,8 @@ fun MapScreen(
                     )
                 } else if (isOffline) {
                     // Why-is-the-map-blank affordance: offline, and (stronger) outside
-                    // every downloaded region. Coverage is re-checked as the camera moves
-                    // (bearing/camera changes recompose this block).
+                    // every downloaded region. Re-checked on each camera-idle via the tick.
+                    @Suppress("UNUSED_EXPRESSION") ui.cameraIdleTick
                     val centre = ui.controller?.center()
                     val outside = centre != null && !offlineIndicator.covered(centre)
                     OfflineChip(

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.MyLocation
 import androidx.compose.material.icons.rounded.Folder
@@ -108,6 +109,7 @@ fun MapScreen(
     routeViewModel: RouteViewModel = hiltViewModel(),
     offlineViewModel: OfflineViewModel = hiltViewModel(),
     recordingViewModel: RecordingViewModel = hiltViewModel(),
+    offlineIndicator: com.sigmundgranaas.turbo.expressive.feature.offline.OfflineIndicatorViewModel = hiltViewModel(),
 ) {
     val cs = MaterialTheme.colorScheme
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -115,6 +117,7 @@ fun MapScreen(
     // All transient UI/tool/dialog state lives in one holder (see MapScreenState).
     val ui = rememberMapScreenState()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val isOffline by offlineIndicator.offline.collectAsStateWithLifecycle()
     val routeState by routeViewModel.state.collectAsStateWithLifecycle()
     val routePreset by routeViewModel.preset.collectAsStateWithLifecycle()
     val toolWaypoints by routeViewModel.waypoints.collectAsStateWithLifecycle()
@@ -570,6 +573,19 @@ fun MapScreen(
                             .windowInsetsPadding(WindowInsets.statusBars)
                             .padding(top = 84.dp),
                     )
+                } else if (isOffline) {
+                    // Why-is-the-map-blank affordance: offline, and (stronger) outside
+                    // every downloaded region. Coverage is re-checked as the camera moves
+                    // (bearing/camera changes recompose this block).
+                    val centre = ui.controller?.center()
+                    val outside = centre != null && !offlineIndicator.covered(centre)
+                    OfflineChip(
+                        outsideCoverage = outside,
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .windowInsetsPadding(WindowInsets.statusBars)
+                            .padding(top = 84.dp),
+                    )
                 }
 
                 // The live sheet owns the bottom of the screen; reserve its height so
@@ -1009,6 +1025,37 @@ private fun LocatingChip(modifier: Modifier = Modifier) {
                 stringResource(R.string.location_finding),
                 style = MaterialTheme.typography.labelLarge,
                 color = cs.onSurface,
+            )
+        }
+    }
+}
+
+/** "You're offline" pill under the search bar; says so louder when the camera is
+ *  also outside every downloaded region (i.e. the basemap will be blank). */
+@Composable
+private fun OfflineChip(outsideCoverage: Boolean, modifier: Modifier = Modifier) {
+    val cs = MaterialTheme.colorScheme
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(50),
+        color = if (outsideCoverage) cs.errorContainer else cs.surfaceContainerHigh,
+        shadowElevation = 3.dp,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+        ) {
+            Icon(
+                Icons.Rounded.CloudOff,
+                null,
+                tint = if (outsideCoverage) cs.onErrorContainer else cs.primary,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                stringResource(if (outsideCoverage) R.string.offline_chip_uncovered else R.string.offline_chip),
+                style = MaterialTheme.typography.labelLarge,
+                color = if (outsideCoverage) cs.onErrorContainer else cs.onSurface,
             )
         }
     }

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
@@ -112,13 +112,15 @@ internal fun MapScreenModals(
     // Pre-flight size confirm for "Download this area": shows the estimate and blocks
     // areas too large to download (zoom in instead). Confirm commits + opens Offline.
     ui.pendingDownloadArea?.let { area ->
-        val estimate = remember(area, baseLayer) {
-            offlineViewModel.estimate(baseLayer, area.bounds, area.zoom)
+        // Cache the overlays toggled on now, so the estimate and the download agree.
+        val overlays = ui.activeOverlays
+        val estimate = remember(area, baseLayer, overlays) {
+            offlineViewModel.estimate(baseLayer, area.bounds, area.zoom, overlays)
         }
         DownloadAreaDialog(
             estimate = estimate,
             onConfirm = {
-                offlineViewModel.download(area.centre, baseLayer, area.bounds, area.zoom)
+                offlineViewModel.download(area.centre, baseLayer, area.bounds, area.zoom, overlays)
                 ui.pendingDownloadArea = null
                 onOpenOffline()
             },

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.icons.rounded.Route
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -114,13 +113,10 @@ internal fun MapScreenModals(
     ui.pendingDownloadArea?.let { area ->
         // Cache the overlays toggled on now, so the estimate and the download agree.
         val overlays = ui.activeOverlays
-        val estimate = remember(area, baseLayer, overlays) {
-            offlineViewModel.estimate(baseLayer, area.bounds, area.zoom, overlays)
-        }
         DownloadAreaDialog(
-            estimate = estimate,
-            onConfirm = {
-                offlineViewModel.download(area.centre, baseLayer, area.bounds, area.zoom, overlays)
+            estimateFor = { detail -> offlineViewModel.estimate(baseLayer, area.bounds, area.zoom, overlays, detail) },
+            onConfirm = { detail ->
+                offlineViewModel.download(area.centre, baseLayer, area.bounds, area.zoom, overlays, detail)
                 ui.pendingDownloadArea = null
                 onOpenOffline()
             },

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenModals.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.rounded.Route
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -21,6 +22,7 @@ import com.sigmundgranaas.turbo.expressive.feature.layers.MapLayersSheet
 import com.sigmundgranaas.turbo.expressive.feature.markers.MarkerEditorSheet
 import com.sigmundgranaas.turbo.expressive.feature.recording.RecordingViewModel
 import com.sigmundgranaas.turbo.expressive.feature.recording.TrackSaveDialog
+import com.sigmundgranaas.turbo.expressive.feature.offline.DownloadAreaDialog
 import com.sigmundgranaas.turbo.expressive.feature.offline.OfflineViewModel
 import com.sigmundgranaas.turbo.expressive.ui.components.DeleteMarkerDialog
 import com.sigmundgranaas.turbo.expressive.ui.components.NameInputDialog
@@ -97,14 +99,30 @@ internal fun MapScreenModals(
                 ui.controller?.let { ctrl ->
                     val bounds = ctrl.visibleBounds()
                     val centre = LatLng((bounds.north + bounds.south) / 2, (bounds.east + bounds.west) / 2)
-                    offlineViewModel.download(centre, baseLayer, bounds, ctrl.zoom())
+                    // Capture the viewport and confirm the size before committing (see below).
+                    ui.pendingDownloadArea = PendingDownloadArea(bounds, centre, ctrl.zoom())
                 }
                 ui.showLayers = false
-                onOpenOffline()
             },
             activeOverlays = ui.activeOverlays,
             onToggleOverlay = { id, on -> ui.activeOverlays = if (on) ui.activeOverlays + id else ui.activeOverlays - id },
             onDismiss = { ui.showLayers = false },
+        )
+    }
+    // Pre-flight size confirm for "Download this area": shows the estimate and blocks
+    // areas too large to download (zoom in instead). Confirm commits + opens Offline.
+    ui.pendingDownloadArea?.let { area ->
+        val estimate = remember(area, baseLayer) {
+            offlineViewModel.estimate(baseLayer, area.bounds, area.zoom)
+        }
+        DownloadAreaDialog(
+            estimate = estimate,
+            onConfirm = {
+                offlineViewModel.download(area.centre, baseLayer, area.bounds, area.zoom)
+                ui.pendingDownloadArea = null
+                onOpenOffline()
+            },
+            onDismiss = { ui.pendingDownloadArea = null },
         )
     }
     // Add-to-collection picker for the selected marker.

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenState.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenState.kt
@@ -3,6 +3,7 @@ package com.sigmundgranaas.turbo.expressive.feature.map
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +32,9 @@ class MapScreenState {
     // ── Camera / map handle ──
     var controller by mutableStateOf<MapController?>(null)
     var bearing by mutableFloatStateOf(0f)
+    /** Bumped on every camera-idle so on-map chrome that reads the camera (e.g. the
+     *  offline-coverage chip) recomposes after a pan/zoom, not just on rotation. */
+    var cameraIdleTick by mutableIntStateOf(0)
     /** A saved track opened on the map ("Show on map") — drawn + selected. */
     var displayedTrack by mutableStateOf<List<LatLng>?>(null)
 

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenState.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapScreenState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Composable
 import com.sigmundgranaas.turbo.expressive.core.map.MapSelectionState
+import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.Marker
 import com.sigmundgranaas.turbo.expressive.domain.OverlayId
@@ -42,6 +43,8 @@ class MapScreenState {
     // ── Layers / overlays ──
     var showLayers by mutableStateOf(false)
     var activeOverlays by mutableStateOf<Set<OverlayId>>(emptySet())
+    /** The captured viewport awaiting the "download this area" size-confirm dialog. */
+    var pendingDownloadArea by mutableStateOf<PendingDownloadArea?>(null)
 
     // ── Create-track tool (one tool, three modes); null = closed ──
     var trackMode by mutableStateOf<TrackMode?>(null)
@@ -74,6 +77,10 @@ class MapScreenState {
     var viewerStart by mutableStateOf(-1)
     var pendingPhotoAt by mutableStateOf<LatLng?>(null)
 }
+
+/** The viewport captured when the user taps "Download this area", held until they
+ *  confirm the size in [com.sigmundgranaas.turbo.expressive.feature.offline.DownloadAreaDialog]. */
+data class PendingDownloadArea(val bounds: GeoBounds, val centre: LatLng, val zoom: Double)
 
 @Composable
 internal fun rememberMapScreenState(): MapScreenState = remember { MapScreenState() }

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapViewModel.kt
@@ -7,6 +7,7 @@ import com.sigmundgranaas.turbo.expressive.core.common.StringProvider
 import com.sigmundgranaas.turbo.expressive.core.data.LocationRepository
 import com.sigmundgranaas.turbo.expressive.core.data.MarkerRepository
 import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
+import com.sigmundgranaas.turbo.expressive.core.data.SettingsRepository
 import com.sigmundgranaas.turbo.expressive.domain.ActivityKindId
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
@@ -43,6 +44,7 @@ class MapViewModel @Inject constructor(
     private val location: LocationRepository,
     private val reverseGeocode: ReverseGeocodeRepository,
     private val strings: StringProvider,
+    private val settings: SettingsRepository,
 ) : ViewModel() {
     private val _state = MutableStateFlow(MapUiState())
     val state: StateFlow<MapUiState> = _state.asStateFlow()
@@ -59,6 +61,11 @@ class MapViewModel @Inject constructor(
             markerRepository.observeAll().collect { markers ->
                 _state.update { it.copy(markers = markers) }
             }
+        }
+        // Restore (and keep in sync with) the persisted base map so the choice
+        // survives relaunch instead of resetting to Norgeskart every time.
+        viewModelScope.launch {
+            settings.settings.collect { s -> _state.update { it.copy(baseLayer = s.baseLayer) } }
         }
     }
 
@@ -98,7 +105,10 @@ class MapViewModel @Inject constructor(
 
     fun dismissLocationNotice() = _state.update { it.copy(locationNotice = null) }
 
-    fun setBaseLayer(layer: BaseLayer) = _state.update { it.copy(baseLayer = layer) }
+    // Persist the choice; the settings collector above reflects it back into state.
+    fun setBaseLayer(layer: BaseLayer) {
+        viewModelScope.launch { settings.setBaseLayer(layer) }
+    }
     fun setFollowing(value: Boolean) = _state.update { it.copy(following = value) }
 
     /** Resolve a human label for [point] (used to pre-fill a new marker's name). */

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModel.kt
@@ -11,6 +11,7 @@ import com.sigmundgranaas.turbo.expressive.core.geo.GeoPathSource
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
 import com.sigmundgranaas.turbo.expressive.core.map.RouteCorridor
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.RoutePlan
 import com.sigmundgranaas.turbo.expressive.domain.RoutePreset
@@ -247,7 +248,7 @@ class RouteViewModel @Inject constructor(
             else -> return
         }
         val bounds = RouteCorridor.bounds(geometry) ?: return
-        offline.download(name, base, bounds, minZoom = 8.0, maxZoom = 15.0)
+        offline.download(DownloadSpec(name = name, base = base, bounds = bounds, minZoom = 8.0, maxZoom = 15.0))
     }
 
     fun saveAsTrack(name: String, kind: com.sigmundgranaas.turbo.expressive.domain.ActivityKindId? = null) {

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialog.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialog.kt
@@ -1,5 +1,9 @@
 package com.sigmundgranaas.turbo.expressive.feature.offline
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CloudDownload
@@ -8,29 +12,40 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.sigmundgranaas.turbo.expressive.domain.DetailLevel
 import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.feature.map.R
 
 /**
- * Pre-flight confirm for "Download this area": shows the estimated size + tile count
- * so the user isn't committing blind, and **disables** the download when the area is
- * too large (the [OfflineEstimate.withinLimits] guard), nudging them to zoom in. This
- * is the gate between the layers sheet's "Download this area" and the actual download.
+ * Pre-flight confirm for "Download this area": a Standard/Detailed zoom-depth
+ * choice with a live size + tile-count estimate, so the user isn't committing
+ * blind, and a **disabled** download when the area is too large (the
+ * [OfflineEstimate.withinLimits] guard), nudging them to zoom in. This is the
+ * gate between the layers sheet's "Download this area" and the actual download.
  */
 @Composable
 internal fun DownloadAreaDialog(
-    estimate: OfflineEstimate,
-    onConfirm: () -> Unit,
+    estimateFor: (DetailLevel) -> OfflineEstimate,
+    onConfirm: (DetailLevel) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val cs = MaterialTheme.colorScheme
+    var detail by remember { mutableStateOf(DetailLevel.Standard) }
+    val estimate = remember(detail) { estimateFor(detail) }
     val ok = estimate.withinLimits
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -44,18 +59,40 @@ internal fun DownloadAreaDialog(
         },
         title = { Text(stringResource(R.string.offline_download_title), style = MaterialTheme.typography.headlineSmall) },
         text = {
-            Text(
-                if (ok) {
-                    stringResource(R.string.offline_download_estimate, formatSize(estimate.bytes), estimate.tiles)
-                } else {
-                    stringResource(R.string.offline_download_too_large, formatSize(estimate.bytes))
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = cs.onSurfaceVariant,
-            )
+            Column {
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                    DetailLevel.entries.forEachIndexed { index, level ->
+                        SegmentedButton(
+                            selected = detail == level,
+                            onClick = { detail = level },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = DetailLevel.entries.size),
+                            modifier = Modifier.testTag("detail_${level.name}"),
+                        ) {
+                            Text(
+                                stringResource(
+                                    when (level) {
+                                        DetailLevel.Standard -> R.string.offline_detail_standard
+                                        DetailLevel.Detailed -> R.string.offline_detail_detailed
+                                    },
+                                ),
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    if (ok) {
+                        stringResource(R.string.offline_download_estimate, formatSize(estimate.bytes), estimate.tiles)
+                    } else {
+                        stringResource(R.string.offline_download_too_large, formatSize(estimate.bytes))
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = cs.onSurfaceVariant,
+                )
+            }
         },
         confirmButton = {
-            Button(onClick = onConfirm, enabled = ok, modifier = Modifier.testTag("downloadConfirm")) {
+            Button(onClick = { onConfirm(detail) }, enabled = ok, modifier = Modifier.testTag("downloadConfirm")) {
                 Text(stringResource(R.string.offline_download_confirm))
             }
         },

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialog.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialog.kt
@@ -1,0 +1,64 @@
+package com.sigmundgranaas.turbo.expressive.feature.offline
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.WarningAmber
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
+import com.sigmundgranaas.turbo.expressive.feature.map.R
+
+/**
+ * Pre-flight confirm for "Download this area": shows the estimated size + tile count
+ * so the user isn't committing blind, and **disables** the download when the area is
+ * too large (the [OfflineEstimate.withinLimits] guard), nudging them to zoom in. This
+ * is the gate between the layers sheet's "Download this area" and the actual download.
+ */
+@Composable
+internal fun DownloadAreaDialog(
+    estimate: OfflineEstimate,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val cs = MaterialTheme.colorScheme
+    val ok = estimate.withinLimits
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                if (ok) Icons.Rounded.CloudDownload else Icons.Rounded.WarningAmber,
+                null,
+                tint = if (ok) cs.primary else cs.error,
+                modifier = Modifier.size(28.dp),
+            )
+        },
+        title = { Text(stringResource(R.string.offline_download_title), style = MaterialTheme.typography.headlineSmall) },
+        text = {
+            Text(
+                if (ok) {
+                    stringResource(R.string.offline_download_estimate, formatSize(estimate.bytes), estimate.tiles)
+                } else {
+                    stringResource(R.string.offline_download_too_large, formatSize(estimate.bytes))
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = cs.onSurfaceVariant,
+            )
+        },
+        confirmButton = {
+            Button(onClick = onConfirm, enabled = ok, modifier = Modifier.testTag("downloadConfirm")) {
+                Text(stringResource(R.string.offline_download_confirm))
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.offline_download_cancel)) } },
+    )
+}

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineDownloadService.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineDownloadService.kt
@@ -1,0 +1,167 @@
+package com.sigmundgranaas.turbo.expressive.feature.offline
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.os.IBinder
+import com.sigmundgranaas.turbo.expressive.core.data.SettingsRepository
+import com.sigmundgranaas.turbo.expressive.core.map.DownloadPolicy
+import com.sigmundgranaas.turbo.expressive.core.map.NetworkMonitor
+import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
+import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
+import com.sigmundgranaas.turbo.expressive.feature.map.R
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Foreground service that keeps offline map downloads running while the app is
+ * backgrounded, surfaces aggregate progress as an ongoing notification, and gates
+ * downloads on the connectivity policy (auto-pausing on metered/no network when
+ * "Wi-Fi only" is on, resuming when un-metered returns). It owns only the
+ * notification, the process lifetime and the policy loop; the downloads themselves
+ * live in the singleton [OfflineTileManager]. Started via [start] from the manager
+ * when a download begins, it stops itself once nothing is downloading or paused.
+ */
+@AndroidEntryPoint
+class OfflineDownloadService : Service() {
+
+    @Inject lateinit var manager: OfflineTileManager
+    @Inject lateinit var network: NetworkMonitor
+    @Inject lateinit var settings: SettingsRepository
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var policyJob: Job? = null
+    private var notifyJob: Job? = null
+    private var started = false
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_PAUSE -> manager.regions.value.filter { it.status == OfflineStatus.Downloading }.forEach { manager.pause(it.id) }
+            ACTION_RESUME -> manager.regions.value.filter { it.status == OfflineStatus.Paused }.forEach { manager.resume(it.id) }
+            else -> Unit
+        }
+        ensureStarted()
+        return START_STICKY
+    }
+
+    private fun ensureStarted() {
+        if (started) return
+        started = true
+        createChannel()
+        startForegroundCompat(buildNotification(manager.regions.value))
+
+        // Apply the connectivity policy continuously so downloads pause on metered/no
+        // network (when Wi-Fi-only) and resume when un-metered comes back.
+        policyJob = scope.launch {
+            combine(network.state, settings.settings) { net, prefs ->
+                DownloadPolicy.shouldDownload(prefs.downloadOverWifiOnly, net)
+            }.distinctUntilChanged().collect { manager.setNetworkAllowed(it) }
+        }
+
+        // Re-post the notification on progress; tear down when no work remains.
+        notifyJob = scope.launch {
+            manager.regions.collect { regions ->
+                if (regions.none { it.status == OfflineStatus.Downloading || it.status == OfflineStatus.Paused }) {
+                    teardown()
+                } else {
+                    notificationManager().notify(NOTIF_ID, buildNotification(regions))
+                }
+            }
+        }
+    }
+
+    private fun teardown() {
+        policyJob?.cancel()
+        notifyJob?.cancel()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        policyJob?.cancel()
+        notifyJob?.cancel()
+        super.onDestroy()
+    }
+
+    private fun startForegroundCompat(notification: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            startForeground(NOTIF_ID, notification)
+        }
+    }
+
+    private fun buildNotification(regions: List<OfflineRegionInfo>): Notification {
+        val pending = regions.filter { it.status == OfflineStatus.Downloading || it.status == OfflineStatus.Paused }
+        val pct = if (pending.isEmpty()) 0 else (pending.map { it.progress }.average() * 100).toInt().coerceIn(0, 100)
+        val anyActive = pending.any { it.status == OfflineStatus.Downloading }
+        val builder = Notification.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentTitle(getString(R.string.offline_notif_title))
+            .setContentText(getString(R.string.offline_notif_content, pending.size, pct))
+            .setContentIntent(openAppIntent())
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setProgress(100, pct, !anyActive)
+        if (anyActive) {
+            builder.addAction(action(android.R.drawable.ic_media_pause, getString(R.string.offline_notif_pause), ACTION_PAUSE, reqCode = 1))
+        } else {
+            builder.addAction(action(android.R.drawable.ic_media_play, getString(R.string.offline_notif_resume), ACTION_RESUME, reqCode = 2))
+        }
+        return builder.build()
+    }
+
+    private fun openAppIntent(): PendingIntent = PendingIntent.getActivity(
+        this, 0, packageManager.getLaunchIntentForPackage(packageName),
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+    )
+
+    private fun action(icon: Int, label: String, action: String, reqCode: Int): Notification.Action =
+        Notification.Action.Builder(
+            Icon.createWithResource(this, icon), label,
+            PendingIntent.getService(
+                this, reqCode, Intent(this, OfflineDownloadService::class.java).setAction(action),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            ),
+        ).build()
+
+    private fun createChannel() {
+        val channel = NotificationChannel(CHANNEL_ID, getString(R.string.offline_notif_channel), NotificationManager.IMPORTANCE_LOW).apply {
+            description = getString(R.string.offline_notif_channel_desc)
+            setShowBadge(false)
+        }
+        notificationManager().createNotificationChannel(channel)
+    }
+
+    private fun notificationManager() = getSystemService(NotificationManager::class.java)
+
+    companion object {
+        private const val CHANNEL_ID = "offline_downloads"
+        private const val NOTIF_ID = 43
+        private const val ACTION_PAUSE = "com.sigmundgranaas.turbo.expressive.OFFLINE_PAUSE"
+        private const val ACTION_RESUME = "com.sigmundgranaas.turbo.expressive.OFFLINE_RESUME"
+
+        /** Start (or keep alive) the foreground download service. Idempotent. */
+        fun start(context: Context) {
+            context.startForegroundService(Intent(context, OfflineDownloadService::class.java))
+        }
+    }
+}

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineDownloadService.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineDownloadService.kt
@@ -47,7 +47,11 @@ class OfflineDownloadService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var policyJob: Job? = null
     private var notifyJob: Job? = null
+    private var graceJob: Job? = null
     private var started = false
+    /** Have we observed actual work yet? Guards against tearing down during the gap
+     *  between startForegroundService and the new region appearing in the flow. */
+    private var sawWork = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -75,21 +79,31 @@ class OfflineDownloadService : Service() {
             }.distinctUntilChanged().collect { manager.setNetworkAllowed(it) }
         }
 
-        // Re-post the notification on progress; tear down when no work remains.
+        // Re-post the notification on progress; tear down once work that we've actually
+        // seen is finished. Don't tear down before any work appears (warm-up gap).
         notifyJob = scope.launch {
             manager.regions.collect { regions ->
-                if (regions.none { it.status == OfflineStatus.Downloading || it.status == OfflineStatus.Paused }) {
-                    teardown()
-                } else {
-                    notificationManager().notify(NOTIF_ID, buildNotification(regions))
+                val pending = regions.any { it.status == OfflineStatus.Downloading || it.status == OfflineStatus.Paused }
+                when {
+                    pending -> { sawWork = true; notificationManager().notify(NOTIF_ID, buildNotification(regions)) }
+                    sawWork -> teardown()
+                    else -> Unit // still warming up — keep foreground, wait for the region
                 }
             }
+        }
+
+        // Safety net: if a download never materialises (e.g. it failed instantly), don't
+        // hold the foreground service open forever.
+        graceJob = scope.launch {
+            kotlinx.coroutines.delay(STARTUP_GRACE_MS)
+            if (!sawWork) teardown()
         }
     }
 
     private fun teardown() {
         policyJob?.cancel()
         notifyJob?.cancel()
+        graceJob?.cancel()
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
@@ -97,6 +111,7 @@ class OfflineDownloadService : Service() {
     override fun onDestroy() {
         policyJob?.cancel()
         notifyJob?.cancel()
+        graceJob?.cancel()
         super.onDestroy()
     }
 
@@ -156,6 +171,7 @@ class OfflineDownloadService : Service() {
     companion object {
         private const val CHANNEL_ID = "offline_downloads"
         private const val NOTIF_ID = 43
+        private const val STARTUP_GRACE_MS = 15_000L
         private const val ACTION_PAUSE = "com.sigmundgranaas.turbo.expressive.OFFLINE_PAUSE"
         private const val ACTION_RESUME = "com.sigmundgranaas.turbo.expressive.OFFLINE_RESUME"
 

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineIndicatorViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineIndicatorViewModel.kt
@@ -1,0 +1,34 @@
+package com.sigmundgranaas.turbo.expressive.feature.offline
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sigmundgranaas.turbo.expressive.core.map.NetworkMonitor
+import com.sigmundgranaas.turbo.expressive.core.map.OfflineCoverage
+import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
+import com.sigmundgranaas.turbo.expressive.domain.LatLng
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * Feeds the map's "you're offline" affordance: whether the device currently has
+ * no validated connectivity, and whether a map position falls inside any
+ * downloaded region (so the chip can say "outside downloaded areas" — the moment
+ * a blank basemap most needs explaining).
+ */
+@HiltViewModel
+class OfflineIndicatorViewModel @Inject constructor(
+    network: NetworkMonitor,
+    private val manager: OfflineTileManager,
+) : ViewModel() {
+
+    val offline: StateFlow<Boolean> = network.state
+        .map { !it.connected }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** True when [centre] is inside a complete downloaded region. */
+    fun covered(centre: LatLng): Boolean = OfflineCoverage.covers(manager.regions.value, centre)
+}

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.DownloadDone
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.Pause
@@ -30,6 +32,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -38,6 +43,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,9 +58,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
 import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import com.sigmundgranaas.turbo.expressive.feature.map.R
-import com.sigmundgranaas.turbo.expressive.ui.components.ConfirmDeleteDialog
 import com.sigmundgranaas.turbo.expressive.ui.components.EmptyState
+import com.sigmundgranaas.turbo.expressive.ui.components.NameInputDialog
+import com.sigmundgranaas.turbo.expressive.ui.components.TurboConfirmDialog
 import com.sigmundgranaas.turbo.expressive.ui.theme.TurboRadius
+import kotlinx.coroutines.launch
+import java.text.DateFormat
+import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,15 +75,26 @@ fun OfflineMapsScreen(
     val cs = MaterialTheme.colorScheme
     val regions by viewModel.regions.collectAsStateWithLifecycle()
     val totalBytes = regions.sumOf { it.sizeBytes }
-    var pendingDelete by remember { mutableStateOf<OfflineRegionInfo?>(null) }
+    val snackbar = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    var renaming by remember { mutableStateOf<OfflineRegionInfo?>(null) }
+    var confirmClearCache by remember { mutableStateOf(false) }
+    val deletedMessage = stringResource(R.string.offline_deleted_snackbar)
+    val undoLabel = stringResource(R.string.offline_undo)
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbar) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.offline_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Rounded.ArrowBack, stringResource(R.string.offline_back))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { confirmClearCache = true }) {
+                        Icon(Icons.Rounded.DeleteSweep, stringResource(R.string.offline_clear_cache))
                     }
                 },
             )
@@ -103,7 +124,24 @@ fun OfflineMapsScreen(
                 items(regions, key = { it.id }) { region ->
                     RegionCard(
                         region = region,
-                        onDelete = { pendingDelete = region },
+                        // Delete is staged, not immediate: the region hides, and the
+                        // snackbar's Undo restores it untouched; letting it lapse commits.
+                        onDelete = {
+                            viewModel.stageDelete(region.id)
+                            scope.launch {
+                                val result = snackbar.showSnackbar(
+                                    message = deletedMessage.format(region.name),
+                                    actionLabel = undoLabel,
+                                    duration = androidx.compose.material3.SnackbarDuration.Short,
+                                )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    viewModel.undoDelete(region.id)
+                                } else {
+                                    viewModel.commitDelete(region.id)
+                                }
+                            }
+                        },
+                        onRename = { renaming = region },
                         onRetry = { viewModel.retry(region.id) },
                         onPause = { viewModel.pause(region.id) },
                         onResume = { viewModel.resume(region.id) },
@@ -114,11 +152,23 @@ fun OfflineMapsScreen(
         }
     }
 
-    pendingDelete?.let { target ->
-        ConfirmDeleteDialog(
-            itemName = target.name,
-            onConfirm = { viewModel.delete(target.id); pendingDelete = null },
-            onDismiss = { pendingDelete = null },
+    renaming?.let { target ->
+        NameInputDialog(
+            title = stringResource(R.string.offline_rename_title),
+            confirmLabel = stringResource(R.string.offline_rename_confirm),
+            initial = target.name,
+            onConfirm = { viewModel.rename(target.id, it); renaming = null },
+            onDismiss = { renaming = null },
+        )
+    }
+    if (confirmClearCache) {
+        TurboConfirmDialog(
+            title = stringResource(R.string.offline_clear_cache_title),
+            body = stringResource(R.string.offline_clear_cache_body),
+            confirmLabel = stringResource(R.string.offline_clear_cache_confirm),
+            icon = Icons.Rounded.DeleteSweep,
+            onConfirm = { viewModel.clearCache(); confirmClearCache = false },
+            onDismiss = { confirmClearCache = false },
         )
     }
 }
@@ -128,6 +178,7 @@ fun OfflineMapsScreen(
 private fun RegionCard(
     region: OfflineRegionInfo,
     onDelete: () -> Unit,
+    onRename: () -> Unit,
     onRetry: () -> Unit,
     onPause: () -> Unit,
     onResume: () -> Unit,
@@ -150,6 +201,7 @@ private fun RegionCard(
                     color = cs.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.clickable(onClick = onRename),
                 )
                 // The base map (+ any overlays) differentiates same-named regions and
                 // shows what's actually available offline (e.g. avalanche terrain).
@@ -164,7 +216,10 @@ private fun RegionCard(
                     OfflineStatus.Complete -> StatusLine(
                         icon = Icons.Rounded.DownloadDone,
                         tint = cs.primary,
-                        text = stringResource(R.string.offline_downloaded, formatSize(region.sizeBytes)),
+                        text = stringResource(R.string.offline_downloaded, formatSize(region.sizeBytes)) +
+                            region.createdAtEpochMs.takeIf { it > 0 }
+                                ?.let { " · " + DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(it)) }
+                                .orEmpty(),
                     )
                     OfflineStatus.Paused -> StatusLine(
                         icon = Icons.Rounded.PauseCircle,

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -134,11 +134,9 @@ fun OfflineMapsScreen(
                                     actionLabel = undoLabel,
                                     duration = androidx.compose.material3.SnackbarDuration.Short,
                                 )
-                                if (result == SnackbarResult.ActionPerformed) {
-                                    viewModel.undoDelete(region.id)
-                                } else {
-                                    viewModel.commitDelete(region.id)
-                                }
+                                // Undo cancels the pending commit; otherwise the
+                                // view-model commits the delete when the window lapses.
+                                if (result == SnackbarResult.ActionPerformed) viewModel.undoDelete(region.id)
                             }
                         },
                         onRename = { renaming = region },

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DownloadDone
 import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PauseCircle
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -103,6 +105,8 @@ fun OfflineMapsScreen(
                         region = region,
                         onDelete = { pendingDelete = region },
                         onRetry = { viewModel.retry(region.id) },
+                        onPause = { viewModel.pause(region.id) },
+                        onResume = { viewModel.resume(region.id) },
                     )
                 }
                 item { Spacer(Modifier.height(16.dp)) }
@@ -121,7 +125,13 @@ fun OfflineMapsScreen(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit, onRetry: () -> Unit) {
+private fun RegionCard(
+    region: OfflineRegionInfo,
+    onDelete: () -> Unit,
+    onRetry: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+) {
     val cs = MaterialTheme.colorScheme
     val regionDesc = stringResource(R.string.offline_region_desc, region.name)
     Surface(
@@ -187,6 +197,15 @@ private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit, onRetry:
                 }
             }
             Spacer(Modifier.size(8.dp))
+            when (region.status) {
+                OfflineStatus.Downloading -> IconButton(onClick = onPause) {
+                    Icon(Icons.Rounded.Pause, stringResource(R.string.offline_pause, region.name), tint = cs.onSurfaceVariant)
+                }
+                OfflineStatus.Paused -> IconButton(onClick = onResume) {
+                    Icon(Icons.Rounded.PlayArrow, stringResource(R.string.offline_resume, region.name), tint = cs.primary)
+                }
+                else -> Unit
+            }
             IconButton(onClick = onDelete) {
                 Icon(Icons.Rounded.Delete, stringResource(R.string.offline_delete, region.name), tint = cs.error)
             }

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -151,9 +151,11 @@ private fun RegionCard(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                // The base map differentiates same-named regions (e.g. two "Tromsø").
+                // The base map (+ any overlays) differentiates same-named regions and
+                // shows what's actually available offline (e.g. avalanche terrain).
                 Text(
-                    region.base.title,
+                    region.base.title + region.overlays.takeIf { it.isNotEmpty() }
+                        ?.joinToString(prefix = " · ") { it.title }.orEmpty(),
                     style = MaterialTheme.typography.labelSmall,
                     color = cs.onSurfaceVariant,
                 )

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -2,6 +2,7 @@ package com.sigmundgranaas.turbo.expressive.feature.offline
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,6 +18,9 @@ import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DownloadDone
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.PauseCircle
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -26,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import com.sigmundgranaas.turbo.expressive.feature.map.R
 import com.sigmundgranaas.turbo.expressive.ui.components.ConfirmDeleteDialog
 import com.sigmundgranaas.turbo.expressive.ui.components.EmptyState
@@ -93,7 +99,11 @@ fun OfflineMapsScreen(
                     )
                 }
                 items(regions, key = { it.id }) { region ->
-                    RegionCard(region = region, onDelete = { pendingDelete = region })
+                    RegionCard(
+                        region = region,
+                        onDelete = { pendingDelete = region },
+                        onRetry = { viewModel.retry(region.id) },
+                    )
                 }
                 item { Spacer(Modifier.height(16.dp)) }
             }
@@ -111,7 +121,7 @@ fun OfflineMapsScreen(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit) {
+private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit, onRetry: () -> Unit) {
     val cs = MaterialTheme.colorScheme
     val regionDesc = stringResource(R.string.offline_region_desc, region.name)
     Surface(
@@ -131,24 +141,49 @@ private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit) {
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                // The base map differentiates same-named regions (e.g. two "Tromsø").
+                Text(
+                    region.base.title,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = cs.onSurfaceVariant,
+                )
                 Spacer(Modifier.height(6.dp))
-                if (region.complete) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Rounded.DownloadDone, null, tint = cs.primary, modifier = Modifier.size(16.dp))
-                        Spacer(Modifier.size(6.dp))
-                        Text(stringResource(R.string.offline_downloaded, formatSize(region.sizeBytes)), style = MaterialTheme.typography.bodyMedium, color = cs.onSurfaceVariant)
+                when (region.status) {
+                    OfflineStatus.Complete -> StatusLine(
+                        icon = Icons.Rounded.DownloadDone,
+                        tint = cs.primary,
+                        text = stringResource(R.string.offline_downloaded, formatSize(region.sizeBytes)),
+                    )
+                    OfflineStatus.Paused -> StatusLine(
+                        icon = Icons.Rounded.PauseCircle,
+                        tint = cs.onSurfaceVariant,
+                        text = stringResource(R.string.offline_paused, (region.progress * 100).toInt()),
+                    )
+                    OfflineStatus.Failed -> {
+                        StatusLine(
+                            icon = Icons.Rounded.ErrorOutline,
+                            tint = cs.error,
+                            text = region.errorReason?.let { stringResource(R.string.offline_failed_reason, it) }
+                                ?: stringResource(R.string.offline_failed),
+                        )
+                        TextButton(onClick = onRetry, contentPadding = PaddingValues(horizontal = 4.dp)) {
+                            Icon(Icons.Rounded.Refresh, null, modifier = Modifier.size(16.dp))
+                            Spacer(Modifier.size(6.dp))
+                            Text(stringResource(R.string.offline_retry))
+                        }
                     }
-                } else {
-                    LinearWavyProgressIndicator(
-                        progress = { region.progress },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Spacer(Modifier.height(6.dp))
-                    Text(
-                        stringResource(R.string.offline_downloading, (region.progress * 100).toInt()),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = cs.onSurfaceVariant,
-                    )
+                    OfflineStatus.Downloading -> {
+                        LinearWavyProgressIndicator(
+                            progress = { region.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            stringResource(R.string.offline_downloading, (region.progress * 100).toInt()),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = cs.onSurfaceVariant,
+                        )
+                    }
                 }
             }
             Spacer(Modifier.size(8.dp))
@@ -156,6 +191,16 @@ private fun RegionCard(region: OfflineRegionInfo, onDelete: () -> Unit) {
                 Icon(Icons.Rounded.Delete, stringResource(R.string.offline_delete, region.name), tint = cs.error)
             }
         }
+    }
+}
+
+/** A small icon + caption row reused by the completed / paused / failed states. */
+@Composable
+private fun StatusLine(icon: androidx.compose.ui.graphics.vector.ImageVector, tint: androidx.compose.ui.graphics.Color, text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, null, tint = tint, modifier = Modifier.size(16.dp))
+        Spacer(Modifier.size(6.dp))
+        Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreen.kt
@@ -223,7 +223,7 @@ private fun StatusLine(icon: androidx.compose.ui.graphics.vector.ImageVector, ti
     }
 }
 
-private fun formatSize(bytes: Long): String = when {
+internal fun formatSize(bytes: Long): String = when {
     bytes >= 1_000_000_000 -> "%.1f GB".format(bytes / 1_000_000_000.0)
     bytes >= 1_000_000 -> "%.1f MB".format(bytes / 1_000_000.0)
     bytes >= 1_000 -> "%.0f kB".format(bytes / 1_000.0)

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineServiceModule.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineServiceModule.kt
@@ -1,0 +1,24 @@
+package com.sigmundgranaas.turbo.expressive.feature.offline
+
+import android.content.Context
+import com.sigmundgranaas.turbo.expressive.core.map.OfflineServiceLauncher
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the [OfflineServiceLauncher] the (core:map) tile manager calls to start the
+ * foreground download service, which lives in this feature module so it can see both
+ * the manager and the settings/network it coordinates.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object OfflineServiceModule {
+    @Provides
+    @Singleton
+    fun provideOfflineServiceLauncher(@ApplicationContext context: Context): OfflineServiceLauncher =
+        OfflineServiceLauncher { OfflineDownloadService.start(context) }
+}

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -65,7 +65,7 @@ class OfflineViewModel @Inject constructor(
         }
     }
 
-    /** Pre-flight estimate for the currently-visible [bounds]; null when nothing to size. */
+    /** Pre-flight tile/byte estimate (+ within-limits guard) for the visible [bounds]. */
     fun estimate(base: BaseLayer, bounds: GeoBounds, fromZoom: Double, overlays: Set<OverlayId> = emptySet()) =
         manager.estimate(
             DownloadSpec(

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -7,6 +7,7 @@ import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
 import com.sigmundgranaas.turbo.expressive.core.geo.formatCoords
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DetailLevel
 import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
@@ -47,36 +48,44 @@ class OfflineViewModel @Inject constructor(
         bounds: GeoBounds,
         fromZoom: Double,
         overlays: Set<OverlayId> = emptySet(),
+        detail: DetailLevel = DetailLevel.Standard,
     ) {
-        val minZoom = floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM)
-        val maxZoom = (minZoom + ZOOM_SPAN).coerceAtMost(MAX_ZOOM)
         viewModelScope.launch {
             val place = (reverseGeocode.describe(centre) as? Outcome.Success)?.value?.title
             manager.download(
-                DownloadSpec(
-                    name = place ?: formatCoords(centre),
-                    base = base,
-                    bounds = bounds,
-                    minZoom = minZoom,
-                    maxZoom = maxZoom,
-                    overlays = overlays,
-                ),
+                spec(place ?: formatCoords(centre), base, bounds, fromZoom, overlays, detail),
             )
         }
     }
 
     /** Pre-flight tile/byte estimate (+ within-limits guard) for the visible [bounds]. */
-    fun estimate(base: BaseLayer, bounds: GeoBounds, fromZoom: Double, overlays: Set<OverlayId> = emptySet()) =
-        manager.estimate(
-            DownloadSpec(
-                name = "",
-                base = base,
-                bounds = bounds,
-                minZoom = floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM),
-                maxZoom = (floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM) + ZOOM_SPAN).coerceAtMost(MAX_ZOOM),
-                overlays = overlays,
-            ),
+    fun estimate(
+        base: BaseLayer,
+        bounds: GeoBounds,
+        fromZoom: Double,
+        overlays: Set<OverlayId> = emptySet(),
+        detail: DetailLevel = DetailLevel.Standard,
+    ) = manager.estimate(spec("", base, bounds, fromZoom, overlays, detail))
+
+    /** One zoom policy for estimate + download, so the dialog's number is what ships. */
+    private fun spec(
+        name: String,
+        base: BaseLayer,
+        bounds: GeoBounds,
+        fromZoom: Double,
+        overlays: Set<OverlayId>,
+        detail: DetailLevel,
+    ): DownloadSpec {
+        val minZoom = floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM)
+        return DownloadSpec(
+            name = name,
+            base = base,
+            bounds = bounds,
+            minZoom = minZoom,
+            maxZoom = (minZoom + detail.zoomSpan).coerceAtMost(MAX_ZOOM),
+            overlays = overlays,
         )
+    }
 
     fun retry(id: Long) = manager.retry(id)
 
@@ -89,6 +98,5 @@ class OfflineViewModel @Inject constructor(
     private companion object {
         const val MIN_ZOOM = 8.0
         const val MAX_ZOOM = 16.0
-        const val ZOOM_SPAN = 4.0
     }
 }

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -14,7 +14,12 @@ import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
 import com.sigmundgranaas.turbo.expressive.domain.OverlayId
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.math.floor
@@ -30,7 +35,12 @@ class OfflineViewModel @Inject constructor(
     private val reverseGeocode: ReverseGeocodeRepository,
 ) : ViewModel() {
 
-    val regions: StateFlow<List<OfflineRegionInfo>> = manager.regions
+    /** Regions staged for deletion: hidden from the list while the undo snackbar runs. */
+    private val staged = MutableStateFlow<Set<Long>>(emptySet())
+
+    val regions: StateFlow<List<OfflineRegionInfo>> =
+        combine(manager.regions, staged) { list, hidden -> list.filterNot { it.id in hidden } }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, manager.regions.value)
 
     init { manager.refresh() }
 
@@ -93,7 +103,25 @@ class OfflineViewModel @Inject constructor(
 
     fun resume(id: Long) = manager.resume(id)
 
+    fun rename(id: Long, name: String) {
+        if (name.isNotBlank()) manager.rename(id, name.trim())
+    }
+
+    /** Hide the region while the undo snackbar runs; nothing is removed yet. */
+    fun stageDelete(id: Long) = staged.update { it + id }
+
+    /** Undo from the snackbar — the region was never actually deleted. */
+    fun undoDelete(id: Long) = staged.update { it - id }
+
+    /** The snackbar lapsed without undo: actually delete the region's tiles. */
+    fun commitDelete(id: Long) {
+        staged.update { it - id }
+        manager.delete(id)
+    }
+
     fun delete(id: Long) = manager.delete(id)
+
+    fun clearCache() = manager.clearAmbientCache()
 
     private companion object {
         const val MIN_ZOOM = 8.0

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -7,9 +7,11 @@ import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
 import com.sigmundgranaas.turbo.expressive.core.geo.formatCoords
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OverlayId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -39,14 +41,44 @@ class OfflineViewModel @Inject constructor(
      * Names the region by the reverse-geocoded place at [centre] ("Storfjellet" /
      * "Tromsø") rather than raw coordinates, falling back to coordinates off-grid.
      */
-    fun download(centre: LatLng, base: BaseLayer, bounds: GeoBounds, fromZoom: Double) {
+    fun download(
+        centre: LatLng,
+        base: BaseLayer,
+        bounds: GeoBounds,
+        fromZoom: Double,
+        overlays: Set<OverlayId> = emptySet(),
+    ) {
         val minZoom = floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM)
         val maxZoom = (minZoom + ZOOM_SPAN).coerceAtMost(MAX_ZOOM)
         viewModelScope.launch {
             val place = (reverseGeocode.describe(centre) as? Outcome.Success)?.value?.title
-            manager.download(place ?: formatCoords(centre), base, bounds, minZoom, maxZoom)
+            manager.download(
+                DownloadSpec(
+                    name = place ?: formatCoords(centre),
+                    base = base,
+                    bounds = bounds,
+                    minZoom = minZoom,
+                    maxZoom = maxZoom,
+                    overlays = overlays,
+                ),
+            )
         }
     }
+
+    /** Pre-flight estimate for the currently-visible [bounds]; null when nothing to size. */
+    fun estimate(base: BaseLayer, bounds: GeoBounds, fromZoom: Double, overlays: Set<OverlayId> = emptySet()) =
+        manager.estimate(
+            DownloadSpec(
+                name = "",
+                base = base,
+                bounds = bounds,
+                minZoom = floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM),
+                maxZoom = (floor(fromZoom).coerceIn(MIN_ZOOM, MAX_ZOOM) + ZOOM_SPAN).coerceAtMost(MAX_ZOOM),
+                overlays = overlays,
+            ),
+        )
+
+    fun retry(id: Long) = manager.retry(id)
 
     fun delete(id: Long) = manager.delete(id)
 

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -80,6 +80,10 @@ class OfflineViewModel @Inject constructor(
 
     fun retry(id: Long) = manager.retry(id)
 
+    fun pause(id: Long) = manager.pause(id)
+
+    fun resume(id: Long) = manager.resume(id)
+
     fun delete(id: Long) = manager.delete(id)
 
     private companion object {

--- a/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
+++ b/apps/android/feature/map/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModel.kt
@@ -14,6 +14,7 @@ import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
 import com.sigmundgranaas.turbo.expressive.domain.OverlayId
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -37,6 +38,7 @@ class OfflineViewModel @Inject constructor(
 
     /** Regions staged for deletion: hidden from the list while the undo snackbar runs. */
     private val staged = MutableStateFlow<Set<Long>>(emptySet())
+    private val deleteJobs = mutableMapOf<Long, kotlinx.coroutines.Job>()
 
     val regions: StateFlow<List<OfflineRegionInfo>> =
         combine(manager.regions, staged) { list, hidden -> list.filterNot { it.id in hidden } }
@@ -107,16 +109,27 @@ class OfflineViewModel @Inject constructor(
         if (name.isNotBlank()) manager.rename(id, name.trim())
     }
 
-    /** Hide the region while the undo snackbar runs; nothing is removed yet. */
-    fun stageDelete(id: Long) = staged.update { it + id }
+    /**
+     * Hide the region, then actually delete its tiles once the undo window lapses —
+     * unless [undoDelete] cancels first. The commit runs in [viewModelScope], not the
+     * snackbar's, so navigating away mid-undo still completes the delete (no orphaned
+     * hidden region).
+     */
+    fun stageDelete(id: Long) {
+        staged.update { it + id }
+        deleteJobs.remove(id)?.cancel()
+        deleteJobs[id] = viewModelScope.launch {
+            delay(UNDO_WINDOW_MS)
+            manager.delete(id)
+            staged.update { it - id }
+            deleteJobs.remove(id)
+        }
+    }
 
-    /** Undo from the snackbar — the region was never actually deleted. */
-    fun undoDelete(id: Long) = staged.update { it - id }
-
-    /** The snackbar lapsed without undo: actually delete the region's tiles. */
-    fun commitDelete(id: Long) {
+    /** Undo from the snackbar — cancel the pending commit and restore the region. */
+    fun undoDelete(id: Long) {
+        deleteJobs.remove(id)?.cancel()
         staged.update { it - id }
-        manager.delete(id)
     }
 
     fun delete(id: Long) = manager.delete(id)
@@ -126,5 +139,6 @@ class OfflineViewModel @Inject constructor(
     private companion object {
         const val MIN_ZOOM = 8.0
         const val MAX_ZOOM = 16.0
+        const val UNDO_WINDOW_MS = 4_500L
     }
 }

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -150,7 +150,15 @@
     <string name="offline_failed">Nedlasting mislyktes</string>
     <string name="offline_failed_reason">Nedlasting mislyktes · %1$s</string>
     <string name="offline_retry">Prøv igjen</string>
+    <string name="offline_pause">Sett %1$s på pause</string>
+    <string name="offline_resume">Fortsett %1$s</string>
     <string name="offline_delete">Slett %1$s</string>
+    <string name="offline_notif_channel">Nedlasting av frakoblede kart</string>
+    <string name="offline_notif_channel_desc">Fremdrift mens kartområder lastes ned</string>
+    <string name="offline_notif_title">Laster ned kart</string>
+    <string name="offline_notif_content">%1$d områder · %2$d %%</string>
+    <string name="offline_notif_pause">Pause</string>
+    <string name="offline_notif_resume">Fortsett</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>
         <item quantity="other">%1$d områder · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -178,6 +178,8 @@
     <string name="offline_clear_cache_title">Tømme kartbufferen?</string>
     <string name="offline_clear_cache_body">Fjerner midlertidig bufrede kartfliser fra utforsking. Nedlastede frakoblede områder beholdes.</string>
     <string name="offline_clear_cache_confirm">Tøm</string>
+    <string name="offline_chip">Du er frakoblet — viser lagrede kart</string>
+    <string name="offline_chip_uncovered">Frakoblet — utenfor nedlastede områder</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>
         <item quantity="other">%1$d områder · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -159,6 +159,11 @@
     <string name="offline_notif_content">%1$d områder · %2$d %%</string>
     <string name="offline_notif_pause">Pause</string>
     <string name="offline_notif_resume">Fortsett</string>
+    <string name="offline_download_title">Last ned dette området?</string>
+    <string name="offline_download_estimate">Omtrent %1$s · %2$d fliser lagres for frakoblet bruk.</string>
+    <string name="offline_download_too_large">Dette området er for stort (omtrent %1$s). Zoom inn og prøv igjen.</string>
+    <string name="offline_download_confirm">Last ned</string>
+    <string name="offline_download_cancel">Avbryt</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>
         <item quantity="other">%1$d områder · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -170,6 +170,14 @@
     <string name="offline_download_cancel">Avbryt</string>
     <string name="offline_detail_standard">Standard</string>
     <string name="offline_detail_detailed">Detaljert</string>
+    <string name="offline_deleted_snackbar">Slettet %1$s</string>
+    <string name="offline_undo">Angre</string>
+    <string name="offline_rename_title">Gi området nytt navn</string>
+    <string name="offline_rename_confirm">Gi nytt navn</string>
+    <string name="offline_clear_cache">Tøm kartbufferen</string>
+    <string name="offline_clear_cache_title">Tømme kartbufferen?</string>
+    <string name="offline_clear_cache_body">Fjerner midlertidig bufrede kartfliser fra utforsking. Nedlastede frakoblede områder beholdes.</string>
+    <string name="offline_clear_cache_confirm">Tøm</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>
         <item quantity="other">%1$d områder · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -130,6 +130,10 @@
     <string name="layers_trails_sub">Merkede ruter · Waymarked Trails</string>
     <string name="layers_avalanche">Skredterreng</string>
     <string name="layers_avalanche_sub">Brattheit ≥27° · NVE</string>
+    <string name="layers_waves">Bølgehøyde</string>
+    <string name="layers_waves_sub">Varmekart for dønninger</string>
+    <string name="layers_wind">Vind</string>
+    <string name="layers_wind_sub">Animert strømningsfelt</string>
     <string name="layers_offline">Frakoblet</string>
     <string name="layers_download_area">Last ned dette området</string>
 
@@ -164,6 +168,8 @@
     <string name="offline_download_too_large">Dette området er for stort (omtrent %1$s). Zoom inn og prøv igjen.</string>
     <string name="offline_download_confirm">Last ned</string>
     <string name="offline_download_cancel">Avbryt</string>
+    <string name="offline_detail_standard">Standard</string>
+    <string name="offline_detail_detailed">Detaljert</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>
         <item quantity="other">%1$d områder · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/map/src/main/res/values-nb/strings.xml
@@ -146,6 +146,10 @@
     <string name="offline_region_desc">frakoblet område %1$s</string>
     <string name="offline_downloaded">Lastet ned · %1$s</string>
     <string name="offline_downloading">Laster ned … %1$d %%</string>
+    <string name="offline_paused">Pauset · %1$d %%</string>
+    <string name="offline_failed">Nedlasting mislyktes</string>
+    <string name="offline_failed_reason">Nedlasting mislyktes · %1$s</string>
+    <string name="offline_retry">Prøv igjen</string>
     <string name="offline_delete">Slett %1$s</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d område · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -160,6 +160,11 @@
     <string name="offline_notif_content">%1$d areas · %2$d%%</string>
     <string name="offline_notif_pause">Pause</string>
     <string name="offline_notif_resume">Resume</string>
+    <string name="offline_download_title">Download this area?</string>
+    <string name="offline_download_estimate">About %1$s · %2$d tiles will be saved for offline use.</string>
+    <string name="offline_download_too_large">This area is too large (about %1$s). Zoom in and try again.</string>
+    <string name="offline_download_confirm">Download</string>
+    <string name="offline_download_cancel">Cancel</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>
         <item quantity="other">%1$d areas · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -171,6 +171,14 @@
     <string name="offline_download_cancel">Cancel</string>
     <string name="offline_detail_standard">Standard</string>
     <string name="offline_detail_detailed">Detailed</string>
+    <string name="offline_deleted_snackbar">Deleted %1$s</string>
+    <string name="offline_undo">Undo</string>
+    <string name="offline_rename_title">Rename area</string>
+    <string name="offline_rename_confirm">Rename</string>
+    <string name="offline_clear_cache">Clear map cache</string>
+    <string name="offline_clear_cache_title">Clear map cache?</string>
+    <string name="offline_clear_cache_body">Removes temporarily cached map tiles from browsing. Downloaded offline areas are kept.</string>
+    <string name="offline_clear_cache_confirm">Clear</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>
         <item quantity="other">%1$d areas · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -151,7 +151,15 @@
     <string name="offline_failed">Download failed</string>
     <string name="offline_failed_reason">Download failed · %1$s</string>
     <string name="offline_retry">Retry</string>
+    <string name="offline_pause">Pause %1$s</string>
+    <string name="offline_resume">Resume %1$s</string>
     <string name="offline_delete">Delete %1$s</string>
+    <string name="offline_notif_channel">Offline map downloads</string>
+    <string name="offline_notif_channel_desc">Progress while map areas download</string>
+    <string name="offline_notif_title">Downloading maps</string>
+    <string name="offline_notif_content">%1$d areas · %2$d%%</string>
+    <string name="offline_notif_pause">Pause</string>
+    <string name="offline_notif_resume">Resume</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>
         <item quantity="other">%1$d areas · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -130,6 +130,10 @@
     <string name="layers_trails_sub">Marked routes · Waymarked Trails</string>
     <string name="layers_avalanche">Avalanche terrain</string>
     <string name="layers_avalanche_sub">Slope steepness ≥27° · NVE</string>
+    <string name="layers_waves">Wave height</string>
+    <string name="layers_waves_sub">Marine swell heatmap</string>
+    <string name="layers_wind">Wind</string>
+    <string name="layers_wind_sub">Animated flow field</string>
     <string name="layers_offline">Offline</string>
     <string name="layers_download_area">Download this area</string>
 
@@ -165,6 +169,8 @@
     <string name="offline_download_too_large">This area is too large (about %1$s). Zoom in and try again.</string>
     <string name="offline_download_confirm">Download</string>
     <string name="offline_download_cancel">Cancel</string>
+    <string name="offline_detail_standard">Standard</string>
+    <string name="offline_detail_detailed">Detailed</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>
         <item quantity="other">%1$d areas · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -147,6 +147,10 @@
     <string name="offline_region_desc">offline region %1$s</string>
     <string name="offline_downloaded">Downloaded · %1$s</string>
     <string name="offline_downloading">Downloading… %1$d%%</string>
+    <string name="offline_paused">Paused · %1$d%%</string>
+    <string name="offline_failed">Download failed</string>
+    <string name="offline_failed_reason">Download failed · %1$s</string>
+    <string name="offline_retry">Retry</string>
     <string name="offline_delete">Delete %1$s</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>

--- a/apps/android/feature/map/src/main/res/values/strings.xml
+++ b/apps/android/feature/map/src/main/res/values/strings.xml
@@ -179,6 +179,8 @@
     <string name="offline_clear_cache_title">Clear map cache?</string>
     <string name="offline_clear_cache_body">Removes temporarily cached map tiles from browsing. Downloaded offline areas are kept.</string>
     <string name="offline_clear_cache_confirm">Clear</string>
+    <string name="offline_chip">You\'re offline — showing saved maps</string>
+    <string name="offline_chip_uncovered">Offline — outside downloaded areas</string>
     <plurals name="offline_summary">
         <item quantity="one">%1$d area · %2$s</item>
         <item quantity="other">%1$d areas · %2$s</item>

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/MapViewModelTest.kt
@@ -5,11 +5,15 @@ import com.sigmundgranaas.turbo.expressive.core.data.LocationRepository
 import com.sigmundgranaas.turbo.expressive.core.data.LocationSample
 import com.sigmundgranaas.turbo.expressive.core.data.MarkerRepository
 import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
+import com.sigmundgranaas.turbo.expressive.core.data.SettingsRepository
 import com.sigmundgranaas.turbo.expressive.domain.ActivityKindId
+import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.LocationDescription
 import com.sigmundgranaas.turbo.expressive.domain.Marker
 import com.sigmundgranaas.turbo.expressive.domain.PlaceQualifier
+import com.sigmundgranaas.turbo.expressive.domain.ThemeMode
+import com.sigmundgranaas.turbo.expressive.domain.UserSettings
 import com.sigmundgranaas.turbo.expressive.ui.theme.labelRes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -54,6 +58,18 @@ private class FakeStringProvider : com.sigmundgranaas.turbo.expressive.core.comm
     override fun get(id: Int, vararg formatArgs: Any): String = "s$id:" + formatArgs.joinToString()
 }
 
+private class FakeSettings : SettingsRepository {
+    val state = MutableStateFlow(UserSettings())
+    override val settings: Flow<UserSettings> = state
+    override suspend fun setCompassOrientation(enabled: Boolean) = Unit
+    override suspend fun setFollowLocation(enabled: Boolean) = Unit
+    override suspend fun setMetricUnits(metric: Boolean) = Unit
+    override suspend fun setThemeMode(mode: ThemeMode) = Unit
+    override suspend fun setCloudSyncEnabled(enabled: Boolean) = Unit
+    override suspend fun setDownloadOverWifiOnly(enabled: Boolean) = Unit
+    override suspend fun setBaseLayer(layer: BaseLayer) { state.value = state.value.copy(baseLayer = layer) }
+}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class MapViewModelTest {
 
@@ -63,7 +79,7 @@ class MapViewModelTest {
     @Test
     fun `addMarker persists and surfaces in state`() = runTest(mainRule.dispatcher) {
         val markers = FakeMarkerRepository()
-        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.addMarker("Camp", ActivityKindId.Camping, LatLng(69.0, 18.0))
         advanceUntilIdle()
 
@@ -75,7 +91,7 @@ class MapViewModelTest {
     @Test
     fun `addMarker keeps the chosen colour and notes`() = runTest(mainRule.dispatcher) {
         val markers = FakeMarkerRepository()
-        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.addMarker("Hut", ActivityKindId.Cabin, LatLng(69.0, 18.0), colorArgb = 0xFF1A73E8, notes = "spring water nearby")
         advanceUntilIdle()
 
@@ -88,7 +104,7 @@ class MapViewModelTest {
     fun `updateMarker replaces the row in place`() = runTest(mainRule.dispatcher) {
         val markers = FakeMarkerRepository()
         markers.markers.value = listOf(Marker("m1", "Old", ActivityKindId.Cabin, LatLng(69.0, 18.0)))
-        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         advanceUntilIdle()
 
         vm.updateMarker(
@@ -107,7 +123,7 @@ class MapViewModelTest {
     fun `blank name falls back to the kind label`() = runTest(mainRule.dispatcher) {
         val markers = FakeMarkerRepository()
         val strings = FakeStringProvider()
-        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), strings)
+        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), strings, FakeSettings())
         vm.addMarker("  ", ActivityKindId.Cabin, LatLng(69.0, 18.0))
         advanceUntilIdle()
         assertEquals(strings.get(ActivityKindId.Cabin.labelRes), vm.state.value.markers[0].name)
@@ -117,7 +133,7 @@ class MapViewModelTest {
     fun `deleteMarker removes it`() = runTest(mainRule.dispatcher) {
         val markers = FakeMarkerRepository()
         markers.markers.value = listOf(Marker("m1", "A", ActivityKindId.Cabin, LatLng(69.0, 18.0)))
-        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(markers, FakeLocationRepository(), FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         advanceUntilIdle()
         assertEquals(1, vm.state.value.markers.size)
 
@@ -129,7 +145,7 @@ class MapViewModelTest {
     @Test
     fun `enableLocation streams fixes into state`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = true)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.enableLocation()
         runCurrent()
         location.fixes.emit(LatLng(69.65, 18.95))
@@ -141,7 +157,7 @@ class MapViewModelTest {
     @Test
     fun `enableLocation is a no-op without permission`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = false)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.enableLocation()
         runCurrent()
         location.fixes.emit(LatLng(1.0, 2.0))
@@ -152,7 +168,7 @@ class MapViewModelTest {
     @Test
     fun `enableLocation marks locating until the first fix arrives`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = true)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.enableLocation()
         runCurrent()
         assertTrue(vm.state.value.locating)
@@ -165,7 +181,7 @@ class MapViewModelTest {
     @Test
     fun `beginInitialLocate flags ServicesOff when location is disabled`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = true, enabled = false)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.beginInitialLocate()
         runCurrent()
         assertEquals(LocationNotice.ServicesOff, vm.state.value.locationNotice)
@@ -175,7 +191,7 @@ class MapViewModelTest {
     @Test
     fun `beginInitialLocate times out to a notice when no fix arrives`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = true, enabled = true)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.beginInitialLocate()
         runCurrent()
         assertTrue(vm.state.value.locating)
@@ -188,7 +204,7 @@ class MapViewModelTest {
     @Test
     fun `a late fix after timeout still recentres and clears the notice`() = runTest(mainRule.dispatcher) {
         val location = FakeLocationRepository(permitted = true, enabled = true)
-        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), location, FakeReverseGeocodeRepository(), FakeStringProvider(), FakeSettings())
         vm.beginInitialLocate()
         advanceTimeBy(13_000)
         runCurrent()
@@ -204,7 +220,7 @@ class MapViewModelTest {
         val geocoder = FakeReverseGeocodeRepository(
             LocationDescription("Galdhøpiggen", PlaceQualifier.On, "fjelltopp", 2469.0),
         )
-        val vm = MapViewModel(FakeMarkerRepository(), FakeLocationRepository(), geocoder, FakeStringProvider())
+        val vm = MapViewModel(FakeMarkerRepository(), FakeLocationRepository(), geocoder, FakeStringProvider(), FakeSettings())
         vm.describePoint(LatLng(61.636, 8.313))
         advanceUntilIdle()
         assertEquals("Galdhøpiggen", vm.pointDescription.value?.title)

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
@@ -10,8 +10,10 @@ import com.sigmundgranaas.turbo.expressive.core.data.RouteRepository
 import com.sigmundgranaas.turbo.expressive.core.geo.GeoPathSource
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
 import com.sigmundgranaas.turbo.expressive.domain.RoutePlan
 import com.sigmundgranaas.turbo.expressive.domain.RoutePreset
@@ -45,9 +47,11 @@ private class FakeOfflineTileManager : OfflineTileManager {
     var lastBounds: GeoBounds? = null
     override val regions = MutableStateFlow<List<OfflineRegionInfo>>(emptyList())
     override fun refresh() = Unit
-    override fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double) {
-        downloads++; lastBounds = bounds
+    override fun download(spec: DownloadSpec) {
+        downloads++; lastBounds = spec.bounds
     }
+    override fun retry(id: Long) = Unit
+    override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) = Unit
 }
 

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
@@ -54,6 +54,8 @@ private class FakeOfflineTileManager : OfflineTileManager {
     override fun pause(id: Long) = Unit
     override fun resume(id: Long) = Unit
     override fun setNetworkAllowed(allowed: Boolean) = Unit
+    override fun rename(id: Long, name: String) = Unit
+    override fun clearAmbientCache() = Unit
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) = Unit
 }

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/map/RouteViewModelTest.kt
@@ -51,6 +51,9 @@ private class FakeOfflineTileManager : OfflineTileManager {
         downloads++; lastBounds = spec.bounds
     }
     override fun retry(id: Long) = Unit
+    override fun pause(id: Long) = Unit
+    override fun resume(id: Long) = Unit
+    override fun setNetworkAllowed(allowed: Boolean) = Unit
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) = Unit
 }

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialogTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialogTest.kt
@@ -6,8 +6,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.sigmundgranaas.turbo.expressive.domain.DetailLevel
 import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,28 +24,42 @@ class DownloadAreaDialogTest {
     @get:Rule
     val composeRule = createComposeRule()
 
+    private val small = OfflineEstimate(tiles = 1_200, bytes = 24_000_000, withinLimits = true)
+    private val huge = OfflineEstimate(tiles = 999_999, bytes = 2_000_000_000, withinLimits = false)
+
     @Test
-    fun `within limits enables download and confirms`() {
-        var confirmed = false
+    fun `within limits enables download and confirms with the chosen detail`() {
+        var confirmed: DetailLevel? = null
+        composeRule.setContent {
+            DownloadAreaDialog(estimateFor = { small }, onConfirm = { confirmed = it }, onDismiss = {})
+        }
+        composeRule.onNodeWithTag("downloadConfirm").assertIsEnabled().performClick()
+        assertEquals(DetailLevel.Standard, confirmed)
+    }
+
+    @Test
+    fun `switching to Detailed re-estimates and confirms Detailed`() {
+        var confirmed: DetailLevel? = null
         composeRule.setContent {
             DownloadAreaDialog(
-                estimate = OfflineEstimate(tiles = 1_200, bytes = 24_000_000, withinLimits = true),
-                onConfirm = { confirmed = true },
+                // Detailed pushes this area over the limit; Standard stays fine.
+                estimateFor = { if (it == DetailLevel.Detailed) huge else small },
+                onConfirm = { confirmed = it },
                 onDismiss = {},
             )
         }
+        composeRule.onNodeWithTag("downloadConfirm").assertIsEnabled()
+        composeRule.onNodeWithTag("detail_Detailed").performClick()
+        composeRule.onNodeWithTag("downloadConfirm").assertIsNotEnabled()
+        composeRule.onNodeWithTag("detail_Standard").performClick()
         composeRule.onNodeWithTag("downloadConfirm").assertIsEnabled().performClick()
-        assertTrue(confirmed)
+        assertEquals(DetailLevel.Standard, confirmed)
     }
 
     @Test
     fun `an over-limit area disables download and explains why`() {
         composeRule.setContent {
-            DownloadAreaDialog(
-                estimate = OfflineEstimate(tiles = 999_999, bytes = 2_000_000_000, withinLimits = false),
-                onConfirm = {},
-                onDismiss = {},
-            )
+            DownloadAreaDialog(estimateFor = { huge }, onConfirm = {}, onDismiss = {})
         }
         composeRule.onNodeWithTag("downloadConfirm").assertIsNotEnabled()
         composeRule.onNodeWithText("Zoom in", substring = true).assertExists()

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialogTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/DownloadAreaDialogTest.kt
@@ -1,0 +1,52 @@
+package com.sigmundgranaas.turbo.expressive.feature.offline
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34])
+class DownloadAreaDialogTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `within limits enables download and confirms`() {
+        var confirmed = false
+        composeRule.setContent {
+            DownloadAreaDialog(
+                estimate = OfflineEstimate(tiles = 1_200, bytes = 24_000_000, withinLimits = true),
+                onConfirm = { confirmed = true },
+                onDismiss = {},
+            )
+        }
+        composeRule.onNodeWithTag("downloadConfirm").assertIsEnabled().performClick()
+        assertTrue(confirmed)
+    }
+
+    @Test
+    fun `an over-limit area disables download and explains why`() {
+        composeRule.setContent {
+            DownloadAreaDialog(
+                estimate = OfflineEstimate(tiles = 999_999, bytes = 2_000_000_000, withinLimits = false),
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+        composeRule.onNodeWithTag("downloadConfirm").assertIsNotEnabled()
+        composeRule.onNodeWithText("Zoom in", substring = true).assertExists()
+    }
+}

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
@@ -1,10 +1,12 @@
 package com.sigmundgranaas.turbo.expressive.feature.offline
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
 import com.sigmundgranaas.turbo.expressive.core.common.Outcome
 import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
@@ -35,6 +37,9 @@ private class StubOfflineTileManager(initial: List<OfflineRegionInfo>) : Offline
     override fun pause(id: Long) = Unit
     override fun resume(id: Long) = Unit
     override fun setNetworkAllowed(allowed: Boolean) = Unit
+    override fun rename(id: Long, name: String) { renamed += id to name }
+    override fun clearAmbientCache() = Unit
+    val renamed = mutableListOf<Pair<Long, String>>()
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id
@@ -88,7 +93,7 @@ class OfflineMapsScreenTest {
     }
 
     @Test
-    fun `tapping delete removes the region`() {
+    fun `delete is staged with an undo snackbar - undo restores the region`() {
         val region = OfflineRegionInfo(id = 9, name = "Lofoten", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 12_000_000)
         val manager = StubOfflineTileManager(listOf(region))
         composeRule.setContent {
@@ -96,11 +101,27 @@ class OfflineMapsScreenTest {
         }
         composeRule.onNodeWithContentDescription("Delete Lofoten").performClick()
         composeRule.waitForIdle()
-        // Tapping delete only opens the confirmation — nothing removed yet.
+        // Hidden from the list, but nothing actually deleted while the snackbar runs.
         assertTrue(manager.deleted.isEmpty())
-        composeRule.onNodeWithText("Delete").performClick()
-        composeRule.waitForIdle()
-        assertTrue(manager.deleted.contains(9L))
         composeRule.onNodeWithText("No offline maps yet").assertIsDisplayed()
+
+        composeRule.onNodeWithText("Undo").performClick()
+        composeRule.waitForIdle()
+        assertTrue(manager.deleted.isEmpty())
+        composeRule.onNodeWithText("Lofoten").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the name opens rename and forwards the new name`() {
+        val region = OfflineRegionInfo(id = 4, name = "Tromsø", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000_000)
+        val manager = StubOfflineTileManager(listOf(region))
+        composeRule.setContent {
+            OfflineMapsScreen(onBack = {}, viewModel = OfflineViewModel(manager, stubGeo))
+        }
+        composeRule.onNodeWithText("Tromsø").performClick()
+        composeRule.onNode(hasSetTextAction()).performTextReplacement("Kvaløya")
+        composeRule.onNodeWithText("Rename").performClick()
+        composeRule.waitForIdle()
+        assertTrue(manager.renamed.contains(4L to "Kvaløya"))
     }
 }

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
@@ -32,6 +32,9 @@ private class StubOfflineTileManager(initial: List<OfflineRegionInfo>) : Offline
     override fun refresh() = Unit
     override fun download(spec: DownloadSpec) = Unit
     override fun retry(id: Long) { retried += id }
+    override fun pause(id: Long) = Unit
+    override fun resume(id: Long) = Unit
+    override fun setNetworkAllowed(allowed: Boolean) = Unit
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineMapsScreenTest.kt
@@ -8,11 +8,12 @@ import androidx.compose.ui.test.performClick
 import com.sigmundgranaas.turbo.expressive.core.common.Outcome
 import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
-import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
-import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.LocationDescription
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Assert.assertTrue
@@ -27,8 +28,11 @@ private class StubOfflineTileManager(initial: List<OfflineRegionInfo>) : Offline
     private val flow = MutableStateFlow(initial)
     override val regions: StateFlow<List<OfflineRegionInfo>> = flow
     val deleted = mutableListOf<Long>()
+    val retried = mutableListOf<Long>()
     override fun refresh() = Unit
-    override fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double) = Unit
+    override fun download(spec: DownloadSpec) = Unit
+    override fun retry(id: Long) { retried += id }
+    override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id
         flow.value = flow.value.filterNot { it.id == id }
@@ -57,7 +61,7 @@ class OfflineMapsScreenTest {
 
     @Test
     fun `a downloading region shows its name and progress`() {
-        val region = OfflineRegionInfo(id = 1, name = "Tromsø", complete = false, progress = 0.42f, sizeBytes = 5_000_000)
+        val region = OfflineRegionInfo(id = 1, name = "Tromsø", status = OfflineStatus.Downloading, progress = 0.42f, sizeBytes = 5_000_000)
         composeRule.setContent {
             OfflineMapsScreen(onBack = {}, viewModel = OfflineViewModel(StubOfflineTileManager(listOf(region)), stubGeo))
         }
@@ -66,8 +70,23 @@ class OfflineMapsScreenTest {
     }
 
     @Test
+    fun `a failed region offers retry which calls the manager`() {
+        val region = OfflineRegionInfo(
+            id = 3, name = "Senja", status = OfflineStatus.Failed, progress = 0f, sizeBytes = 0,
+            errorReason = "Area too large",
+        )
+        val manager = StubOfflineTileManager(listOf(region))
+        composeRule.setContent {
+            OfflineMapsScreen(onBack = {}, viewModel = OfflineViewModel(manager, stubGeo))
+        }
+        composeRule.onNodeWithText("Retry").performClick()
+        composeRule.waitForIdle()
+        assertTrue(manager.retried.contains(3L))
+    }
+
+    @Test
     fun `tapping delete removes the region`() {
-        val region = OfflineRegionInfo(id = 9, name = "Lofoten", complete = true, progress = 1f, sizeBytes = 12_000_000)
+        val region = OfflineRegionInfo(id = 9, name = "Lofoten", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 12_000_000)
         val manager = StubOfflineTileManager(listOf(region))
         composeRule.setContent {
             OfflineMapsScreen(onBack = {}, viewModel = OfflineViewModel(manager, stubGeo))

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
@@ -16,7 +16,9 @@ import com.sigmundgranaas.turbo.expressive.feature.map.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -115,25 +117,35 @@ class OfflineViewModelTest {
     }
 
     @Test
-    fun `staged delete hides the region, undo restores it, commit deletes it`() = runTest(mainRule.dispatcher) {
+    fun `staged delete hides the region then auto-commits after the undo window`() = runTest(mainRule.dispatcher) {
         val region = OfflineRegionInfo(id = 7, name = "A", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000)
         val manager = FakeOfflineTileManager(listOf(region))
         val vm = OfflineViewModel(manager, FakeReverseGeocode("A"))
-        advanceUntilIdle()
+        runCurrent()
 
         vm.stageDelete(7)
-        advanceUntilIdle()
+        runCurrent()
         assertTrue("hidden while staged", vm.regions.value.isEmpty())
-        assertTrue("nothing deleted yet", manager.deleted.isEmpty())
+        assertTrue("not deleted during the undo window", manager.deleted.isEmpty())
 
-        vm.undoDelete(7)
-        advanceUntilIdle()
-        assertEquals(listOf(region), vm.regions.value)
+        advanceTimeBy(5_000)
+        runCurrent()
+        assertTrue("committed after the window", manager.deleted.contains(7))
+    }
+
+    @Test
+    fun `undo within the window cancels the delete and restores the region`() = runTest(mainRule.dispatcher) {
+        val region = OfflineRegionInfo(id = 7, name = "A", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000)
+        val manager = FakeOfflineTileManager(listOf(region))
+        val vm = OfflineViewModel(manager, FakeReverseGeocode("A"))
+        runCurrent()
 
         vm.stageDelete(7)
-        vm.commitDelete(7)
-        advanceUntilIdle()
-        assertTrue(manager.deleted.contains(7))
-        assertTrue(vm.regions.value.isEmpty())
+        runCurrent()
+        vm.undoDelete(7)
+        advanceTimeBy(10_000)
+        runCurrent()
+        assertEquals(listOf(region), vm.regions.value)
+        assertTrue("never deleted", manager.deleted.isEmpty())
     }
 }

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
@@ -4,10 +4,13 @@ import com.sigmundgranaas.turbo.expressive.core.common.Outcome
 import com.sigmundgranaas.turbo.expressive.core.data.ReverseGeocodeRepository
 import com.sigmundgranaas.turbo.expressive.core.map.OfflineTileManager
 import com.sigmundgranaas.turbo.expressive.domain.BaseLayer
+import com.sigmundgranaas.turbo.expressive.domain.DownloadSpec
 import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.LatLng
 import com.sigmundgranaas.turbo.expressive.domain.LocationDescription
+import com.sigmundgranaas.turbo.expressive.domain.OfflineEstimate
 import com.sigmundgranaas.turbo.expressive.domain.OfflineRegionInfo
+import com.sigmundgranaas.turbo.expressive.domain.OfflineStatus
 import com.sigmundgranaas.turbo.expressive.domain.PlaceQualifier
 import com.sigmundgranaas.turbo.expressive.feature.map.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,19 +24,18 @@ import org.junit.Rule
 import org.junit.Test
 
 private class FakeOfflineTileManager(initial: List<OfflineRegionInfo> = emptyList()) : OfflineTileManager {
-    data class Download(val name: String, val base: BaseLayer, val bounds: GeoBounds, val minZoom: Double, val maxZoom: Double)
-
     private val flow = MutableStateFlow(initial)
     override val regions: StateFlow<List<OfflineRegionInfo>> = flow
 
     var refreshCount = 0
-    var lastDownload: Download? = null
+    var lastDownload: DownloadSpec? = null
     val deleted = mutableListOf<Long>()
+    val retried = mutableListOf<Long>()
 
     override fun refresh() { refreshCount++ }
-    override fun download(name: String, base: BaseLayer, bounds: GeoBounds, minZoom: Double, maxZoom: Double) {
-        lastDownload = Download(name, base, bounds, minZoom, maxZoom)
-    }
+    override fun download(spec: DownloadSpec) { lastDownload = spec }
+    override fun retry(id: Long) { retried += id }
+    override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id
         flow.value = flow.value.filterNot { it.id == id }
@@ -98,7 +100,7 @@ class OfflineViewModelTest {
     @Test
     fun `delete forwards to the manager and removes the region`() {
         val manager = FakeOfflineTileManager(
-            listOf(OfflineRegionInfo(id = 7, name = "A", complete = true, progress = 1f, sizeBytes = 1_000)),
+            listOf(OfflineRegionInfo(id = 7, name = "A", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000)),
         )
         val vm = OfflineViewModel(manager, FakeReverseGeocode("A"))
         vm.delete(7)

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
@@ -38,6 +38,8 @@ private class FakeOfflineTileManager(initial: List<OfflineRegionInfo> = emptyLis
     override fun pause(id: Long) = Unit
     override fun resume(id: Long) = Unit
     override fun setNetworkAllowed(allowed: Boolean) = Unit
+    override fun rename(id: Long, name: String) = Unit
+    override fun clearAmbientCache() = Unit
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id
@@ -101,12 +103,36 @@ class OfflineViewModelTest {
     }
 
     @Test
-    fun `delete forwards to the manager and removes the region`() {
+    fun `delete forwards to the manager and removes the region`() = runTest(mainRule.dispatcher) {
         val manager = FakeOfflineTileManager(
             listOf(OfflineRegionInfo(id = 7, name = "A", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000)),
         )
         val vm = OfflineViewModel(manager, FakeReverseGeocode("A"))
         vm.delete(7)
+        advanceUntilIdle()
+        assertTrue(manager.deleted.contains(7))
+        assertTrue(vm.regions.value.isEmpty())
+    }
+
+    @Test
+    fun `staged delete hides the region, undo restores it, commit deletes it`() = runTest(mainRule.dispatcher) {
+        val region = OfflineRegionInfo(id = 7, name = "A", status = OfflineStatus.Complete, progress = 1f, sizeBytes = 1_000)
+        val manager = FakeOfflineTileManager(listOf(region))
+        val vm = OfflineViewModel(manager, FakeReverseGeocode("A"))
+        advanceUntilIdle()
+
+        vm.stageDelete(7)
+        advanceUntilIdle()
+        assertTrue("hidden while staged", vm.regions.value.isEmpty())
+        assertTrue("nothing deleted yet", manager.deleted.isEmpty())
+
+        vm.undoDelete(7)
+        advanceUntilIdle()
+        assertEquals(listOf(region), vm.regions.value)
+
+        vm.stageDelete(7)
+        vm.commitDelete(7)
+        advanceUntilIdle()
         assertTrue(manager.deleted.contains(7))
         assertTrue(vm.regions.value.isEmpty())
     }

--- a/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
+++ b/apps/android/feature/map/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/offline/OfflineViewModelTest.kt
@@ -35,6 +35,9 @@ private class FakeOfflineTileManager(initial: List<OfflineRegionInfo> = emptyLis
     override fun refresh() { refreshCount++ }
     override fun download(spec: DownloadSpec) { lastDownload = spec }
     override fun retry(id: Long) { retried += id }
+    override fun pause(id: Long) = Unit
+    override fun resume(id: Long) = Unit
+    override fun setNetworkAllowed(allowed: Boolean) = Unit
     override fun estimate(spec: DownloadSpec) = OfflineEstimate(tiles = 0, bytes = 0)
     override fun delete(id: Long) {
         deleted += id

--- a/apps/android/feature/settings/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.rounded.MyLocation
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.CloudSync
 import androidx.compose.material.icons.rounded.Straighten
+import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -145,6 +146,12 @@ fun SettingsScreen(
                     Icons.Rounded.CloudSync, stringResource(R.string.settings_cloud_sync),
                     subtitle = stringResource(R.string.settings_cloud_sync_sub),
                     trailing = { Switch(settings.cloudSyncEnabled, { haptics.toggle(it); viewModel.setCloudSync(it) }, modifier = Modifier.testTag("cloudSyncSwitch")) },
+                )
+                HorizontalDivider(color = cs.outlineVariant)
+                ListRowItem(
+                    Icons.Rounded.Wifi, stringResource(R.string.settings_wifi_only),
+                    subtitle = stringResource(R.string.settings_wifi_only_sub),
+                    trailing = { Switch(settings.downloadOverWifiOnly, { haptics.toggle(it); viewModel.setWifiOnly(it) }, modifier = Modifier.testTag("wifiOnlySwitch")) },
                 )
             }
             SettingsGroup {

--- a/apps/android/feature/settings/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModel.kt
@@ -29,4 +29,5 @@ class SettingsViewModel @Inject constructor(
     fun setMetric(metric: Boolean) = viewModelScope.launch { repository.setMetricUnits(metric) }
     fun setThemeMode(mode: ThemeMode) = viewModelScope.launch { repository.setThemeMode(mode) }
     fun setCloudSync(enabled: Boolean) = viewModelScope.launch { repository.setCloudSyncEnabled(enabled) }
+    fun setWifiOnly(enabled: Boolean) = viewModelScope.launch { repository.setDownloadOverWifiOnly(enabled) }
 }

--- a/apps/android/feature/settings/src/main/res/values-nb/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values-nb/strings.xml
@@ -31,4 +31,6 @@
     <string name="about_terms">Vilkår for bruk</string>
     <string name="settings_cloud_sync">Skysynk</string>
     <string name="settings_cloud_sync_sub">Sikkerhetskopier spor, markører og samlinger til kontoen din</string>
+    <string name="settings_wifi_only">Last bare ned over Wi-Fi</string>
+    <string name="settings_wifi_only_sub">Sett nedlasting av frakoblede kart på pause på mobildata</string>
 </resources>

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -31,4 +31,6 @@
     <string name="about_terms">Terms of use</string>
     <string name="settings_cloud_sync">Cloud sync</string>
     <string name="settings_cloud_sync_sub">Back up tracks, markers and collections to your account</string>
+    <string name="settings_wifi_only">Download over Wi-Fi only</string>
+    <string name="settings_wifi_only_sub">Pause offline map downloads on mobile data</string>
 </resources>

--- a/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreenTest.kt
+++ b/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreenTest.kt
@@ -28,6 +28,7 @@ private class FakeSettingsRepository : SettingsRepository {
     override suspend fun setThemeMode(mode: ThemeMode) = state.update { it.copy(themeMode = mode) }
     override suspend fun setCloudSyncEnabled(enabled: Boolean) = state.update { it.copy(cloudSyncEnabled = enabled) }
     override suspend fun setDownloadOverWifiOnly(enabled: Boolean) = state.update { it.copy(downloadOverWifiOnly = enabled) }
+    override suspend fun setBaseLayer(layer: com.sigmundgranaas.turbo.expressive.domain.BaseLayer) = state.update { it.copy(baseLayer = layer) }
 }
 
 @RunWith(RobolectricTestRunner::class)

--- a/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreenTest.kt
+++ b/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsScreenTest.kt
@@ -27,6 +27,7 @@ private class FakeSettingsRepository : SettingsRepository {
     override suspend fun setMetricUnits(metric: Boolean) = state.update { it.copy(metricUnits = metric) }
     override suspend fun setThemeMode(mode: ThemeMode) = state.update { it.copy(themeMode = mode) }
     override suspend fun setCloudSyncEnabled(enabled: Boolean) = state.update { it.copy(cloudSyncEnabled = enabled) }
+    override suspend fun setDownloadOverWifiOnly(enabled: Boolean) = state.update { it.copy(downloadOverWifiOnly = enabled) }
 }
 
 @RunWith(RobolectricTestRunner::class)

--- a/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModelTest.kt
@@ -23,6 +23,7 @@ private class MutableSettingsRepository : SettingsRepository {
     override suspend fun setMetricUnits(metric: Boolean) = state.update { it.copy(metricUnits = metric) }
     override suspend fun setThemeMode(mode: ThemeMode) = state.update { it.copy(themeMode = mode) }
     override suspend fun setCloudSyncEnabled(enabled: Boolean) = state.update { it.copy(cloudSyncEnabled = enabled) }
+    override suspend fun setDownloadOverWifiOnly(enabled: Boolean) = state.update { it.copy(downloadOverWifiOnly = enabled) }
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/kotlin/com/sigmundgranaas/turbo/expressive/feature/settings/SettingsViewModelTest.kt
@@ -24,6 +24,7 @@ private class MutableSettingsRepository : SettingsRepository {
     override suspend fun setThemeMode(mode: ThemeMode) = state.update { it.copy(themeMode = mode) }
     override suspend fun setCloudSyncEnabled(enabled: Boolean) = state.update { it.copy(cloudSyncEnabled = enabled) }
     override suspend fun setDownloadOverWifiOnly(enabled: Boolean) = state.update { it.copy(downloadOverWifiOnly = enabled) }
+    override suspend fun setBaseLayer(layer: com.sigmundgranaas.turbo.expressive.domain.BaseLayer) = state.update { it.copy(baseLayer = layer) }
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## Summary

This PR implements a comprehensive offline map caching system for the Android app, turning the analysis and implementation plan into working code. It adds robust tile management, a foreground download service that survives backgrounding, network-aware download policies, and a significantly improved offline maps UI.

## Key Changes

### Core Model & Domain
- **Rich offline region model**: Replaced thin `OfflineRegionInfo` with a comprehensive model carrying status (Downloading/Complete/Paused/Failed), tile count, base layer, overlays, bounds, zoom range, and creation time
- **New domain types**: Added `OfflineStatus` enum, `DownloadSpec`, `OfflineEstimate`, `DetailLevel`, `OverlayId`, and `NetworkState` to support the expanded feature set

### Tile Management Infrastructure
- **Metadata codec** (`OfflineRegionMetadata.kt`): Encodes full region metadata (name, base, overlays, bounds, zoom, creation time) as versioned JSON so it round-trips through MapLibre's opaque byte storage; handles legacy bare-name fallback
- **Tile math estimator** (`TileMath.kt`): Pure slippy-map math for pre-flight tile/byte estimates and area guards (6° span limit, 100k tile ceiling); fully unit-testable without MapLibre
- **Network monitoring** (`NetworkMonitor.kt`): Observes device connectivity (Wi-Fi vs. cellular) as a StateFlow for download policy gating
- **Download policy** (`DownloadPolicy.kt`): Gates downloads on connectivity; respects "Wi-Fi only" setting from user preferences
- **Offline coverage** (`OfflineCoverage.kt`): Pure utility to check if a location is covered by complete offline regions

### Download Service & Lifecycle
- **Foreground download service** (`OfflineDownloadService.kt`): Keeps downloads running while app is backgrounded; surfaces aggregate progress as ongoing notification; auto-pauses on metered networks when "Wi-Fi only" is enabled; recovers after process death via sticky intent
- **Service launcher abstraction** (`OfflineServiceLauncher.kt`): Lets core:map ensure the service starts without direct Android dependency
- **Enhanced OfflineTileManager interface**: Expanded with `retry()`, `pause()`, `resume()`, `rename()`, `clearAmbientCache()`, `setNetworkAllowed()`, and `estimate()` operations; all three implementations (real, synthetic, test stub) updated

### UI & UX Improvements
- **Download area dialog** (`DownloadAreaDialog.kt`): Pre-flight confirm with Standard/Detailed zoom-depth choice, live size + tile-count estimate, and disabled download button when area exceeds limits
- **Enhanced offline maps screen**: 
  - Failed regions show error message + retry button
  - Pause/resume controls for in-flight downloads
  - Rename dialog for regions
  - Undo-delete snackbar (staged deletion with recovery)
  - Offline/out-of-coverage chip indicator
  - Clear ambient cache action
- **Offline indicator** (`OfflineIndicatorViewModel.kt`): Shows whether current map view is covered by offline regions
- **Updated view models**: `OfflineViewModel` and `RouteViewModel` adapted to new download spec and manager interface

### Robustness & Concurrency
- **Error handling**: All MapLibre errors (network, server, tile-limit) now surface as `OfflineStatus.Failed` with reason strings; no silent failures
- **Concurrent collections**: Replaced mutable maps with `ConcurrentHashMap` to handle MapLibre callbacks arriving off-thread
- **Atomic list publication**: Region list updates are atomic to prevent partial-state reads
- **Synthetic manager enhancements**: Added pause/resume/retry/cancel state transitions and forced-failure path for testing without MapLibre

### Configuration & Settings
- **Ambient cache sizing**: Increased from MapLibre's ~50 MB default to 256 MB for better browse-cache coverage
- **Wi-Fi-only preference**: Added to `UserSettings` and `SettingsRepository`; wired to download policy
- **Overlay support**: Fixed "Waves" and "Wind" overlay labels in strings; `LocalStyleServer` now

https://claude.ai/code/session_01ThUT4UyMNxQDRi6Zrdfh93