### PR TITLE
feat(turbomap): kill motion drift + zoom momentum, faster tile fill

### DIFF
--- a/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/MapGestureDetector.kt
+++ b/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/MapGestureDetector.kt
@@ -6,12 +6,72 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import kotlin.math.abs
 import kotlin.math.hypot
+import kotlin.math.ln
 
-/** Don't fling on a slow release / tap — only a real flick gets momentum. */
-internal const val MIN_FLING_VELOCITY = 120f
+/** Don't fling on a slow release / tap / tiny drift — only a deliberate flick. */
+internal const val MIN_FLING_VELOCITY = 220f
 
-/** True if a release velocity (px/s) is fast enough to throw the map. Pure → unit-tested. */
+/** ln(2): converts a natural-log scale rate into zoom-levels/second. */
+private const val LN2 = 0.6931472f
+
+/** Below this pinch speed (zoom-levels/s) the release just rests — no momentum zoom. */
+internal const val MIN_ZOOM_FLING_VELOCITY = 0.7f
+
+/** True if a pinch-release zoom rate (levels/s) is fast enough to coast. */
+internal fun shouldZoomFling(zoomVelocity: Float): Boolean =
+    abs(zoomVelocity) >= MIN_ZOOM_FLING_VELOCITY
+
+/**
+ * Tracks the zoom rate of a pinch so a release can carry zoom momentum. Each
+ * frame's spread *ratio* (`spread / prevSpread`) is accumulated as natural-log
+ * scale; [velocity] reports the recent slope in **zoom-levels/second** (positive
+ * = zooming in) over a short trailing window, so a pinch that decelerates before
+ * release reports ~0 (rests) just like the pan [VelocityTracker]. Pure → tested.
+ */
+internal class ZoomVelocityTracker(private val windowMs: Long = 100L) {
+    private val times = ArrayDeque<Long>()
+    private val logScale = ArrayDeque<Float>()
+    private var cumLogScale = 0f
+
+    /** Fold one frame's spread ratio (must be > 0) in at time [timeMs]. */
+    fun addRatio(timeMs: Long, ratio: Float) {
+        if (ratio <= 0f) return
+        cumLogScale += ln(ratio)
+        times.addLast(timeMs)
+        logScale.addLast(cumLogScale)
+        while (times.size > 2 && timeMs - times.first() > windowMs) {
+            times.removeFirst()
+            logScale.removeFirst()
+        }
+    }
+
+    /** Recent zoom rate in zoom-levels/second (positive = zooming in). */
+    fun velocity(): Float {
+        if (times.size < 2) return 0f
+        val dtSec = (times.last() - times.first()) / 1000f
+        if (dtSec <= 0f) return 0f
+        return (logScale.last() - logScale.first()) / dtSec / LN2
+    }
+
+    fun reset() {
+        times.clear()
+        logScale.clear()
+        cumLogScale = 0f
+    }
+}
+
+/**
+ * Decide the release momentum (px/s). Returns `(0,0)` — i.e. no fling, the map
+ * just rests — when the flick was too slow (small-motion drift) OR the gesture
+ * involved a second finger ([wasPinch]): a pinch is a zoom, and we don't want it
+ * to throw the map sideways afterward ("zoom then drift"). Pure → unit-tested.
+ */
+internal fun flingVelocity(vx: Float, vy: Float, wasPinch: Boolean): Pair<Float, Float> =
+    if (wasPinch || hypot(vx, vy) < MIN_FLING_VELOCITY) 0f to 0f else vx to vy
+
+/** True if a release velocity (px/s) is fast enough to throw the map. */
 internal fun shouldFling(vx: Float, vy: Float): Boolean = hypot(vx, vy) >= MIN_FLING_VELOCITY
 
 /**
@@ -21,8 +81,10 @@ internal fun shouldFling(vx: Float, vy: Float): Boolean = hypot(vx, vy) >= MIN_F
  *   touch stops the map exactly where it is);
  * - **move** → [onTransform] with the centroid pan delta + pinch zoom factor
  *   (applied live), while a [VelocityTracker] follows the centroid;
- * - **release** → [onFling] with the centroid velocity (px/s) for the momentum
- *   throw — `(0,0)` when the flick was too slow, so it just rests.
+ * - **release** → either a pan [onFling] (single-finger centroid velocity, px/s)
+ *   or a [onZoomFling] (pinch zoom rate, levels/s) — never both. A pinch release
+ *   carries only zoom momentum, locked to the zoom axis (no sideways drift); a
+ *   slow release rests.
  *
  * The velocity baseline is reset whenever the pointer count changes, so adding
  * or lifting a finger during a pinch doesn't inject a spurious centroid jump.
@@ -31,20 +93,24 @@ internal suspend fun PointerInputScope.detectMapGestures(
     onDown: () -> Unit,
     onTransform: (panX: Float, panY: Float, zoom: Float) -> Unit,
     onFling: (vx: Float, vy: Float) -> Unit,
+    onZoomFling: (zoomVelocity: Float, focusX: Float, focusY: Float) -> Unit = { _, _, _ -> },
 ) {
     awaitEachGesture {
         val tracker = VelocityTracker()
+        val zoomTracker = ZoomVelocityTracker()
         val first = awaitFirstDown(requireUnconsumed = false)
         onDown()
         tracker.addPosition(first.uptimeMillis, first.position)
         var prevCount = 1
         var prevCentroid = first.position
         var prevSpread = 0f
+        var wasPinch = false
 
         while (true) {
             val event = awaitPointerEvent()
             val pressed = event.changes.filter { it.pressed }
             if (pressed.isEmpty()) break
+            if (pressed.size >= 2) wasPinch = true
 
             val centroid = pressed.fold(Offset.Zero) { acc, c -> acc + c.position } / pressed.size.toFloat()
             val spread = if (pressed.size >= 2) {
@@ -59,9 +125,11 @@ internal suspend fun PointerInputScope.detectMapGestures(
                 // otherwise jump the centroid) and restart velocity tracking.
                 prevCount = pressed.size
                 tracker.resetTracking()
+                zoomTracker.reset()
             } else {
                 val pan = centroid - prevCentroid
                 val zoom = if (pressed.size >= 2 && prevSpread > 0f && spread > 0f) spread / prevSpread else 1f
+                if (zoom != 1f) zoomTracker.addRatio(t, zoom)
                 if (pan != Offset.Zero || zoom != 1f) onTransform(pan.x, pan.y, zoom)
             }
             prevCentroid = centroid
@@ -70,7 +138,15 @@ internal suspend fun PointerInputScope.detectMapGestures(
             event.changes.forEach { if (it.positionChanged()) it.consume() }
         }
 
-        val v = tracker.calculateVelocity()
-        if (shouldFling(v.x, v.y)) onFling(v.x, v.y) else onFling(0f, 0f)
+        // A pinch carries zoom momentum (locked to the zoom axis) and never a
+        // pan fling; a single-finger flick carries pan momentum. Either may rest.
+        if (wasPinch) {
+            val zv = zoomTracker.velocity()
+            if (shouldZoomFling(zv)) onZoomFling(zv, prevCentroid.x, prevCentroid.y) else onFling(0f, 0f)
+        } else {
+            val v = tracker.calculateVelocity()
+            val (fx, fy) = flingVelocity(v.x, v.y, wasPinch = false)
+            onFling(fx, fy)
+        }
     }
 }

--- a/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/NativeSurfaceMap.kt
+++ b/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/NativeSurfaceMap.kt
@@ -56,6 +56,9 @@ internal object NativeSurfaceMap {
     /** Start an inertial pan fling at screen-pixel velocity (drag-release). */
     external fun nativeFling(handle: Long, vx: Double, vy: Double)
 
+    /** Start a momentum zoom at [zoomVelocity] (zoom-levels/s, +=in) about ([fx],[fy]). */
+    external fun nativeZoomFling(handle: Long, zoomVelocity: Double, fx: Double, fy: Double)
+
     /** Ease the camera to a pose over [durationMs] (accel/decel). */
     external fun nativeEaseTo(handle: Long, lat: Double, lng: Double, zoom: Double, bearingDeg: Double, durationMs: Int)
 

--- a/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/TurbomapMapView.kt
+++ b/apps/android/core/turbomap-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/TurbomapMapView.kt
@@ -129,6 +129,7 @@ fun TurbomapMapView(
                         onDown = { controller.onGestureDown() },
                         onTransform = { panX, panY, zoom -> controller.onTransform(panX, panY, zoom) },
                         onFling = { vx, vy -> controller.onFling(vx, vy) },
+                        onZoomFling = { zv, fx, fy -> controller.onZoomFling(zv, fx, fy) },
                     )
                 }
                 .pointerInput(onMapTap, onMapLongClick) {
@@ -201,6 +202,7 @@ internal class TurbomapSurfaceController {
     private var reconcileLoop: Job? = null
     private var lastStatsLogMs = 0L
     private var lastAnimReconcileMs = 0L
+    private var lastPendingCount = 0
     private val http = OkHttpClient.Builder()
         .connectTimeout(TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
         .readTimeout(TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
@@ -349,6 +351,13 @@ internal class TurbomapSurfaceController {
         requestRender(cameraMoved = true) // kick the loop so it ticks the fling
     }
 
+    /** Pinch release: coast the zoom about ([fx],[fy]) at [zv] levels/s (no pan drift). */
+    fun onZoomFling(zv: Float, fx: Float, fy: Float) {
+        if (handle == 0L) return
+        NativeSurfaceMap.nativeZoomFling(handle, zv.toDouble(), fx.toDouble(), fy.toDouble())
+        requestRender(cameraMoved = true) // kick the loop so it ticks the zoom fling
+    }
+
     /** Geographic point under a screen pixel, or null before the map is ready. */
     fun unproject(xPx: Float, yPx: Float): LatLng? {
         if (handle == 0L) return null
@@ -379,19 +388,23 @@ internal class TurbomapSurfaceController {
         }
     }
 
-    /** While tiles are loading, log GPU-texture memory + eviction telemetry (throttled). */
+    /** While tiles are outstanding, log pending/in-flight + cache telemetry (throttled). */
     private fun logStatsThrottled() {
-        if (handle == 0L || inFlight.isEmpty()) return
+        if (handle == 0L || (inFlight.isEmpty() && lastPendingCount == 0)) return
         val now = SystemClock.uptimeMillis()
         if (now - lastStatsLogMs < STATS_LOG_INTERVAL_MS) return
         lastStatsLogMs = now
-        android.util.Log.d("TurbomapTiles", "inflight=${inFlight.size} stats=${NativeSurfaceMap.nativeStats(handle)}")
+        android.util.Log.d(
+            "TurbomapTiles",
+            "pending=$lastPendingCount inflight=${inFlight.size} backoff=${retryAt.size} stats=${NativeSurfaceMap.nativeStats(handle)}",
+        )
     }
 
     private fun reconcile() {
         if (handle == 0L) return
         val arr = runCatching { JSONArray(NativeSurfaceMap.nativePendingTilesJson(handle)) }.getOrNull() ?: return
         val desired = (0 until arr.length()).mapNotNull { parsePendingRaster(arr.optJSONObject(it)) }
+        lastPendingCount = desired.size
         val byKey = desired.associateBy { it.key }
         val decision = planReconcile(
             desiredOrdered = desired.map { it.key },

--- a/apps/android/core/turbomap-android/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/MapGestureTest.kt
+++ b/apps/android/core/turbomap-android/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/turbomap/android/MapGestureTest.kt
@@ -1,5 +1,6 @@
 package com.sigmundgranaas.turbo.expressive.core.turbomap.android
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -9,7 +10,8 @@ class MapGestureTest {
     @Test
     fun a_slow_release_or_tap_does_not_fling() {
         assertFalse("zero velocity (a tap) rests", shouldFling(0f, 0f))
-        assertFalse("a slow drift rests", shouldFling(40f, 30f)) // |v| = 50 < 120
+        assertFalse("a slow drift rests", shouldFling(40f, 30f)) // |v| = 50 < 220
+        assertFalse("a small flick still rests", shouldFling(120f, 90f)) // |v| = 150 < 220
     }
 
     @Test
@@ -20,8 +22,53 @@ class MapGestureTest {
 
     @Test
     fun threshold_is_on_speed_not_a_single_axis() {
-        // Just under vs just over the 120 px/s magnitude, off-axis.
-        assertFalse(shouldFling(80f, 80f)) // ~113
-        assertTrue(shouldFling(90f, 90f)) // ~127
+        // Just under vs just over the 220 px/s magnitude, off-axis.
+        assertFalse(shouldFling(150f, 150f)) // ~212
+        assertTrue(shouldFling(160f, 160f)) // ~226
+    }
+
+    @Test
+    fun small_motion_is_negated_to_prevent_drift() {
+        // A sub-threshold release rests (0,0) — no momentum, no drift.
+        assertEquals(0f to 0f, flingVelocity(120f, 90f, wasPinch = false))
+        // A real flick keeps its velocity.
+        assertEquals(900f to 0f, flingVelocity(900f, 0f, wasPinch = false))
+    }
+
+    @Test
+    fun a_pinch_never_pan_flings() {
+        // Even a fast centroid velocity is dropped when a second finger was down,
+        // so a zoom doesn't throw the map sideways afterward.
+        assertEquals(0f to 0f, flingVelocity(900f, 600f, wasPinch = true))
+        assertEquals(0f to 0f, flingVelocity(0f, 0f, wasPinch = true))
+    }
+
+    @Test
+    fun zoom_tracker_reports_levels_per_second() {
+        // Spread doubles (×2 = +1 zoom level) over 100 ms → ~10 levels/s.
+        val tracker = ZoomVelocityTracker()
+        tracker.addRatio(0L, 1f)
+        tracker.addRatio(50L, 1.41421f) // ×√2 = +0.5 levels
+        tracker.addRatio(100L, 1.41421f) // ×√2 = +0.5 levels (total +1 over 100 ms)
+        assertEquals(10f, tracker.velocity(), 0.3f)
+    }
+
+    @Test
+    fun zoom_tracker_zero_until_two_samples_and_after_reset() {
+        val tracker = ZoomVelocityTracker()
+        assertEquals(0f, tracker.velocity(), 0f)
+        tracker.addRatio(0L, 2f)
+        assertEquals("one sample is not yet a rate", 0f, tracker.velocity(), 0f)
+        tracker.addRatio(50L, 2f)
+        assertTrue("two samples give a rate", tracker.velocity() > 0f)
+        tracker.reset()
+        assertEquals("reset clears the window", 0f, tracker.velocity(), 0f)
+    }
+
+    @Test
+    fun a_slow_pinch_release_does_not_zoom_fling() {
+        assertFalse("imperceptible zoom rate rests", shouldZoomFling(0.2f))
+        assertTrue("a brisk pinch coasts", shouldZoomFling(3.0f))
+        assertTrue("zoom-out coasts too (sign-agnostic)", shouldZoomFling(-3.0f))
     }
 }

--- a/apps/turbomap/crates/turbomap-ffi/src/surface.rs
+++ b/apps/turbomap/crates/turbomap-ffi/src/surface.rs
@@ -130,8 +130,13 @@ fn build(
     // Fade newly-ingested tiles in over ~0.3 s instead of popping. The host keeps
     // rendering (render-on-demand) while `is_animating` is true so the fade
     // completes. Goldens keep the default 0 (deterministic, no time dependence).
+    // A tighter off-screen prefetch ring than the 256px default: the reconciler
+    // fetches nearest-first, so visible tiles still come in first, but a smaller
+    // margin roughly halves the per-view tile count on a slow connection — the
+    // visible area fills noticeably faster instead of competing with a wide ring.
     let options = MapOptions {
         fade_in_secs: 0.3,
+        prefetch_margin_px: 128,
         ..MapOptions::default()
     };
     let engine = TurbomapEngine::new(
@@ -356,6 +361,24 @@ pub extern "system" fn Java_com_sigmundgranaas_turbo_expressive_core_turbomap_an
 ) {
     unsafe {
         with_map(handle, |map| map.engine.fling((vx, vy)));
+    }
+}
+
+/// Start a momentum **zoom** from a pinch release: `zoom_velocity` is in
+/// zoom-levels/second (positive = zooming in), gliding about the pinch focus
+/// `(fx, fy)`. Locked to the zoom axis — the focus pixel stays fixed, so the
+/// map doesn't pan/drift sideways while the zoom coasts to rest.
+#[no_mangle]
+pub extern "system" fn Java_com_sigmundgranaas_turbo_expressive_core_turbomap_android_NativeSurfaceMap_nativeZoomFling(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    zoom_velocity: jdouble,
+    fx: jdouble,
+    fy: jdouble,
+) {
+    unsafe {
+        with_map(handle, |map| map.engine.zoom_fling(zoom_velocity, (fx, fy)));
     }
 }
 


### PR DESCRIPTION
Drift tuning the wgpu map's gesture physics, plus tile-load + diagnostics.

MapGestureDetector:
- MIN_FLING_VELOCITY 120→220 so a small flick just rests (no micro-drift).
- flingVelocity(vx,vy,wasPinch): a pinch (a 2nd finger ever down) never pan-flings — a zoom no longer throws the map sideways afterward.
- ZoomVelocityTracker + onZoomFling: a pinch release now carries *zoom* momentum (levels/s) locked to the zoom axis about the pinch focus, via a new nativeZoomFling FFI into the engine's ZoomFlingAnimation. Slow pinch releases rest. Pure helpers unit-tested in MapGestureTest.

Tile load:
- surface-path prefetch_margin_px 256→128: roughly halves per-view tiles on a slow connection so the visible area (nearest-first) fills faster.

Diagnostics:
- TurbomapTiles logcat now reports pending/inflight/backoff (fires while any tile is outstanding) to distinguish a genuine stall (pending>0, inflight=0) from slow loading (pending draining, inflight=8). Telemetry confirmed the pipeline drains and settles — the prior "stuck grey" was slow load, not a stall.

Verified: unit tests + detekt green; emulator smoke (no crash, render, pan fling + rail zoom intact, tiles drain). Two-finger pinch feel needs a real device (adb can't script multitouch).