### PR TITLE
fix(tileserver): recycle DB pool + DB-aware readiness so a wedged pool self-heals

### DIFF
--- a/apps/tileserver/crates/turbo-tiles-db/src/pool.rs
+++ b/apps/tileserver/crates/turbo-tiles-db/src/pool.rs
@@ -65,6 +65,23 @@ impl DbConfig {
             .max_connections(self.max_connections)
             .min_connections(self.min_connections)
             .acquire_timeout(Duration::from_secs(10))
+            // Connections MUST be recycled. Without these, a connection lives
+            // forever; one network blip (conntrack drop, DB failover) on the
+            // single-node cluster turns every pooled socket into a half-open
+            // zombie, sqlx's pre-acquire health check hangs on each until the
+            // acquire timeout, and the pool stays wedged until a human restarts
+            // the pod (the failure this guards against). With recycling, stale
+            // connections are dropped and replaced, so the pool self-heals.
+            //   - max_lifetime: hard cap on connection age → the whole pool
+            //     rotates through fresh sockets within 10 min no matter what, so
+            //     a wedge self-heals within that window with no human action.
+            //   - idle_timeout: a connection unused for 5 min is closed, so a
+            //     zombie that went idle is reaped long before it's handed out.
+            //   - test_before_acquire: ping (bounded by acquire_timeout) before
+            //     lending a connection, so a dead one is discarded, not returned.
+            .max_lifetime(Duration::from_secs(600))
+            .idle_timeout(Duration::from_secs(300))
+            .test_before_acquire(true)
             .after_connect(move |conn, _meta| {
                 Box::pin(async move {
                     sqlx::query(&format!("SET statement_timeout = {statement_timeout_ms}"))

--- a/infra/k8s/base/tileserver.yaml
+++ b/infra/k8s/base/tileserver.yaml
@@ -212,11 +212,21 @@ spec:
           # failure budget (≈20 min) so the one-time restore can finish. Once the
           # tiles-db is populated, provision is a no-op and the pod is responsive
           # again, so this generous window only matters on first/empty boot.
+          # Readiness exercises the DB (/readyz does SELECT 1), so a wedged
+          # connection pool — the failure mode where every tile 500s with
+          # "pool timed out waiting for an open connection" — takes the pod OUT
+          # of the Service endpoints (clients get a fast 503, not a 14s-then-500)
+          # and it rejoins automatically once the pool recycles itself (see the
+          # max_lifetime/idle_timeout in turbo-tiles-db::pool). Liveness stays on
+          # the DB-FREE /healthz on purpose: a DB-dependent liveness probe would
+          # SIGKILL the pod mid-restore during the CPU-pegged provisioning window
+          # above → the exact crash loop we fixed. So readiness detects+sheds the
+          # wedge, the pool self-heals, and liveness never false-kills on boot.
           readinessProbe:
-            httpGet: { path: /healthz, port: 8080 }
+            httpGet: { path: /readyz, port: 8080 }
             periodSeconds: 15
             timeoutSeconds: 8
-            failureThreshold: 6
+            failureThreshold: 4
           livenessProbe:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 30


### PR DESCRIPTION
## Incident
For ~19 h every `/v1/basemap` tile returned **HTTP 500 `database error: pool timed out while waiting for an open connection`** (~14 s each). This also broke the Android app's water tiles (any uncached tile).

## Root cause
The **DB was healthy** (16/100 connections, all idle, zero slow queries). The failure was the tileserver's **connection pool holding dead connections**:
- `pg_stat_activity` showed the pooled sockets were **19.4 h old** — exactly the age of the last tileserver restart.
- On the single-node cluster a network blip (conntrack drop / DB hiccup) turns pooled TCP sockets into **half-open zombies**; sqlx's pre-acquire health check hangs on each until the 10 s acquire timeout → every request 500s.
- `pool.rs` set **no `max_lifetime` and no `idle_timeout`**, so dead connections were **never recycled** → the pool stayed wedged until a human restarted the pod.
- Both k8s probes hit the **DB-free `/healthz`**, so a fully wedged pool still reported healthy and was never taken out of service or restarted.

## Fix
1. **`pool.rs`** — `max_lifetime(10 min)` + `idle_timeout(5 min)` + `test_before_acquire`. Connections can no longer live forever, so a wedged pool rotates through fresh sockets and **self-heals within ~10 min**.
2. **`tileserver.yaml`** — readiness probe → `/readyz` (does `SELECT 1`). A wedged pool now takes the pod out of the Service endpoints (fast 503 instead of a 14 s 500) and it rejoins automatically once the pool heals. **Liveness intentionally stays on the DB-free `/healthz`** — a DB-dependent liveness probe would SIGKILL the pod mid-restore during the CPU-pegged provisioning window (the crash loop previously fixed).

## Ops
Service was restored immediately with `kubectl rollout restart deploy/tileserver`. This PR prevents recurrence (merging rebuilds the image → ArgoCD rolls it out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)