### PR TITLE
Stop a second device build from deleting the first one's directory

### DIFF
--- a/apps/android/core/routing-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/routing/DevicePackBuilder.kt
+++ b/apps/android/core/routing-android/src/main/kotlin/com/sigmundgranaas/turbo/expressive/core/routing/DevicePackBuilder.kt
@@ -4,6 +4,8 @@ import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.RoutingPack
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.coroutineContext
 import uniffi.turbo_route_ffi.BuildBounds
@@ -14,6 +16,7 @@ import uniffi.turbo_route_ffi.PackHttp
 import uniffi.turbo_route_ffi.RouteException
 import uniffi.turbo_route_ffi.buildPack
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -91,6 +94,48 @@ class DevicePackBuilder(
         onProgress: (BuildPhase, Float) -> Unit = { _, _ -> },
         isCancelled: () -> Boolean = { false },
     ): Outcome = withContext(io) {
+        val key = RoutingPack.keyFor(bounds)
+        val done = File(root, key)
+        if (File(done, RoutingPack.MANIFEST).isFile) {
+            return@withContext Outcome.Done(key, done, done.sizeOnDisk())
+        }
+        if (!RoutingPack.fitsOnePack(bounds)) {
+            return@withContext Outcome.TooLarge(RoutingPack.areaSqKm(bounds))
+        }
+
+        // One build per pack at a time, and the lock is not optional.
+        //
+        // Cancelling a download does not stop a build that is already
+        // running — `buildPack` is blocking native code, and the
+        // downloader's `cancel()` returns immediately. So a retry, a
+        // resume, or the network gate flipping back on starts a *second*
+        // build for the same region while the first is still inside the
+        // FFI. Both derive the same key, and the second one's
+        // `deleteRecursively()` below removes the directory the first is
+        // still writing into. The first then dies on its next file
+        // operation with a bare "No such file or directory (os error 2)"
+        // — which is what a user saw, and which names neither the file
+        // nor the cause.
+        //
+        // Waiting is the right behaviour rather than merely the safe
+        // one: the loser wakes up to find the pack already built and
+        // returns it, so the work is shared instead of repeated.
+        locks.computeIfAbsent(key) { Mutex() }.withLock {
+            if (File(done, RoutingPack.MANIFEST).isFile) {
+                Outcome.Done(key, done, done.sizeOnDisk())
+            } else {
+                buildInto(key, done, bounds, onProgress, isCancelled)
+            }
+        }
+    }
+
+    private suspend fun buildInto(
+        key: String,
+        done: File,
+        bounds: GeoBounds,
+        onProgress: (BuildPhase, Float) -> Unit,
+        isCancelled: () -> Boolean,
+    ): Outcome {
         // Cancelling the coroutine is not enough on its own. `buildPack`
         // is a blocking call into native code: cancellation cannot
         // interrupt it, it only takes effect when the call returns. A
@@ -102,14 +147,6 @@ class DevicePackBuilder(
         // host already had: returning false from the progress callback.
         val job = coroutineContext[kotlinx.coroutines.Job]
         val stop = { job?.isActive == false || isCancelled() }
-        val key = RoutingPack.keyFor(bounds)
-        val done = File(root, key)
-        if (File(done, RoutingPack.MANIFEST).isFile) {
-            return@withContext Outcome.Done(key, done, done.sizeOnDisk())
-        }
-        if (!RoutingPack.fitsOnePack(bounds)) {
-            return@withContext Outcome.TooLarge(RoutingPack.areaSqKm(bounds))
-        }
 
         val partial = File(root, "$key.partial")
         partial.deleteRecursively()
@@ -153,23 +190,33 @@ class DevicePackBuilder(
             // build has no other way to report that it stopped early —
             // so it is separated back out here rather than shown to the
             // user as a failure they might retry.
-            return@withContext if (stop()) {
+            return if (stop()) {
                 Outcome.Cancelled
             } else {
                 Outcome.Failed(e.message ?: e::class.java.simpleName)
             }
         } catch (e: Exception) {
             partial.deleteRecursively()
-            return@withContext Outcome.Failed(e.message ?: e::class.java.simpleName)
+            return Outcome.Failed(e.message ?: e::class.java.simpleName)
         }
 
         done.deleteRecursively()
         if (!partial.renameTo(done)) {
             partial.deleteRecursively()
-            return@withContext Outcome.Failed("could not move the finished pack into place")
+            return Outcome.Failed("could not move the finished pack into place")
         }
-        Outcome.Done(key, done, done.sizeOnDisk())
+        return Outcome.Done(key, done, done.sizeOnDisk())
     }
+
+    /**
+     * One [Mutex] per pack key, never removed.
+     *
+     * Bounded by the number of distinct regions a user downloads, and an
+     * unlocked Mutex is a few bytes — cheaper than the bookkeeping that
+     * removing them safely would need, which has to prove nobody is
+     * about to take the one being dropped.
+     */
+    private val locks = ConcurrentHashMap<String, Mutex>()
 
     private fun File.sizeOnDisk(): Long =
         walkTopDown().filter { it.isFile }.sumOf { it.length() }

--- a/apps/android/core/routing-android/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/routing/DevicePackBuilderTest.kt
+++ b/apps/android/core/routing-android/src/test/kotlin/com/sigmundgranaas/turbo/expressive/core/routing/DevicePackBuilderTest.kt
@@ -4,7 +4,9 @@ import com.sigmundgranaas.turbo.expressive.domain.GeoBounds
 import com.sigmundgranaas.turbo.expressive.domain.RoutingPack
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -20,6 +22,10 @@ import uniffi.turbo_route_ffi.PackBuildResult
 import uniffi.turbo_route_ffi.PackHttp
 import uniffi.turbo_route_ffi.RouteException
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * The builder around the FFI call — not the build itself, which is
@@ -220,6 +226,69 @@ class DevicePackBuilderTest {
         testScheduler.advanceUntilIdle()
 
         assertEquals("the callback must say stop", false, keptGoing)
+    }
+
+    /**
+     * Two builds of the same region must not overlap.
+     *
+     * `buildPack` is blocking native code, so cancelling a download does
+     * not stop a build already inside it. A retry, a resume, or the
+     * network gate flipping back on therefore starts a second build
+     * while the first is still running — and both derive the same key,
+     * so the second one's `deleteRecursively()` removes the directory
+     * the first is writing into. The first then dies on its next file
+     * operation with a bare "No such file or directory (os error 2)".
+     *
+     * Real threads and latches, not a test dispatcher: the thing under
+     * test is mutual exclusion between two blocking calls, and a
+     * single-threaded scheduler cannot interleave them at all — a
+     * version of this test written that way passed against the bug.
+     */
+    @Test
+    fun a_second_build_of_the_same_region_waits_instead_of_deleting_the_first() = runBlocking {
+        val root = tmp.newFolder()
+        val inside = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val concurrent = AtomicInteger(0)
+        val overlapped = AtomicBoolean(false)
+        val vanished = AtomicBoolean(false)
+        val builds = AtomicInteger(0)
+        val b = DevicePackBuilder(
+            root = root,
+            http = NoHttp,
+            io = Dispatchers.IO,
+            build = { dir, _, _, _, _ ->
+                builds.incrementAndGet()
+                if (concurrent.incrementAndGet() > 1) overlapped.set(true)
+                File(dir).mkdirs()
+                File(dir, "norway.dem").writeText("terrain")
+                inside.countDown()
+                release.await(10, TimeUnit.SECONDS)
+                // Whoever else ran would have wiped this out from under us.
+                if (!File(dir, "norway.dem").isFile) vanished.set(true)
+                File(dir, RoutingPack.MANIFEST).writeText("[pack]\n")
+                concurrent.decrementAndGet()
+                result()
+            },
+        )
+
+        val first = launch(Dispatchers.IO) { b.build(bounds) }
+        assertTrue("the first build must get going", inside.await(10, TimeUnit.SECONDS))
+        val second = launch(Dispatchers.IO) { b.build(bounds) }
+        // Long enough for an unguarded second build to reach its
+        // deleteRecursively, which is the very first thing it does.
+        Thread.sleep(300)
+        release.countDown()
+        first.join()
+        second.join()
+
+        assertFalse("the two builds must not overlap", overlapped.get())
+        assertFalse("neither build may lose its working directory", vanished.get())
+        // The loser finds the pack already there and returns it.
+        assertEquals("built once, not twice", 1, builds.get())
+        val key = RoutingPack.keyFor(bounds)
+        assertTrue("the pack is in place", File(root, "$key/${RoutingPack.MANIFEST}").isFile)
+        assertFalse("no .partial left", File(root, "$key.partial").exists())
     }
 
     /**

--- a/apps/tileserver/crates/turbo-pack-build/src/dem.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/dem.rs
@@ -23,6 +23,7 @@ use turbo_tiles_elev::{
 use crate::geotiff::Raster;
 use crate::wcs::{BoxUtm, RESOLUTION_M};
 use crate::BuildError;
+use crate::IoAt;
 
 /// Accumulates tiles into `norway.dem` as rasters arrive.
 pub struct DemWriter {
@@ -43,7 +44,7 @@ impl DemWriter {
     /// free (the file is rewritten to the true count); undershooting is
     /// not, so callers should round up.
     pub fn create(out_dir: &Path, expected_tiles: usize) -> Result<Self, BuildError> {
-        std::fs::create_dir_all(out_dir)?;
+        std::fs::create_dir_all(out_dir).at(out_dir)?;
         let out_path = out_dir.join(ArtifactKind::Dem.filename());
         let tmp_path = out_dir.join(format!("{}.tmp", ArtifactKind::Dem.filename()));
         let file = OpenOptions::new()
@@ -51,7 +52,8 @@ impl DemWriter {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&tmp_path)?;
+            .open(&tmp_path)
+            .at(&tmp_path)?;
         let mut w = BufWriter::with_capacity(8 << 20, file);
 
         write_header(
@@ -201,7 +203,7 @@ impl DemWriter {
         file.sync_all()?;
         drop(file);
 
-        std::fs::rename(&self.tmp_path, &self.out_path)?;
+        std::fs::rename(&self.tmp_path, &self.out_path).at(&self.tmp_path)?;
         Ok(self.out_path)
     }
 }

--- a/apps/tileserver/crates/turbo-pack-build/src/graph.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/graph.rs
@@ -28,6 +28,7 @@ use turbo_tiles_graph::{
 
 use crate::node::{node_endpoints, TOLERANCE_M};
 use crate::BuildError;
+use crate::IoAt;
 
 /// One input way: a polyline plus the classification the cost model reads.
 #[derive(Debug, Clone)]
@@ -64,7 +65,7 @@ pub fn build(
     dem: Option<&Dem>,
     out_dir: &Path,
 ) -> Result<(PathBuf, PathBuf, GraphReport), BuildError> {
-    std::fs::create_dir_all(out_dir)?;
+    std::fs::create_dir_all(out_dir).at(out_dir)?;
     let mut report = GraphReport {
         ways_in: ways.len(),
         ..Default::default()
@@ -202,7 +203,7 @@ pub fn build(
     let out_path = out_dir.join(ArtifactKind::Graph.filename());
     let tmp = out_dir.join(format!("{}.tmp", ArtifactKind::Graph.filename()));
     {
-        let mut w = BufWriter::with_capacity(4 << 20, File::create(&tmp)?);
+        let mut w = BufWriter::with_capacity(4 << 20, File::create(&tmp).at(&tmp)?);
         write_header(
             &mut w,
             &Header {
@@ -236,14 +237,14 @@ pub fn build(
         }
         w.flush()?;
     }
-    std::fs::rename(&tmp, &out_path)?;
-    report.graph_bytes = std::fs::metadata(&out_path)?.len();
+    std::fs::rename(&tmp, &out_path).at(&tmp)?;
+    report.graph_bytes = std::fs::metadata(&out_path).at(&out_path)?.len();
 
     // ---- norway.graph_geom ----
     let geom_path = out_dir.join(ArtifactKind::GraphGeom.filename());
     let geom_tmp = out_dir.join(format!("{}.tmp", ArtifactKind::GraphGeom.filename()));
     {
-        let mut w = BufWriter::with_capacity(4 << 20, File::create(&geom_tmp)?);
+        let mut w = BufWriter::with_capacity(4 << 20, File::create(&geom_tmp).at(&geom_tmp)?);
         let total: u32 = polylines.iter().map(|p| p.len() as u32).sum();
         write_header(
             &mut w,
@@ -276,8 +277,8 @@ pub fn build(
         }
         w.flush()?;
     }
-    std::fs::rename(&geom_tmp, &geom_path)?;
-    report.geom_bytes = std::fs::metadata(&geom_path)?.len();
+    std::fs::rename(&geom_tmp, &geom_path).at(&geom_tmp)?;
+    report.geom_bytes = std::fs::metadata(&geom_path).at(&geom_path)?.len();
 
     Ok((out_path, geom_path, report))
 }

--- a/apps/tileserver/crates/turbo-pack-build/src/lib.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/lib.rs
@@ -57,6 +57,18 @@ use std::path::PathBuf;
 pub enum BuildError {
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+    /// An IO failure that knows which file it was.
+    ///
+    /// A bare `ENOENT` names nothing — a user reported "No such file or
+    /// directory (os error 2)" from a device build and there was no way
+    /// to tell from the message whether it was the DEM, a rename, or the
+    /// output directory itself. Every operation that can plausibly fail
+    /// on a path that should exist carries it now.
+    #[error("io: {path}: {source}")]
+    IoAt {
+        path: String,
+        source: std::io::Error,
+    },
     /// A source service failed or answered something unusable.
     #[error("fetch: {0}")]
     Fetch(String),
@@ -68,6 +80,25 @@ pub enum BuildError {
     Decode(String),
     #[error("build: {0}")]
     Logic(String),
+}
+
+/// Attach the path to an IO result: `File::create(&p).at(&p)?`.
+///
+/// `std::io::Error` drops the path on the way out of `std::fs`, so a
+/// `?` on any of these produces an error naming an errno and nothing
+/// else. On a server that is merely annoying — you have the logs and
+/// the working directory. On a phone it is the whole diagnosis.
+pub(crate) trait IoAt<T> {
+    fn at(self, path: &std::path::Path) -> Result<T, BuildError>;
+}
+
+impl<T> IoAt<T> for Result<T, std::io::Error> {
+    fn at(self, path: &std::path::Path) -> Result<T, BuildError> {
+        self.map_err(|source| BuildError::IoAt {
+            path: path.display().to_string(),
+            source,
+        })
+    }
 }
 
 /// A [`fetch::Fetch`] backed by `reqwest`, for callers that want one.
@@ -163,7 +194,7 @@ pub fn build_dem(
     let tiles = writer.tiles_written;
     let nodata = writer.tiles_all_nodata;
     let dem_path = writer.finish()?;
-    let dem_bytes = std::fs::metadata(&dem_path)?.len();
+    let dem_bytes = std::fs::metadata(&dem_path).at(&dem_path)?.len();
 
     Ok(RegionReport {
         out_dir: out_dir.to_path_buf(),
@@ -300,5 +331,24 @@ mod tests {
         assert!(haloed.max_x >= plain.max_x + 990.0);
         assert!(haloed.min_y <= plain.min_y - 990.0);
         assert!(haloed.max_y >= plain.max_y + 990.0);
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+
+    /// A bare errno is not a diagnosis.
+    ///
+    /// This is the message a user actually saw from a device build:
+    /// "No such file or directory (os error 2)", naming nothing. Anyone
+    /// reading it has to guess which of a dozen file operations it was.
+    #[test]
+    fn an_io_failure_names_the_file_it_was() {
+        let missing = std::path::Path::new("/nonexistent-dir/norway.dem");
+        let err: BuildError = std::fs::read(missing).at(missing).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("norway.dem"), "must name the file: {msg}");
+        assert!(msg.contains("No such file"), "and keep the cause: {msg}");
     }
 }

--- a/apps/tileserver/crates/turbo-pack-build/src/mask.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/mask.rs
@@ -26,6 +26,7 @@ use turbo_tiles_mask::{
 
 use crate::wcs::BoxUtm;
 use crate::BuildError;
+use crate::IoAt;
 
 /// The N50 feature types that become water.
 ///
@@ -100,7 +101,7 @@ impl MaskWriter {
 
     /// Pack to 2 bits per cell and write the artifact.
     pub fn finish(self, out_dir: &Path) -> Result<PathBuf, BuildError> {
-        std::fs::create_dir_all(out_dir)?;
+        std::fs::create_dir_all(out_dir).at(out_dir)?;
         let n_packed = packed_bytes(self.cells.len() as u64) as usize;
         let mut packed = vec![0u8; n_packed];
         for (i, &v) in self.cells.iter().enumerate() {
@@ -109,7 +110,7 @@ impl MaskWriter {
 
         let out_path = out_dir.join(ArtifactKind::Mask.filename());
         let tmp_path = out_dir.join(format!("{}.tmp", ArtifactKind::Mask.filename()));
-        let f = File::create(&tmp_path)?;
+        let f = File::create(&tmp_path).at(&tmp_path)?;
         let mut w = BufWriter::new(f);
         write_header(
             &mut w,
@@ -140,7 +141,7 @@ impl MaskWriter {
         w.write_all(&packed)?;
         w.flush()?;
         drop(w);
-        std::fs::rename(&tmp_path, &out_path)?;
+        std::fs::rename(&tmp_path, &out_path).at(&tmp_path)?;
         Ok(out_path)
     }
 }

--- a/apps/tileserver/crates/turbo-pack-build/src/pack.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/pack.rs
@@ -21,6 +21,7 @@ use sha2::{Digest, Sha256};
 use turbo_tiles_artifacts::{PackFile, PackManifest, PackMeta, PACK_FORMAT_VERSION};
 
 use crate::BuildError;
+use crate::IoAt;
 
 /// How a pack was produced.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -47,7 +48,7 @@ pub struct Source {
 }
 
 fn digest(path: &Path) -> Result<(u64, String), BuildError> {
-    let bytes = std::fs::read(path)?;
+    let bytes = std::fs::read(path).at(path)?;
     let mut h = Sha256::new();
     h.update(&bytes);
     Ok((bytes.len() as u64, format!("{:x}", h.finalize())))
@@ -65,7 +66,7 @@ pub fn write_manifest(
     created_by: &str,
 ) -> Result<PathBuf, BuildError> {
     let mut files = Vec::new();
-    let mut names: Vec<String> = std::fs::read_dir(dir)?
+    let mut names: Vec<String> = std::fs::read_dir(dir).at(dir)?
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_file())
         .map(|e| e.file_name().to_string_lossy().to_string())
@@ -104,7 +105,7 @@ pub fn write_manifest(
     let toml = toml::to_string_pretty(&manifest)
         .map_err(|e| BuildError::Logic(format!("serialise pack.toml: {e}")))?;
     let path = dir.join(PackManifest::FILENAME);
-    std::fs::write(&path, toml)?;
+    std::fs::write(&path, toml).at(&path)?;
     Ok(path)
 }
 
@@ -112,7 +113,7 @@ pub fn write_provenance(dir: &Path, p: &Provenance) -> Result<PathBuf, BuildErro
     let toml = toml::to_string_pretty(p)
         .map_err(|e| BuildError::Logic(format!("serialise provenance: {e}")))?;
     let path = dir.join("provenance.toml");
-    std::fs::write(&path, toml)?;
+    std::fs::write(&path, toml).at(&path)?;
     Ok(path)
 }
 

--- a/apps/tileserver/crates/turbo-pack-build/src/region.rs
+++ b/apps/tileserver/crates/turbo-pack-build/src/region.rs
@@ -11,6 +11,7 @@ use turbo_tiles_elev::Dem;
 use turbo_tiles_mask::RefusalKind;
 
 use crate::{gml, graph, mask, n50, pack, wcs, wfs, BuildError, Kommuner};
+use crate::IoAt;
 
 /// Progress across the whole build, so a caller can drive one bar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +55,7 @@ pub fn build_pack(
 ) -> Result<PackReport, BuildError> {
     let started = std::time::Instant::now();
     let mut report = PackReport::default();
-    std::fs::create_dir_all(out_dir)?;
+    std::fs::create_dir_all(out_dir).at(out_dir)?;
 
     let region = crate::region_box(extent[0], extent[1], extent[2], extent[3], halo_m);
 
@@ -248,7 +249,7 @@ pub fn build_pack(
     )?;
     on_progress(Phase::Manifest, 1, 1);
 
-    report.total_bytes = std::fs::read_dir(out_dir)?
+    report.total_bytes = std::fs::read_dir(out_dir).at(out_dir)?
         .filter_map(|e| e.ok())
         .filter_map(|e| e.metadata().ok())
         .map(|m| m.len())


### PR DESCRIPTION
The ENOENT a user hit on Android is a race, and the pieces were all
already written down — just not connected.

`DevicePackBuilder` documents that `buildPack` is blocking native code
and that cancelling the coroutine cannot interrupt it. `startJob` does
`jobs.remove(id)?.cancel()`, which returns immediately. Put those
together: a retry, a resume, or the Wi-Fi gate flipping back on starts a
second build for a region whose first build is still inside the FFI.
Both derive the same key from the same bounds, and the second one's
`partial.deleteRecursively()` — the first thing it does — removes the
directory the first is still writing into. The first then dies on its
next file operation with

    No such file or directory (os error 2)

naming neither the file nor the cause.

A Mutex per pack key now serialises them. Waiting is better than merely
safe here: the loser wakes up, finds the pack already built, and returns
it, so the work is shared rather than repeated.

The first version of the test was worthless and passed against the bug.
It used StandardTestDispatcher, which is single-threaded, and the build
seam is not a suspending function — so the two builds could not
interleave no matter what the code did. Rewritten with real threads and
latches, it fails without the lock on "the two builds must not overlap"
and passes with it.

Separately: the error had no business being that hard to read.
`BuildError::Io(#[from] io::Error)` drops the path on the way out of
`std::fs`, so every IO failure in a pack build reported an errno and
nothing else — on a server you have the logs and the working directory
to fall back on, on a phone that message is the whole diagnosis. Every
operation that can fail on a path that should exist now carries it, so
the same failure would have read

    io: /data/.../<key>.partial/norway.dem: No such file or directory (os error 2)

and needed no investigation at all.